### PR TITLE
Initialize op objects with all properties

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -546,21 +546,30 @@ function CreateOp(src, seq, v, create) {
   this.seq = seq;
   this.v = v;
   this.create = create;
+  this.c = null;
+  this.d = null;
   this.m = null;
+  this.i = null;
 }
 function EditOp(src, seq, v, op) {
   this.src = src;
   this.seq = seq;
   this.v = v;
   this.op = op;
+  this.c = null;
+  this.d = null;
   this.m = null;
+  this.i = null;
 }
 function DeleteOp(src, seq, v, del) {
   this.src = src;
   this.seq = seq;
   this.v = v;
   this.del = del;
+  this.c = null;
+  this.d = null;
   this.m = null;
+  this.i = null;
 }
 // Normalize the properties submitted
 Agent.prototype._createOp = function(request) {


### PR DESCRIPTION
This way, op objects won't change form later when properties
are assigned. This makes the objects be optimized as structs
in V8.