### PR TITLE
avoid breaking browserify

### DIFF
--- a/lib/ot.js
+++ b/lib/ot.js
@@ -8,6 +8,11 @@ var otTypes = {};
 // Default validation function
 var defaultValidate = function() {};
 
+// We make sure not to break browserify
+require('ot-json0');
+require('ot-text');
+require('ot-text-tp2');
+
 // Register the specified type in the bundled ottypes module.
 var registerType = exports.registerType = function(type) {
   if (typeof type === 'string') type = require(type).type;


### PR DESCRIPTION
the dynamic way that ot.js is using requires breaks browserify when requiring livedb directly on the client side for ot functions.