### PR TITLE
Add fetchAndSubscribe to collection prototype.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -703,6 +703,7 @@ Livedb.prototype.collection = function(cName) {
     subscribe: this.subscribe.bind(this, cName),
     getOps: this.getOps.bind(this, cName),
     fetch: this.fetch.bind(this, cName),
+    fetchAndSubscribe: this.fetchAndSubscribe.bind(this, cName),
     queryFetch: this.queryFetch.bind(this, cName),
     queryPoll: this.queryPoll.bind(this, cName),
 


### PR DESCRIPTION
This is just a consistency thing- collection didn't have a "fetchAndSubscribe" property. This should add it without any side effects.