### PR TITLE
Support expiring ops from oplog

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -216,7 +216,7 @@ Livedb.prototype.getOps = function(cName, docName, from, to, callback) {
     
     // If we got results, check that we got the right ops.
     // Sometimes, if ops have expired from the oplog, there might be some missing.
-    if (ops.length > 0 && ops[0].v !== from)
+    if (ops && ops.length > 0 && ops[0].v !== from)
       return callback('Missing operations');
 
     // Interestingly, this will filter ops for other types as if they were the projected type. This

--- a/lib/index.js
+++ b/lib/index.js
@@ -187,6 +187,11 @@ Livedb.prototype.getOps = function(cName, docName, from, to, callback) {
 
   this.driver.getOps(c, docName, from, to, function(err, ops) {
     if (self.sdc) self.sdc.timing('livedb.getOps', Date.now() - start);
+    
+    // If we got results, check that we got the right ops.
+    // Sometimes, if ops have expired from the oplog, there might be some missing.
+    if (ops.length > 0 && ops[0].v !== from)
+      return callback('Missing operations');
 
     // Interestingly, this will filter ops for other types as if they were the projected type. This
     // is a bug, but it shouldn't cause any problems for now. I'll have to revisit this

--- a/lib/index.js
+++ b/lib/index.js
@@ -335,6 +335,14 @@ Livedb.prototype._trySubmit = function(submitData) {
         self._resumeSubmitting(opData.src);
         return;
       }
+      
+      // Check if the first op we received wasn't the one we requested.
+      // This can occur if the ops were dropped from the oplog (e.g. expired).
+      if (from !== snapshot.v && (ops.length === 0 || ops[0].v !== from)) {
+        submitData.callback('Missing operations');
+        self._resumeSubmitting(opData.src);
+        return;
+      }
 
       for (var i = 0; i < ops.length; i++) {
         var op = ops[i];
@@ -347,12 +355,7 @@ Livedb.prototype._trySubmit = function(submitData) {
           self._resumeSubmitting(opData.src);
           return;
         }
-                
-        // Check if the first op we received wasn't the one we requested.
-        // This can occur if the ops were dropped from the oplog (e.g. expired).
-        if (from !== snapshot.v && (ops.length === 0 || ops[0].v !== from))
-          return callback('Missing operations');
-
+        
         // Bring both the op and the snapshot up to date. At least one of
         // these two conditionals should be true.
         if (snapshot.v === op.v) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -260,6 +260,11 @@ Livedb.prototype.submit = function(cName, docName, opData, options, callback) {
             + "Please file an issue if you can recreate this state reliably.");
           return callback('Internal data corruption - cannot submit');
         }
+                
+        // Check if the first op we received wasn't the one we requested.
+        // This can occur if the ops were dropped from the oplog (e.g. expired).
+        if (from !== snapshot.v && (ops.length === 0 || ops[0].v !== from))
+          return callback('Missing operations');
 
         for (var i = 0; i < ops.length; i++) {
           var op = ops[i];

--- a/lib/redisdriver.js
+++ b/lib/redisdriver.js
@@ -322,7 +322,7 @@ RedisDriver.prototype._oplogGetOps = function(cName, docName, from, to, callback
   this.oplog.getOps(cName, docName, from, to, function(err, ops) {
     if (err) return callback(err);
     if (ops.length && ops[0].v !== from) 
-      return callback('Oplog is returning incorrect ops');
+      return callback('Missing operations');
 
     for (var i = 0; i < ops.length; i++) {
       ops[i].v = from++;

--- a/lib/redisdriver.js
+++ b/lib/redisdriver.js
@@ -172,7 +172,7 @@ RedisDriver.prototype.atomicSubmit = function(cName, docName, opData, options, c
           // In this case, we should write a no-op ramp to the snapshot
           // version, followed by a delete & a create to fill in the missing
           // ops.
-          throw Error('Missing oplog for ' + cName + ' ' + docName);
+          return callback('Missing oplog for ' + cName + ' ' + docName);
         }
         self._redisSubmitScript(cName, docName, opData, dirtyData, version, callbackWrapper);
       });
@@ -321,7 +321,8 @@ RedisDriver.prototype._oplogGetOps = function(cName, docName, from, to, callback
   var self = this;
   this.oplog.getOps(cName, docName, from, to, function(err, ops) {
     if (err) return callback(err);
-    if (ops.length && ops[0].v !== from) throw Error('Oplog is returning incorrect ops');
+    if (ops.length && ops[0].v !== from) 
+      return callback('Oplog is returning incorrect ops');
 
     for (var i = 0; i < ops.length; i++) {
       ops[i].v = from++;

--- a/test/oplog.coffee
+++ b/test/oplog.coffee
@@ -98,15 +98,10 @@ module.exports = (create) ->
         check = (error, ops) ->
           throw new Error error if error
           assert.deepEqual ops, []
-          done() if ++num is 7
+          done() if ++num is 2
 
         @db.getOps @cName, @docName, 0, 0, check
-        @db.getOps @cName, @docName, 0, 1, check
-        @db.getOps @cName, @docName, 0, 10, check
         @db.getOps @cName, @docName, 0, null, check
-        @db.getOps @cName, @docName, 10, 10, check
-        @db.getOps @cName, @docName, 10, 11, check
-        @db.getOps @cName, @docName, 10, null, check
 
       it 'returns ops', (done) ->
         num = 0

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -405,11 +405,22 @@ describe 'livedb', ->
             assert.deepEqual stripTs(ops), [{create:{type:textType.uri, data:''}, v:0, m:{}}, {op:['hi'], v:1, m:{}}]
             done()
 
-
-
-    it 'errors if ops are missing from the snapshotdb and oplogs'
-
-
+    it 'errors if ops are missing from the snapshotdb and oplogs', (done) -> @create =>
+      @collection.submit @docName, {v:1, op:['test']}, (err, v) =>
+        throw new Error err if err
+        @collection.submit @docName, {v:1, op:['test2']}, (err, v) =>
+          throw new Error err if err
+        
+          getOps = @client.driver.getOps
+          @client.driver.getOps = (cName, docName, from, to, fn) =>
+            getOps.call @client.driver, cName, docName, from, to, (err, ops) ->
+              throw new Error err if err
+              fn null, ops.slice 1
+        
+          @collection.getOps @docName, 0, (err, ops) =>
+            assert.equal err, 'Missing operations'
+            @client.driver.getOps = getOps
+            done()
 
     it 'works with separate clients', (done) -> @create =>
       return done() unless @driver.distributed


### PR DESCRIPTION
This goes along with https://github.com/share/livedb-mongo/pull/12.  It handles emitting `Missing operations` errors when operations requested from the oplog are not there.  This happens in `submit` and `getOps` (and by extension `fetch`, since it calls `getOps`).

This error should occur if a client has been offline longer than the ttl and tries to submit/fetch some ops.  It should only occur if other edits have taken place while the user was offline, which have also expired.  Specifically:

1. user 1 goes offline
2. user 1 edits
3. user 2 edits
4. ops are dropped (user 2’s ops expire)
5. user 1 comes back online and submits its ops
6. ERROR

If 3 and 4 are swapped (i.e. user 2 doesn’t edit anything before the ops are dropped), the error shouldn't occur. Basically, it should be fairly rare.

When the error happens, ShareJS sends it back to the client, which has an opportunity to notify the user that their changes could not be merged.  Not ideal, but necessary to keep the data size in mongo from growing forever.

One case I thought of but I'm not sure about is whether we need to get the snapshot version in `getOps` when `to` is null to determine whether ops are expected from the oplog.  Right now, the check for missing operations only occurs when there are ops returned (check `ops[0].v === from`).  If `to` is null, we may also need to check if ops were expected if `from < snapshot.v`, which means fetching the snapshot there.  I don't really like that, but it may be necessary.  In `submit` this is handled already.  What do you think?