### PR TITLE
Sanitize but log stack traces from errors sent to client

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -188,9 +188,24 @@ Agent.prototype._sendOps = function(collection, id, ops) {
 
 Agent.prototype._reply = function(request, err, message) {
   if (err) {
-    request.error = (typeof err === 'string') ?
-      {message: err} :
-      {code: err.code, message: err.message, stack: err.stack};
+    if (typeof err === 'string') {
+      request.error = {message: err};
+    } else {
+      if (err.stack) {
+        // Log stack trace on the server
+        var message = 'Error: ' + err.message;
+        if (err.code) message = message + ' (' + err.code + ')';
+        console.warn(message);
+        console.warn(err.stack);
+        console.warn();
+
+        // Then hide stack trace from client
+        request.error = JSON.parse(JSON.stringify(err));
+        delete request.error.stack;
+      } else {
+        request.error = err;
+      }
+    }
     this.send(request);
     return;
   }


### PR DESCRIPTION
Here's what server logs look like when an error is sanitized:

```
Sanitizing stack trace from error: server 192.168.99.100:27017 sockets closed
MongoError: server 192.168.99.100:27017 sockets closed
    at Server.destroy (/Users/avital/tmp/sharedb-mongo/node_modules/mongodb/node_modules/mongodb-core/lib/topologies/server.js:1074:47)
    at Server.close (/Users/avital/tmp/sharedb-mongo/node_modules/mongodb/lib/server.js:417:17)
    at Db.close (/Users/avital/tmp/sharedb-mongo/node_modules/mongodb/lib/db.js:357:19)
    at /Users/avital/tmp/sharedb-mongo/index.js:173:11
    at DB.ShareDbMongo.getDbs (/Users/avital/tmp/sharedb-mongo/index.js:111:26)
    at DB.ShareDbMongo.close (/Users/avital/tmp/sharedb-mongo/index.js:170:8)
    at Backend.close (/Users/avital/tmp/sharedb/lib/backend.js:51:11)
    at Context.<anonymous> (/Users/avital/tmp/sharedb/test/db.js:19:20)
    at callFnAsync (/Users/avital/tmp/sharedb-mongo/node_modules/mocha/lib/runnable.js:349:8)
    at Hook.Runnable.run (/Users/avital/tmp/sharedb-mongo/node_modules/mocha/lib/runnable.js:301:7)
    at next (/Users/avital/tmp/sharedb-mongo/node_modules/mocha/lib/runner.js:298:10)
    at Object._onImmediate (/Users/avital/tmp/sharedb-mongo/node_modules/mocha/lib/runner.js:320:5)
    at processImmediate [as _immediateCallback] (timers.js:363:15)
```