### PR TITLE
Registers rich-text support in livedb.

### DIFF
--- a/lib/ot.js
+++ b/lib/ot.js
@@ -18,7 +18,7 @@ var registerType = exports.registerType = function(type) {
 registerType('ot-json0');
 registerType('ot-text');
 registerType('ot-text-tp2');
-
+registerType('rich-text');
 // Returns an error string on failure. Rockin' it C style.
 exports.checkOpData = function(opData) {
   if (typeof opData !== 'object') return 'Missing opData';

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "description": "Realtime database wrapper",
   "main": "lib/index.js",
   "dependencies": {
-    "deep-is": "~0.1",
     "arraydiff": "~0.1",
     "async": "~0.7",
-    "ot-text-tp2": "^1.0.0",
+    "deep-is": "~0.1",
+    "ot-json0": "^1.0.0",
     "ot-text": "^1.0.0",
-    "ot-json0": "^1.0.0"
+    "ot-text-tp2": "^1.0.0",
+    "rich-text": "^1.0.3"
   },
   "optionalDependencies": {
     "redis": "^0.12.1",


### PR DESCRIPTION
Registers rich-text support in livedb. ottypes/rich-text must include .type property on export for this to work.