### PR TITLE
Fix driver tests for updated Streams API

### DIFF
--- a/test/driver.coffee
+++ b/test/driver.coffee
@@ -253,7 +253,7 @@ module.exports = runTests = (createDriver, destroyDriver, distributed = no) ->
 
       it 'can observe a document that doesnt exist yet', (done) ->
         @subscribe 'users', @docName, 0, {}, (err, stream) =>
-          stream.on 'readable', ->
+          stream.once 'readable', ->
             assert.deepEqual stream.read(), createOp()
             stream.destroy()
             done()


### PR DESCRIPTION
The Streams API (in v0.12.0 and io.js) will return `null` from `read` if there is no data. We do not want to run this test more than once and test against a `null` value.

I'd love for someone to verify that this is correct. The tests pass, but I'm not sure if there are other changes needed to account for streams changes.

This should fix https://github.com/share/livedb/issues/42