### PR TITLE
remove op.options implementation; maintain change to options in doc methods

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -556,29 +556,26 @@ Agent.prototype._submit = function(collection, id, op, callback) {
   });
 };
 
-function CreateOp(src, seq, v, create, options) {
+function CreateOp(src, seq, v, create) {
   this.src = src;
   this.seq = seq;
   this.v = v;
   this.create = create;
   this.m = null;
-  this.options = options;
 }
-function EditOp(src, seq, v, op, options) {
+function EditOp(src, seq, v, op) {
   this.src = src;
   this.seq = seq;
   this.v = v;
   this.op = op;
   this.m = null;
-  this.options = options;
 }
-function DeleteOp(src, seq, v, del, options) {
+function DeleteOp(src, seq, v, del) {
   this.src = src;
   this.seq = seq;
   this.v = v;
   this.del = del;
   this.m = null;
-  this.options = options;
 }
 // Normalize the properties submitted
 Agent.prototype._createOp = function(request) {
@@ -586,10 +583,10 @@ Agent.prototype._createOp = function(request) {
   // such as a resubmission after a reconnect, but it usually isn't needed
   var src = request.src || this.clientId;
   if (request.op) {
-    return new EditOp(src, request.seq, request.v, request.op, request.options);
+    return new EditOp(src, request.seq, request.v, request.op);
   } else if (request.create) {
-    return new CreateOp(src, request.seq, request.v, request.create, request.options);
+    return new CreateOp(src, request.seq, request.v, request.create);
   } else if (request.del) {
-    return new DeleteOp(src, request.seq, request.v, request.del, request.options);
+    return new DeleteOp(src, request.seq, request.v, request.del);
   }
 };

--- a/lib/client/connection.js
+++ b/lib/client/connection.js
@@ -400,7 +400,6 @@ Connection.prototype.sendOp = function(doc, op) {
   if (op.op) message.op = op.op;
   if (op.create) message.create = op.create;
   if (op.del) message.del = op.del;
-  if (op.options) message.options = op.options;
   this.send(message);
 };
 

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -725,17 +725,14 @@ Doc.prototype._tryCompose = function(op) {
 // @param [callback] called after operation submitted
 //
 // @fires before op, op, after op
-Doc.prototype.submitOp = function(op, options, callback) {
+Doc.prototype.submitOp = function(component, options, callback) {
   if (typeof options === 'function') {
     callback = options;
-    options = {};
+    options = null;
   }
-  var source = (options && options.source) || null;
-  if (options) delete options.source;
-
-  var fullOp = {op: op};
-  if (options) fullOp.options = options;
-  this._submit(fullOp, source, callback);
+  var op = {op: component};
+  var source = options && options.source;
+  this._submit(op, source, callback);
 };
 
 // Create the document, which in ShareJS semantics means to set its type. Every
@@ -750,11 +747,11 @@ Doc.prototype.submitOp = function(op, options, callback) {
 Doc.prototype.create = function(data, type, options, callback) {
   if (typeof type === 'function') {
     callback = type;
-    options = {};
+    options = null;
     type = null;
   } else if (typeof options === 'function') {
     callback = options;
-    options = {};
+    options = null;
   }
   if (!type) {
     type = types.defaultType.uri;
@@ -764,12 +761,8 @@ Doc.prototype.create = function(data, type, options, callback) {
     if (callback) return callback(err);
     return this.emit('error', err);
   }
-
-  var source = (options && options.source) || null;
-  if (options) delete options.source;
-
   var op = {create: {type: type, data: data}};
-  if (options) op.options = options;
+  var source = options && options.source;
   this._submit(op, source, callback);
 };
 
@@ -783,19 +776,15 @@ Doc.prototype.create = function(data, type, options, callback) {
 Doc.prototype.del = function(options, callback) {
   if (typeof options === 'function') {
     callback = options;
-    options = {};
+    options = null;
   }
   if (!this.type) {
     var err = new ShareDBError(4015, 'Document does not exist');
     if (callback) return callback(err);
     return this.emit('error', err);
   }
-
-  var source = (options && options.source) || null;
-  if (options) delete options.source;
-
   var op = {del: true};
-  if (options) op.options = options;
+  var source = options && options.source;
   this._submit(op, source, callback);
 };
 

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -37,47 +37,4 @@ describe('middleware', function() {
     });
 
   });
-
-  describe('doc options', function() {
-    it('on create', function(done) {
-      this.backend.use('submit', function(req) {
-        expect(req.op.options).eql({hairy: true});
-        done();
-      });
-
-      var connection = this.backend.connect();
-      connection.get('dogs', 'fido').create({}, types.defaultType.uri, {hairy: true});
-    });
-
-    it('on op', function(done) {
-      var backend = this.backend;
-      var connection = this.backend.connect();
-      var doc = connection.get('dogs', 'fido');
-      doc.create({}, function(err) {
-        if (err) return done(err);
-
-        backend.use('submit', function(req) {
-          expect(req.op.options).eql({hairy: true});
-          done();
-        });
-        doc.submitOp({p: ['age'], oi: 1}, {hairy: true});
-      });
-    });
-
-    it('on del', function(done) {
-      var backend = this.backend;
-      var connection = this.backend.connect();
-      var doc = connection.get('dogs', 'fido');
-      doc.create({}, function(err) {
-        if (err) return done(err);
-
-        backend.use('submit', function(req) {
-          expect(req.op.options).eql({hairy: true});
-          done();
-        });
-        doc.del({hairy: true});
-      });
-    });
-  });
-
 });


### PR DESCRIPTION
Rolls back changes that added options to ops, because this is non trivial to implement and we probably need a different API for it. It won't work as expected if ops are composed. There are perhaps good ways to do this, but punting for now as this is not high priority currently.

Keeping the options format change to create, del, and submitOp doc methods, because having source as an option rather than an argument is more clear and allows for further extension.