### PR TITLE
fixed reference error because driver was undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,8 +128,8 @@ function Livedb(options) {
     this.sdc = new SDC(options.statsd);
     this.closeSdc = true;
   }
-  if (this.sdc && !driver.sdc) {
-    driver.sdc = this.sdc;
+  if (this.sdc && !this.driver.sdc) {
+    this.driver.sdc = this.sdc;
   }
 
   // this.onOp = this.onOp.bind(this);
@@ -181,7 +181,7 @@ Livedb.prototype.getOps = function(cName, docName, from, to, callback) {
   if (to != null && to >= 0 && from > to) return callback(null, []);
 
   var start = Date.now();
-  
+
   var projection = this.projections[cName];
   var c = projection ? projection.target : cName;
 
@@ -213,7 +213,7 @@ Livedb.prototype.submit = function(cName, docName, opData, options, callback) {
   }
 
   var start = Date.now();
-  
+
   if (!options) options = {};
   if (!callback) callback = doNothing;
 
@@ -228,7 +228,7 @@ Livedb.prototype.submit = function(cName, docName, opData, options, callback) {
   if (projection) cName = projection.target;
 
   var transformedOps = [];
-  
+
   var self = this;
 
   // There's an awful state that should never happen (but did happen to us


### PR DESCRIPTION
When using live0.4.5 I was seeing this error
ReferenceError: driver is not defined - node_modules/livedb/lib/index.js:131:20

Looks like driver was meant to be this.driver
