### PR TITLE
avoid corrupting the version cached in redis

### DIFF
--- a/lib/redisdriver.js
+++ b/lib/redisdriver.js
@@ -61,7 +61,7 @@ function RedisDriver(oplog, client, observer) {
   var self = this;
   this.redisObserver.on('message', function(channel, msg) {
     if (self.sdc) self.sdc.increment('livedb.redis.message');
-    
+
     self.subscribers.emit(channel, channel, JSON.parse(msg));
   });
 
@@ -766,12 +766,15 @@ RedisDriver.prototype.bulkGetOpsSince = function(requests, callback) {
           // anything missing in redis, I'm not super worried about the extra
           // calls here.
           self._oplogGetOps(cName, docName, from, null, function(err, ops) {
-            var version;
             if (err) return callback(err);
             results[cName][docName] = ops;
 
-            version = from + ops.length;
-            self._redisCacheVersion(cName, docName, version, done);
+            // I'm going to do a sneaky cache here if its not in redis.
+            self.oplog.getVersion(cName, docName, function(err, version) {
+              if (err) return;
+              self._redisCacheVersion(cName, docName, version);
+            });
+            done();
           });
         })(cName, docName, from);
 


### PR DESCRIPTION
bulkGetOpsSince would corrupt the cached version key for a document if
called with a from version from the future. This is bad, because
confused clients can get redis into a permanently corrupt state.
Instead of relying on the from being a valid version, get the version
from the oplog db method each time
