### PR TITLE
Let MemoryDB instances return "extra" from _querySync

### DIFF
--- a/lib/db/memory.js
+++ b/lib/db/memory.js
@@ -95,20 +95,22 @@ MemoryDB.prototype.query = function(collection, query, fields, options, callback
       snapshots.push(snapshot);
     }
     try {
-      var filtered = db._querySync(snapshots, query, options);
-      callback(null, filtered);
+      var result = db._querySync(snapshots, query, options);
+      callback(null, result.snapshots, result.extra);
     } catch (err) {
       callback(err);
     }
   });
 };
 
-// For testing, it may be useful to implement the desired query language by
-// defining this function
+// For testing, it may be useful to implement the desired query
+// language by defining this function. Returns an object with
+// two properties:
+// - snapshots: array of query result snapshots
+// - extra: (optional) other types of results, such as counts
 MemoryDB.prototype._querySync = function(snapshots, query, options) {
-  return snapshots;
+  return {snapshots: snapshots};
 };
-
 
 MemoryDB.prototype._writeOpSync = function(collection, id, op) {
   var opLog = this._getOpLogSync(collection, id);

--- a/test/db-memory.js
+++ b/test/db-memory.js
@@ -61,7 +61,7 @@ require('./db')(function(callback) {
   db._querySync = function(snapshots, query) {
     var filtered = filter(snapshots, query.$query || query);
     sort(filtered, query.$orderby);
-    return filtered;
+    return {snapshots: filtered};
   };
 
   db.queryPollDoc = function(collection, id, query, options, callback) {


### PR DESCRIPTION
In case like queries with $count, in addition to the array of snapshots
returned from a query, an additional "extra" argument is passed in
the callback to the query method.

This change lets implementors of MemoryDB still only implement
_querySync even when exposing the "extra" field. This is done by
adding an "extra" property to the returned array, which in turn
is stripped out when MemoryDB calls the callback passed to the
query method.

We use this functionality in https://github.com/avital/sharedb-mingo-memory
to implement $count.