### PR TITLE
Fix redis dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 
 script:
   - sudo stop redis-server
-  - sudo add-apt-repository ppa:rwky/redis && sudo apt-get update
+  - sudo add-apt-repository -y ppa:rwky/redis && sudo apt-get update
   - sudo apt-get install redis-server -qq
   - sudo start redis-server
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: node_js
 services:
   - mongodb
-  - redis-server
 node_js:
   - 0.10
+
+script:
+  - sudo stop redis-server
+  - sudo add-apt-repository ppa:rwky/redis && sudo apt-get update
+  - sudo apt-get install redis-server -qq
+  - sudo start redis-server
+  - npm test

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "devDependencies": {
     "mocha": "~1",
     "sinon": "~1",
-    "coffee-script": "*"
+    "coffee-script": "*",
+    "better-stack-traces": "~1.0.0"
   },
   "scripts": {
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Realtime database wrapper",
   "main": "lib/index.js",
   "dependencies": {
-    "redis": "~0.8",
+    "redis": ">=0.8.6",
     "ottypes": "~1",
     "deep-is": "~0.1",
     "arraydiff": "~0.1"

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -2,6 +2,8 @@
 # livedb have been pulled out. These tests should probably be split out into
 # multiple files.
 
+require('better-stack-traces').install()
+
 redisLib = require 'redis'
 livedb = require '../lib'
 Memory = require '../lib/memory'


### PR DESCRIPTION
The new `redis.eval` syntax that is now used needs the latest redis version. With `0.8.4` the tests will fail.