### PR TITLE
Add 'index' to 'doc' event

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -66,6 +66,7 @@ Backend.prototype.addProjection = function(name, collection, type, fields) {
   }
 
   this.projections[name] = {
+    name: name,
     target: collection,
     type: ot.normalizeType(type),
     fields: fields
@@ -135,7 +136,7 @@ Backend.prototype._sanitizeOpsBulk = function(agent, projection, collection, ops
   }, callback);
 };
 
-Backend.prototype._sanitizeSnapshot = function(agent, projection, collection, id, snapshot, callback) {
+Backend.prototype._sanitizeSnapshot = function(agent, index, projection, collection, id, snapshot, callback) {
   if (projection) {
     try {
       projections.projectSnapshot(projection.fields, snapshot);
@@ -143,18 +144,18 @@ Backend.prototype._sanitizeSnapshot = function(agent, projection, collection, id
       return callback(err);
     }
   }
-  this.trigger('doc', agent, {collection: collection, id: id, snapshot: snapshot}, callback);
+  this.trigger('doc', agent, {index: index, collection: collection, id: id, snapshot: snapshot}, callback);
 };
-Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, callback) {
+Backend.prototype._sanitizeSnapshots = function(agent, index, projection, collection, snapshots, callback) {
   var backend = this;
   async.each(snapshots, function(snapshot, eachCb) {
-    backend._sanitizeSnapshot(agent, projection, collection, snapshot.id, snapshot, eachCb);
+    backend._sanitizeSnapshot(agent, index, projection, collection, snapshot.id, snapshot, eachCb);
   }, callback);
 };
-Backend.prototype._sanitizeSnapshotBulk = function(agent, projection, collection, snapshotMap, callback) {
+Backend.prototype._sanitizeSnapshotBulk = function(agent, index, projection, collection, snapshotMap, callback) {
   var backend = this;
   async.forEachOf(snapshotMap, function(snapshot, id, eachCb) {
-    backend._sanitizeSnapshot(agent, projection, collection, id, snapshot, eachCb);
+    backend._sanitizeSnapshot(agent, index, projection, collection, id, snapshot, eachCb);
   }, callback);
 };
 
@@ -229,7 +230,7 @@ Backend.prototype.fetch = function(agent, index, id, callback) {
   backend.db.getSnapshot(collection, id, fields, function(err, snapshot) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
-    backend._sanitizeSnapshot(agent, snapshotProjection, collection, id, snapshot, function(err) {
+    backend._sanitizeSnapshot(agent, index, snapshotProjection, collection, id, snapshot, function(err) {
       if (err) return callback(err);
       backend.emit('timing', 'fetch', Date.now() - start);
       callback(null, snapshot);
@@ -246,7 +247,7 @@ Backend.prototype.fetchBulk = function(agent, index, ids, callback) {
   backend.db.getSnapshotBulk(collection, ids, fields, function(err, snapshotMap) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
-    backend._sanitizeSnapshotBulk(agent, snapshotProjection, collection, snapshotMap, function(err) {
+    backend._sanitizeSnapshotBulk(agent, index, snapshotProjection, collection, snapshotMap, function(err) {
       if (err) return callback(err);
       backend.emit('timing', 'fetchBulk', Date.now() - start);
       callback(null, snapshotMap);
@@ -420,7 +421,7 @@ Backend.prototype._query = function(agent, request, callback) {
   var backend = this;
   request.db.query(request.collection, request.query, request.fields, request.options, function(err, snapshots, extra) {
     if (err) return callback(err);
-    backend._sanitizeSnapshots(agent, request.snapshotProjection, request.collection, snapshots, function(err) {
+    backend._sanitizeSnapshots(agent, request.index, request.snapshotProjection, request.collection, snapshots, function(err) {
       callback(err, snapshots, extra);
     });
   });

--- a/lib/query-emitter.js
+++ b/lib/query-emitter.js
@@ -128,7 +128,7 @@ QueryEmitter.prototype.queryPoll = function() {
       if (inserted.length) {
         emitter.db.getSnapshotBulk(emitter.collection, inserted, emitter.fields, function(err, snapshotMap) {
           if (err) return emitter._finishPoll(err);
-          emitter.backend._sanitizeSnapshotBulk(emitter.agent, emitter.snapshotProjection, emitter.collection, snapshotMap, function(err) {
+          emitter.backend._sanitizeSnapshotBulk(emitter.agent, emitter.index, emitter.snapshotProjection, emitter.collection, snapshotMap, function(err) {
             if (err) return emitter._finishPoll(err);
             emitter._emitTiming('query.pollGetSnapshotBulk', start);
             var diff = mapDiff(idsDiff, snapshotMap);


### PR DESCRIPTION
We should definitely know 'index' in the 'doc' event for access control purpose. Source collection name is not sufficient.

Also we maybe should do the same change for 'op' event.