### PR TITLE
Fix flaky pollDebounce tests

### DIFF
--- a/test/client/query-subscribe.js
+++ b/test/client/query-subscribe.js
@@ -214,10 +214,11 @@ describe('client query subscribe', function() {
       }
     });
     function createDoc(count) {
-      connection.get('items', count.toString()).create({});
-      if (--count) {
-        setTimeout(createDoc, 5, count);
-      }
+      connection.get('items', count.toString()).create({}, function() {
+        if (--count) {
+          createDoc(count);
+        }
+      });
     }
     createDoc(10);
   });
@@ -242,10 +243,11 @@ describe('client query subscribe', function() {
       }
     });
     function createDoc(count) {
-      connection.get('items', count.toString()).create({});
-      if (--count) {
-        setTimeout(createDoc, 5, count);
-      }
+      connection.get('items', count.toString()).create({}, function() {
+        if (--count) {
+          createDoc(count);
+        }
+      });
     }
     createDoc(10);
   });

--- a/test/client/query-subscribe.js
+++ b/test/client/query-subscribe.js
@@ -201,13 +201,15 @@ describe('client query subscribe', function() {
       return false;
     };
     var query = connection.createSubscribeQuery('items', {}, {pollDebounce: 100});
-    var calls = 0;
+    var batchSizes = [];
     var total = 0;
     query.on('insert', function(docs) {
-      calls++;
+      batchSizes.push(docs.length);
       total += docs.length;
       if (total === 10) {
-        expect(calls).equal(2);
+        // first document is its own batch; then subsequent creates
+        // are debounced until after all other 9 docs are created
+        expect(batchSizes).eql([1, 9]);
         done();
       }
     });
@@ -227,13 +229,15 @@ describe('client query subscribe', function() {
     };
     this.backend.db.pollDebounce = 100;
     var query = connection.createSubscribeQuery('items', {});
-    var calls = 0;
+    var batchSizes = [];
     var total = 0;
     query.on('insert', function(docs) {
-      calls++;
+      batchSizes.push(docs.length);
       total += docs.length;
       if (total === 10) {
-        expect(calls).equal(2);
+        // first document is its own batch; then subsequent creates
+        // are debounced until after all other 9 docs are created
+        expect(batchSizes).eql([1, 9]);
         done();
       }
     });


### PR DESCRIPTION
The pollDebounce tests insert 10 documents and make sure
that debouncing leads to two separate chunks of documents
being passed through the 'insert' callback on the query.

The problem was that we weren't waiting for the document
creation to be submitted before sending the next document.

Even though the original test behavior was a more accurate
representation of what a real client would do, it lead to
unpredictable results. The timing of when the op was submitted
could have lead to all of the documents being added in one single
chunk, rather than two.

While at it, made the test more strict -- it now checks the sizes
of the two chunks passed through the 'insert' callback, rather
than just the number of chunks.