### PR TITLE
Fix creating redis observer client for redis >= 0.12

### DIFF
--- a/lib/redisdriver.js
+++ b/lib/redisdriver.js
@@ -49,7 +49,11 @@ function RedisDriver(oplog, client, observer) {
   this.redisObserver = observer;
   if (!this.redisObserver) {
     // We can't copy the selected db, but pubsub messages aren't namespaced to their db anyway.
-    this.redisObserver = redisLib.createClient(this.redis.options, this.redis.port, this.redis.host);
+    // port and host are stored inside connectionOption object in redis >= 0.12. previously they
+    // were stored directly on the redis client itself.
+    var port = this.redis.connectionOption ? this.redis.connectionOption.port : this.redis.port;
+    var host = this.redis.connectionOption ? this.redis.connectionOption.host : this.redis.host;
+    this.redisObserver = redisLib.createClient(this.redis.options, port, host);
     if (this.redis.auth_path) this.redisObserver.auth(this.redis.auth_pass);
     this.redisObserverCreated = true;
   }


### PR DESCRIPTION
Redis v0.12 and later stores the port and host of the client inside a `connectionOption` object. See https://github.com/mranney/node_redis/commit/064260d1c5f2729f413e4266c3e1e0047cfd19ad#diff-168726dbe96b3ce427e7fedce31bb0bcL1236.  This adds code to handle both new and old versions.
