### PR TITLE
add options argument to all DB public methods that read or write from snapshots or ops

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -235,7 +235,7 @@ Backend.prototype.getOps = function(agent, index, id, from, to, callback) {
     from: from,
     to: to
   };
-  backend.db.getOps(collection, id, from, to, function(err, ops) {
+  backend.db.getOps(collection, id, from, to, null, function(err, ops) {
     if (err) return callback(err);
     backend._sanitizeOps(agent, projection, collection, id, ops, function(err) {
       if (err) return callback(err);
@@ -257,7 +257,7 @@ Backend.prototype.getOpsBulk = function(agent, index, fromMap, toMap, callback) 
     fromMap: fromMap,
     toMap: toMap
   };
-  backend.db.getOpsBulk(collection, fromMap, toMap, function(err, opsMap) {
+  backend.db.getOpsBulk(collection, fromMap, toMap, null, function(err, opsMap) {
     if (err) return callback(err);
     backend._sanitizeOpsBulk(agent, projection, collection, opsMap, function(err) {
       if (err) return callback(err);
@@ -279,7 +279,7 @@ Backend.prototype.fetch = function(agent, index, id, callback) {
     collection: collection,
     id: id
   };
-  backend.db.getSnapshot(collection, id, fields, function(err, snapshot) {
+  backend.db.getSnapshot(collection, id, fields, null, function(err, snapshot) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     backend._sanitizeSnapshot(agent, snapshotProjection, collection, id, snapshot, function(err) {
@@ -302,7 +302,7 @@ Backend.prototype.fetchBulk = function(agent, index, ids, callback) {
     collection: collection,
     ids: ids
   };
-  backend.db.getSnapshotBulk(collection, ids, fields, function(err, snapshotMap) {
+  backend.db.getSnapshotBulk(collection, ids, fields, null, function(err, snapshotMap) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     backend._sanitizeSnapshotBulk(agent, snapshotProjection, collection, snapshotMap, function(err) {
@@ -339,7 +339,7 @@ Backend.prototype.subscribe = function(agent, index, id, version, callback) {
         callback(null, stream, snapshot);
       });
     } else {
-      backend.db.getOps(collection, id, version, null, function(err, ops) {
+      backend.db.getOps(collection, id, version, null, null, function(err, ops) {
         if (err) return callback(err);
         stream.pushOps(collection, id, ops);
         backend.emit('timing', 'subscribe.ops', Date.now() - start, request);
@@ -388,7 +388,7 @@ Backend.prototype.subscribeBulk = function(agent, index, versions, callback) {
       });
     } else {
       // If a versions map, get ops since requested versions
-      backend.db.getOpsBulk(collection, versions, null, function(err, opsMap) {
+      backend.db.getOpsBulk(collection, versions, null, null, function(err, opsMap) {
         if (err) {
           destroyStreams(streams);
           return callback(err);

--- a/lib/db/index.js
+++ b/lib/db/index.js
@@ -14,19 +14,19 @@ DB.prototype.close = function(callback) {
   if (callback) callback();
 };
 
-DB.prototype.commit = function(collection, id, op, snapshot, callback) {
+DB.prototype.commit = function(collection, id, op, snapshot, options, callback) {
   callback(new ShareDBError(5011, 'commit DB method unimplemented'));
 };
 
-DB.prototype.getSnapshot = function(collection, id, fields, callback) {
+DB.prototype.getSnapshot = function(collection, id, fields, options, callback) {
   callback(new ShareDBError(5012, 'getSnapshot DB method unimplemented'));
 };
 
-DB.prototype.getSnapshotBulk = function(collection, ids, fields, callback) {
+DB.prototype.getSnapshotBulk = function(collection, ids, fields, options, callback) {
   var results = {};
   var db = this;
   async.each(ids, function(id, eachCb) {
-    db.getSnapshot(collection, id, fields, function(err, snapshot) {
+    db.getSnapshot(collection, id, fields, options, function(err, snapshot) {
       if (err) return eachCb(err);
       results[id] = snapshot;
       eachCb();
@@ -37,21 +37,21 @@ DB.prototype.getSnapshotBulk = function(collection, ids, fields, callback) {
   });
 };
 
-DB.prototype.getOps = function(collection, id, from, to, callback) {
+DB.prototype.getOps = function(collection, id, from, to, options, callback) {
   callback(new ShareDBError(5013, 'getOps DB method unimplemented'));
 };
 
-DB.prototype.getOpsToSnapshot = function(collection, id, from, snapshot, callback) {
+DB.prototype.getOpsToSnapshot = function(collection, id, from, snapshot, options, callback) {
   var to = snapshot.v;
-  this.getOps(collection, id, from, to, callback);
+  this.getOps(collection, id, from, to, options, callback);
 };
 
-DB.prototype.getOpsBulk = function(collection, fromMap, toMap, callback) {
+DB.prototype.getOpsBulk = function(collection, fromMap, toMap, options, callback) {
   var results = {};
   var db = this;
   async.forEachOf(fromMap, function(from, id, eachCb) {
     var to = toMap && toMap[id];
-    db.getOps(collection, id, from, to, function(err, ops) {
+    db.getOps(collection, id, from, to, options, function(err, ops) {
       if (err) return eachCb(err);
       results[id] = ops;
       eachCb();
@@ -62,8 +62,8 @@ DB.prototype.getOpsBulk = function(collection, fromMap, toMap, callback) {
   });
 };
 
-DB.prototype.getCommittedOpVersion = function(collection, id, snapshot, op, callback) {
-  this.getOpsToSnapshot(collection, id, 0, snapshot, function(err, ops) {
+DB.prototype.getCommittedOpVersion = function(collection, id, snapshot, op, options, callback) {
+  this.getOpsToSnapshot(collection, id, 0, snapshot, options, function(err, ops) {
     if (err) return callback(err);
     for (var i = ops.length; i--;) {
       var item = ops[i];

--- a/lib/db/memory.js
+++ b/lib/db/memory.js
@@ -36,6 +36,7 @@ MemoryDB.prototype.close = function(callback) {
 // callback(err, succeeded)
 MemoryDB.prototype.commit = function(collection, id, op, snapshot, options, callback) {
   var db = this;
+  if (typeof callback !== 'function') throw new Error('Callback required');
   process.nextTick(function() {
     var version = db._getVersionSync(collection, id);
     if (snapshot.v !== version + 1) {
@@ -56,6 +57,7 @@ MemoryDB.prototype.commit = function(collection, id, op, snapshot, options, call
 // has never been created in the database.
 MemoryDB.prototype.getSnapshot = function(collection, id, fields, options, callback) {
   var db = this;
+  if (typeof callback !== 'function') throw new Error('Callback required');
   process.nextTick(function() {
     var snapshot = db._getSnapshotSync(collection, id);
     callback(null, snapshot);
@@ -73,6 +75,7 @@ MemoryDB.prototype.getSnapshot = function(collection, id, fields, options, callb
 // Callback should be called as callback(error, [list of ops]);
 MemoryDB.prototype.getOps = function(collection, id, from, to, options, callback) {
   var db = this;
+  if (typeof callback !== 'function') throw new Error('Callback required');
   process.nextTick(function() {
     var opLog = db._getOpLogSync(collection, id);
     if (to == null) {
@@ -87,6 +90,7 @@ MemoryDB.prototype.getOps = function(collection, id, from, to, options, callback
 // regardless of query by default
 MemoryDB.prototype.query = function(collection, query, fields, options, callback) {
   var db = this;
+  if (typeof callback !== 'function') throw new Error('Callback required');
   process.nextTick(function() {
     var collectionDocs = db.docs[collection];
     var snapshots = [];

--- a/lib/db/memory.js
+++ b/lib/db/memory.js
@@ -34,7 +34,7 @@ MemoryDB.prototype.close = function(callback) {
 
 // Persists an op and snapshot if it is for the next version. Calls back with
 // callback(err, succeeded)
-MemoryDB.prototype.commit = function(collection, id, op, snapshot, callback) {
+MemoryDB.prototype.commit = function(collection, id, op, snapshot, options, callback) {
   var db = this;
   process.nextTick(function() {
     var version = db._getVersionSync(collection, id);
@@ -54,7 +54,7 @@ MemoryDB.prototype.commit = function(collection, id, op, snapshot, callback) {
 // Get the named document from the database. The callback is called with (err,
 // snapshot). A snapshot with a version of zero is returned if the docuemnt
 // has never been created in the database.
-MemoryDB.prototype.getSnapshot = function(collection, id, fields, callback) {
+MemoryDB.prototype.getSnapshot = function(collection, id, fields, options, callback) {
   var db = this;
   process.nextTick(function() {
     var snapshot = db._getSnapshotSync(collection, id);
@@ -71,7 +71,7 @@ MemoryDB.prototype.getSnapshot = function(collection, id, fields, callback) {
 // The version will be inferred from the parameters if it is missing.
 //
 // Callback should be called as callback(error, [list of ops]);
-MemoryDB.prototype.getOps = function(collection, id, from, to, callback) {
+MemoryDB.prototype.getOps = function(collection, id, from, to, options, callback) {
   var db = this;
   process.nextTick(function() {
     var opLog = db._getOpLogSync(collection, id);

--- a/lib/query-emitter.js
+++ b/lib/query-emitter.js
@@ -183,7 +183,7 @@ QueryEmitter.prototype.queryPoll = function(callback) {
       emitter.ids = ids;
       var inserted = getInserted(idsDiff);
       if (inserted.length) {
-        emitter.db.getSnapshotBulk(emitter.collection, inserted, emitter.fields, function(err, snapshotMap) {
+        emitter.db.getSnapshotBulk(emitter.collection, inserted, emitter.fields, null, function(err, snapshotMap) {
           if (err) return emitter._finishPoll(err, callback, pending);
           emitter.backend._sanitizeSnapshotBulk(emitter.agent, emitter.snapshotProjection, emitter.collection, snapshotMap, function(err) {
             if (err) return emitter._finishPoll(err, callback, pending);
@@ -230,7 +230,7 @@ QueryEmitter.prototype.queryPollDoc = function(id, callback) {
       var index = emitter.ids.push(id) - 1;
       // We can get the result to send to the client async, since there is a
       // delay in sending to the client anyway
-      emitter.db.getSnapshot(emitter.collection, id, emitter.fields, function(err, snapshot) {
+      emitter.db.getSnapshot(emitter.collection, id, emitter.fields, null, function(err, snapshot) {
         if (err) return callback(err);
         emitter.backend._sanitizeSnapshot(emitter.agent, emitter.snapshotProjection, emitter.collection, id, snapshot, function(err) {
           if (err) return callback(err);

--- a/lib/submit-request.js
+++ b/lib/submit-request.js
@@ -41,7 +41,7 @@ SubmitRequest.prototype.submit = function(callback) {
   // With a null projection, it strips document metadata
   var fields = {$submit: true};
 
-  backend.db.getSnapshot(collection, id, fields, function(err, snapshot) {
+  backend.db.getSnapshot(collection, id, fields, null, function(err, snapshot) {
     if (err) return callback(err);
 
     request.snapshot = snapshot;
@@ -57,7 +57,7 @@ SubmitRequest.prototype.submit = function(callback) {
         // case, we should return a non-fatal 'Op already submitted' error. We
         // must get the past ops and check their src and seq values to
         // differentiate.
-        backend.db.getCommittedOpVersion(collection, id, snapshot, op, function(err, version) {
+        backend.db.getCommittedOpVersion(collection, id, snapshot, op, null, function(err, version) {
           if (err) return callback(err);
           if (version == null) {
             callback(request.alreadyCreatedError());
@@ -90,7 +90,7 @@ SubmitRequest.prototype.submit = function(callback) {
 
     // Transform the op up to the current snapshot version, then apply
     var from = op.v;
-    backend.db.getOpsToSnapshot(collection, id, from, snapshot, function(err, ops) {
+    backend.db.getOpsToSnapshot(collection, id, from, snapshot, null, function(err, ops) {
       if (err) return callback(err);
 
       if (ops.length !== snapshot.v - from) {
@@ -141,7 +141,7 @@ SubmitRequest.prototype.commit = function(callback) {
     if (err) return callback(err);
 
     // Try committing the operation and snapshot to the database atomically
-    backend.db.commit(request.collection, request.id, request.op, request.snapshot, function(err, succeeded) {
+    backend.db.commit(request.collection, request.id, request.op, request.snapshot, null, function(err, succeeded) {
       if (err) return callback(err);
       if (!succeeded) {
         // Between our fetch and our call to commit, another client committed an

--- a/test/client/submit.js
+++ b/test/client/submit.js
@@ -245,7 +245,7 @@ describe('client submit', function() {
   });
 
   it('submit fails if the server is missing ops required for transforming', function(done) {
-    this.backend.db.getOpsToSnapshot = function(collection, id, from, snapshot, callback) {
+    this.backend.db.getOpsToSnapshot = function(collection, id, from, snapshot, options, callback) {
       callback(null, []);
     };
     var doc = this.backend.connect().get('dogs', 'fido');
@@ -267,8 +267,8 @@ describe('client submit', function() {
 
   it('submit fails if ops returned are not the expected version', function(done) {
     var getOpsToSnapshot = this.backend.db.getOpsToSnapshot;
-    this.backend.db.getOpsToSnapshot = function(collection, id, from, snapshot, callback) {
-      getOpsToSnapshot.call(this, collection, id, from, snapshot, function(err, ops) {
+    this.backend.db.getOpsToSnapshot = function(collection, id, from, snapshot, options, callback) {
+      getOpsToSnapshot.call(this, collection, id, from, snapshot, options, function(err, ops) {
         ops[0].v++;
         callback(null, ops);
       });

--- a/test/db-memory.js
+++ b/test/db-memory.js
@@ -20,7 +20,7 @@ describe('DB base class', function() {
 
   it('returns an error if db.commit() is unimplemented', function(done) {
     var db = new DB();
-    db.commit('testcollection', 'test', {}, {}, function(err) {
+    db.commit('testcollection', 'test', {}, {}, null, function(err) {
       expect(err).an(Error);
       done();
     });
@@ -28,7 +28,7 @@ describe('DB base class', function() {
 
   it('returns an error if db.getSnapshot() is unimplemented', function(done) {
     var db = new DB();
-    db.getSnapshot('testcollection', 'foo', null, function(err) {
+    db.getSnapshot('testcollection', 'foo', null, null, function(err) {
       expect(err).an(Error);
       done();
     });
@@ -36,7 +36,7 @@ describe('DB base class', function() {
 
   it('returns an error if db.getOps() is unimplemented', function(done) {
     var db = new DB();
-    db.getOps('testcollection', 'foo', 0, null, function(err) {
+    db.getOps('testcollection', 'foo', 0, null, null, function(err) {
       expect(err).an(Error);
       done();
     });

--- a/test/db.js
+++ b/test/db.js
@@ -48,7 +48,7 @@ module.exports = function(options) {
     // snapshot before committing. Thus, commit may rely on the behavior
     // of getSnapshot with this special projection
     function submit(db, collection, id, op, callback) {
-      db.getSnapshot(collection, id, {$submit: true}, function(err, snapshot) {
+      db.getSnapshot(collection, id, {$submit: true}, null, function(err, snapshot) {
         if (err) return callback(err);
         if (snapshot.v !== op.v) {
           var succeeded = false;
@@ -56,7 +56,7 @@ module.exports = function(options) {
         }
         var err = ot.apply(snapshot, op);
         if (err) return callback(err);
-        db.commit(collection, id, op, snapshot, callback);
+        db.commit(collection, id, op, snapshot, null, callback);
       });
     }
 
@@ -73,9 +73,9 @@ module.exports = function(options) {
           if (err) return done(err);
           expect(numSucceeded).equal(1);
           if (!test) return done();
-          db.getOps('testcollection', 'foo', 0, null, function(err, opsOut) {
+          db.getOps('testcollection', 'foo', 0, null, null, function(err, opsOut) {
             if (err) return done(err);
-            db.getSnapshot('testcollection', 'foo', null, function(err, snapshotOut) {
+            db.getSnapshot('testcollection', 'foo', null, null, function(err, snapshotOut) {
               if (err) return done(err);
               test(opsOut, snapshotOut);
               done();
@@ -219,7 +219,7 @@ module.exports = function(options) {
 
     describe('getSnapshot', function() {
       it('getSnapshot returns v0 snapshot', function(done) {
-        this.db.getSnapshot('testcollection', 'test', null, function(err, result) {
+        this.db.getSnapshot('testcollection', 'test', null, null, function(err, result) {
           if (err) return done(err);
           expect(result).eql({id: 'test', type: null, v: 0, data: undefined});
           done();
@@ -232,7 +232,7 @@ module.exports = function(options) {
         var db = this.db;
         submit(db, 'testcollection', 'test', op, function(err, succeeded) {
           if (err) return done(err);
-          db.getSnapshot('testcollection', 'test', null, function(err, result) {
+          db.getSnapshot('testcollection', 'test', null, null, function(err, result) {
             if (err) return done(err);
             expect(result).eql({id: 'test', type: 'http://sharejs.org/types/JSONv0', v: 1, data: data});
             done();
@@ -248,7 +248,7 @@ module.exports = function(options) {
         var db = this.db;
         submit(db, 'testcollection', 'test', op, function(err, succeeded) {
           if (err) return done(err);
-          db.getSnapshotBulk('testcollection', ['test2', 'test'], null, function(err, resultMap) {
+          db.getSnapshotBulk('testcollection', ['test2', 'test'], null, null, function(err, resultMap) {
             if (err) return done(err);
             expect(resultMap).eql({
               test: {id: 'test', type: 'http://sharejs.org/types/JSONv0', v: 1, data: data},
@@ -262,7 +262,7 @@ module.exports = function(options) {
 
     describe('getOps', function() {
       it('getOps returns empty list when there are no ops', function(done) {
-        this.db.getOps('testcollection', 'test', 0, null, function(err, ops) {
+        this.db.getOps('testcollection', 'test', 0, null, null, function(err, ops) {
           if (err) return done(err);
           expect(ops).eql([]);
           done();
@@ -274,7 +274,7 @@ module.exports = function(options) {
         var db = this.db;
         submit(db, 'testcollection', 'test', op, function(err, succeeded) {
           if (err) return done(err);
-          db.getOps('testcollection', 'test', 0, null, function(err, ops) {
+          db.getOps('testcollection', 'test', 0, null, null, function(err, ops) {
             if (err) return done(err);
             expect(ops).eql([op]);
             done();
@@ -290,7 +290,7 @@ module.exports = function(options) {
           if (err) return done(err);
           submit(db, 'testcollection', 'test', op1, function(err, succeeded) {
             if (err) return done(err);
-            db.getOps('testcollection', 'test', 0, null, function(err, ops) {
+            db.getOps('testcollection', 'test', 0, null, null, function(err, ops) {
               if (err) return done(err);
               expect(ops).eql([op0, op1]);
               done();
@@ -307,7 +307,7 @@ module.exports = function(options) {
           if (err) return done(err);
           submit(db, 'testcollection', 'test', op1, function(err, succeeded) {
             if (err) return done(err);
-            db.getOps('testcollection', 'test', null, null, function(err, ops) {
+            db.getOps('testcollection', 'test', null, null, null, function(err, ops) {
               if (err) return done(err);
               expect(ops).eql([op0, op1]);
               done();
@@ -324,7 +324,7 @@ module.exports = function(options) {
           if (err) return done(err);
           submit(db, 'testcollection', 'test', op1, function(err, succeeded) {
             if (err) return done(err);
-            db.getOps('testcollection', 'test', 1, null, function(err, ops) {
+            db.getOps('testcollection', 'test', 1, null, null, function(err, ops) {
               if (err) return done(err);
               expect(ops).eql([op1]);
               done();
@@ -341,7 +341,7 @@ module.exports = function(options) {
           if (err) return done(err);
           submit(db, 'testcollection', 'test', op1, function(err, succeeded) {
             if (err) return done(err);
-            db.getOps('testcollection', 'test', 0, 1, function(err, ops) {
+            db.getOps('testcollection', 'test', 0, 1, null, function(err, ops) {
               if (err) return done(err);
               expect(ops).eql([op0]);
               done();
@@ -353,7 +353,7 @@ module.exports = function(options) {
 
     describe('getOpsBulk', function() {
       it('getOpsBulk returns empty map when there are no ops', function(done) {
-        this.db.getOpsBulk('testcollection', {test: 0, test2: 0}, null, function(err, opsMap) {
+        this.db.getOpsBulk('testcollection', {test: 0, test2: 0}, null, null, function(err, opsMap) {
           if (err) return done(err);
           expect(opsMap).eql({
             test: [],
@@ -370,7 +370,7 @@ module.exports = function(options) {
           if (err) return done(err);
           submit(db, 'testcollection', 'test2', op, function(err, succeeded) {
             if (err) return done(err);
-            db.getOpsBulk('testcollection', {test: 0, test2: 0}, null, function(err, opsMap) {
+            db.getOpsBulk('testcollection', {test: 0, test2: 0}, null, null, function(err, opsMap) {
               if (err) return done(err);
               expect(opsMap).eql({
                 test: [op],
@@ -389,7 +389,7 @@ module.exports = function(options) {
           if (err) return done(err);
           submit(db, 'testcollection', 'test2', op, function(err, succeeded) {
             if (err) return done(err);
-            db.getOpsBulk('testcollection', {test: null, test2: null}, null, function(err, opsMap) {
+            db.getOpsBulk('testcollection', {test: null, test2: null}, null, null, function(err, opsMap) {
               if (err) return done(err);
               expect(opsMap).eql({
                 test: [op],
@@ -413,7 +413,7 @@ module.exports = function(options) {
               if (err) return done(err);
               submit(db, 'testcollection', 'test2', op1, function(err, succeeded) {
                 if (err) return done(err);
-                db.getOpsBulk('testcollection', {test: 0, test2: 1}, null, function(err, opsMap) {
+                db.getOpsBulk('testcollection', {test: 0, test2: 1}, null, null, function(err, opsMap) {
                   if (err) return done(err);
                   expect(opsMap).eql({
                     test: [op0, op1],
@@ -439,7 +439,7 @@ module.exports = function(options) {
               if (err) return done(err);
               submit(db, 'testcollection', 'test2', op1, function(err, succeeded) {
                 if (err) return done(err);
-                db.getOpsBulk('testcollection', {test: 1, test2: 0}, {test2: 1}, function(err, opsMap) {
+                db.getOpsBulk('testcollection', {test: 1, test2: 0}, {test2: 1}, null, function(err, opsMap) {
                   if (err) return done(err);
                   expect(opsMap).eql({
                     test: [op1],
@@ -460,9 +460,9 @@ module.exports = function(options) {
         var db = this.db;
         submit(db, 'testcollection', 'test', op, function(err, succeeded) {
           if (err) return done(err);
-          db.getSnapshot('testcollection', 'test', {$submit: true}, function(err, snapshot) {
+          db.getSnapshot('testcollection', 'test', {$submit: true}, null, function(err, snapshot) {
             if (err) return done(err);
-            db.getOpsToSnapshot('testcollection', 'test', 0, snapshot, function(err, ops) {
+            db.getOpsToSnapshot('testcollection', 'test', 0, snapshot, null, function(err, ops) {
               if (err) return done(err);
               expect(ops).eql([op]);
               done();
@@ -476,7 +476,7 @@ module.exports = function(options) {
       it('returns data in the collection', function(done) {
         var snapshot = {v: 1, type: 'json0', data: {x: 5, y: 6}};
         var db = this.db;
-        db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, function(err, succeeded) {
+        db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, null, function(err, succeeded) {
           if (err) return done(err);
           db.query('testcollection', {x: 5}, null, null, function(err, results) {
             if (err) return done(err);
@@ -502,7 +502,7 @@ module.exports = function(options) {
 
         var snapshot = {type: 'json0', v: 1, data: {x: 5, y: 6}};
         var db = this.db;
-        db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, function(err) {
+        db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, null, function(err) {
           db.query('testcollection', {x: 5}, {y: true}, null, function(err, results) {
             if (err) return done(err);
             expect(results).eql([{type: 'json0', v: 1, data: {y: 6}, id: 'test'}]);
@@ -516,7 +516,7 @@ module.exports = function(options) {
 
         var snapshot = {type: 'json0', v: 1, data: {x: 5, y: 6}};
         var db = this.db;
-        db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, function(err) {
+        db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, null, function(err) {
           db.query('testcollection', {x: 5}, {}, null, function(err, results) {
             if (err) return done(err);
             expect(results).eql([{type: 'json0', v: 1, data: {}, id: 'test'}]);
@@ -530,7 +530,7 @@ module.exports = function(options) {
       it('returns data in the collection', function(done) {
         var snapshot = {v: 1, type: 'json0', data: {x: 5, y: 6}};
         var db = this.db;
-        db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, function(err, succeeded) {
+        db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, null, function(err, succeeded) {
           if (err) return done(err);
           db.queryPoll('testcollection', {x: 5}, null, function(err, ids) {
             if (err) return done(err);
@@ -568,7 +568,7 @@ module.exports = function(options) {
 
         var snapshot = {type: 'json0', v: 1, data: {x: 5, y: 6}};
         var db = this.db;
-        db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, function(err) {
+        db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, null, function(err) {
           db.queryPollDoc('testcollection', 'test', query, null, function(err, result) {
             if (err) return done(err);
             expect(result).equal(true);
@@ -583,7 +583,7 @@ module.exports = function(options) {
 
         var snapshot = {type: 'json0', v: 1, data: {x: 5, y: 6}};
         var db = this.db;
-        db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, function(err) {
+        db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, null, function(err) {
           db.queryPollDoc('testcollection', 'test', query, null, function(err, result) {
             if (err) return done(err);
             expect(result).equal(false);
@@ -607,7 +607,7 @@ module.exports = function(options) {
         var dbQuery = getQuery({query: {}, sort: [['foo', 1], ['bar', -1]]});
 
         async.each(snapshots, function(snapshot, cb) {
-          db.commit('testcollection', snapshot.id, {v: 0, create: {}}, snapshot, cb);
+          db.commit('testcollection', snapshot.id, {v: 0, create: {}}, snapshot, null, cb);
         }, function(err) {
           if (err) throw err;
           db.query('testcollection', dbQuery, null, null, function(err, results) {


### PR DESCRIPTION
This needs be changed in concert with sharedb-mingo-memory and sharedb-mongo. Just merging for now and will fix the dependencies