### PR TITLE
In client, wrap errors in Error object so they pass through event emi…

### DIFF
--- a/lib/client/connection.js
+++ b/lib/client/connection.js
@@ -157,8 +157,14 @@ Connection.prototype.bindToSocket = function(socket) {
  * @param {String} message.a action
  */
 Connection.prototype.handleMessage = function(message) {
-  var err = message.error;
-  if (err) {
+  var err = null;
+  if (message.error) {
+    // wrap in Error object so can be passed through event emitters
+    err = new Error;
+    for (var key in message.error) {
+      err[key] = message.error[key];
+    }
+
     // Add the message data to the error object for more context
     err.data = message;
     delete message.error;


### PR DESCRIPTION
…tters

Node's event emitters only allow Error objects to be passed in to
'error' events. Prior to this change we were swallowing errors and reporting
them instead as the cryptic:

     Uncaught Error: Uncaught, unspecified "error" event. ([object Object])