### PR TITLE
Backend::submit options argument

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -539,7 +539,7 @@ Agent.prototype._unsubscribeBulk = function(collection, ids, callback) {
 
 Agent.prototype._submit = function(collection, id, op, callback) {
   var agent = this;
-  this.backend.submit(this, collection, id, op, function(err, ops) {
+  this.backend.submit(this, collection, id, op, null, function(err, ops) {
     // Message to acknowledge the op was successfully submitted
     var ack = {src: op.src, seq: op.seq, v: op.v};
     if (err) {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -149,10 +149,10 @@ Backend.prototype.trigger = function(action, agent, request, callback) {
 // Submit an operation on the named collection/docname. op should contain a
 // {op:}, {create:} or {del:} field. It should probably contain a v: field (if
 // it doesn't, it defaults to the current version).
-Backend.prototype.submit = function(agent, index, id, op, callback) {
+Backend.prototype.submit = function(agent, index, id, op, options, callback) {
   var err = ot.checkOp(op);
   if (err) return callback(err);
-  var request = new SubmitRequest(this, agent, index, id, op);
+  var request = new SubmitRequest(this, agent, index, id, op, options);
   var backend = this;
   backend.trigger('submit', agent, request, function(err) {
     if (err) return callback(err);

--- a/lib/submit-request.js
+++ b/lib/submit-request.js
@@ -1,7 +1,7 @@
 var ot = require('./ot');
 var projections = require('./projections');
 
-function SubmitRequest(backend, agent, index, id, op) {
+function SubmitRequest(backend, agent, index, id, op, options) {
   this.backend = backend;
   this.agent = agent;
   // If a projection, rewrite the call into a call against the collection
@@ -11,6 +11,7 @@ function SubmitRequest(backend, agent, index, id, op) {
   this.collection = (projection) ? projection.target : index;
   this.id = id;
   this.op = op;
+  this.options = options;
 
   this.start = Date.now();
   this._addOpMeta();
@@ -141,7 +142,7 @@ SubmitRequest.prototype.commit = function(callback) {
     if (err) return callback(err);
 
     // Try committing the operation and snapshot to the database atomically
-    backend.db.commit(request.collection, request.id, request.op, request.snapshot, null, function(err, succeeded) {
+    backend.db.commit(request.collection, request.id, request.op, request.snapshot, request.options, function(err, succeeded) {
       if (err) return callback(err);
       if (!succeeded) {
         // Between our fetch and our call to commit, another client committed an

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -38,6 +38,22 @@ describe('middleware', function() {
 
   });
 
+  describe('submit', function() {
+
+    it('gets options passed to backend.submit', function(done) {
+      this.backend.use('submit', function(request, next) {
+        expect(request.options).eql({testOption: true});
+        done();
+      });
+      var op = {create: {type: types.defaultType.uri}};
+      var options = {testOption: true};
+      this.backend.submit(null, 'dogs', 'fido', op, options, function(err) {
+        if (err) throw err;
+      });
+    });
+
+  });
+
   describe('doc options', function() {
     it('on create', function(done) {
       this.backend.use('submit', function(req) {


### PR DESCRIPTION
Adds options argument to Backend::submit, which sets the options on the submit request passed through submit / apply / commit middleware and ultimately passes options to db.commit.

Clients don't have a good way of passing this in directly when they create ops, but this does create the ability for users to add the options in middleware.

No such options are currently defined, but one could imagine that this would enable DB adapters to expose the write options of their underlying DB drivers.