### PR TITLE
Add support for {metadata: true} option on all DB methods that get snapshots or ops

### DIFF
--- a/lib/db/memory.js
+++ b/lib/db/memory.js
@@ -56,10 +56,11 @@ MemoryDB.prototype.commit = function(collection, id, op, snapshot, options, call
 // snapshot). A snapshot with a version of zero is returned if the docuemnt
 // has never been created in the database.
 MemoryDB.prototype.getSnapshot = function(collection, id, fields, options, callback) {
+  var includeMetadata = options && options.metadata;
   var db = this;
   if (typeof callback !== 'function') throw new Error('Callback required');
   process.nextTick(function() {
-    var snapshot = db._getSnapshotSync(collection, id);
+    var snapshot = db._getSnapshotSync(collection, id, includeMetadata);
     callback(null, snapshot);
   });
 };
@@ -74,6 +75,7 @@ MemoryDB.prototype.getSnapshot = function(collection, id, fields, options, callb
 //
 // Callback should be called as callback(error, [list of ops]);
 MemoryDB.prototype.getOps = function(collection, id, from, to, options, callback) {
+  var includeMetadata = options && options.metadata;
   var db = this;
   if (typeof callback !== 'function') throw new Error('Callback required');
   process.nextTick(function() {
@@ -82,6 +84,11 @@ MemoryDB.prototype.getOps = function(collection, id, from, to, options, callback
       to = opLog.length;
     }
     var ops = clone(opLog.slice(from, to));
+    if (!includeMetadata) {
+      for (var i = 0; i < ops.length; i++) {
+        delete ops[i].m;
+      }
+    }
     callback(null, ops);
   });
 };
@@ -89,13 +96,14 @@ MemoryDB.prototype.getOps = function(collection, id, from, to, options, callback
 // The memory database query function returns all documents in a collection
 // regardless of query by default
 MemoryDB.prototype.query = function(collection, query, fields, options, callback) {
+  var includeMetadata = options && options.metadata;
   var db = this;
   if (typeof callback !== 'function') throw new Error('Callback required');
   process.nextTick(function() {
     var collectionDocs = db.docs[collection];
     var snapshots = [];
     for (var id in collectionDocs || {}) {
-      var snapshot = db._getSnapshotSync(collection, id);
+      var snapshot = db._getSnapshotSync(collection, id, includeMetadata);
       snapshots.push(snapshot);
     }
     try {
@@ -135,7 +143,7 @@ MemoryDB.prototype._writeSnapshotSync = function(collection, id, snapshot) {
   }
 };
 
-MemoryDB.prototype._getSnapshotSync = function(collection, id) {
+MemoryDB.prototype._getSnapshotSync = function(collection, id, includeMetadata) {
   var collectionDocs = this.docs[collection];
   // We need to clone the snapshot, because ShareDB assumes each call to
   // getSnapshot returns a new object
@@ -143,7 +151,7 @@ MemoryDB.prototype._getSnapshotSync = function(collection, id) {
   var snapshot;
   if (doc) {
     var data = clone(doc.data);
-    var meta = clone(doc.m);
+    var meta = (includeMetadata) ? clone(doc.m) : undefined;
     snapshot = new MemorySnapshot(id, doc.v, doc.type, data, meta);
   } else {
     var version = this._getVersionSync(collection, id);

--- a/test/db.js
+++ b/test/db.js
@@ -682,6 +682,28 @@ module.exports = function(options) {
           });
         });
       });
+
+      it('query does not return committed metadata by default with projection', function(done) {
+        var db = this.db;
+        commitSnapshotWithMetadata(db, function(err) {
+          db.query('testcollection', {x: 5}, {x: true}, null, function(err, results) {
+            if (err) return done(err);
+            expect(results[0].m).equal(undefined);
+            done();
+          });
+        });
+      });
+
+      it('query returns metadata when option is true with projection', function(done) {
+        var db = this.db;
+        commitSnapshotWithMetadata(db, function(err) {
+          db.query('testcollection', {x: 5}, {x: true}, {metadata: true}, function(err, results) {
+            if (err) return done(err);
+            expect(results[0].m).eql({test: 3});
+            done();
+          });
+        });
+      });
     });
 
     describe('queryPoll', function() {

--- a/test/db.js
+++ b/test/db.js
@@ -217,6 +217,14 @@ module.exports = function(options) {
       });
     });
 
+    function commitSnapshotWithMetadata(db, cb) {
+      var data = {x: 5, y: 6};
+      var metadata = {test: 3};
+      var op = {v: 0, create: {type: 'http://sharejs.org/types/JSONv0', data: data}};
+      var snapshot = {v: 1, type: 'http://sharejs.org/types/JSONv0', data: data, m: metadata};
+      db.commit('testcollection', 'test', op, snapshot, null, cb);
+    }
+
     describe('getSnapshot', function() {
       it('getSnapshot returns v0 snapshot', function(done) {
         this.db.getSnapshot('testcollection', 'test', null, null, function(err, result) {
@@ -239,6 +247,28 @@ module.exports = function(options) {
           });
         });
       });
+
+      it('getSnapshot does not return committed metadata by default', function(done) {
+        var db = this.db;
+        commitSnapshotWithMetadata(db, function(err) {
+          db.getSnapshot('testcollection', 'test', null, null, function(err, result) {
+            if (err) return done(err);
+            expect(result.m).equal(undefined);
+            done();
+          });
+        });
+      });
+
+      it('getSnapshot returns metadata when option is true', function(done) {
+        var db = this.db;
+        commitSnapshotWithMetadata(db, function(err) {
+          db.getSnapshot('testcollection', 'test', null, {metadata: true}, function(err, result) {
+            if (err) return done(err);
+            expect(result.m).eql({test: 3});
+            done();
+          });
+        });
+      });
     });
 
     describe('getSnapshotBulk', function() {
@@ -254,6 +284,28 @@ module.exports = function(options) {
               test: {id: 'test', type: 'http://sharejs.org/types/JSONv0', v: 1, data: data},
               test2: {id: 'test2', type: null, v: 0, data: undefined}
             });
+            done();
+          });
+        });
+      });
+
+      it('getSnapshotBulk does not return committed metadata by default', function(done) {
+        var db = this.db;
+        commitSnapshotWithMetadata(db, function(err) {
+          db.getSnapshotBulk('testcollection', ['test2', 'test'], null, null, function(err, resultMap) {
+            if (err) return done(err);
+            expect(resultMap.test.m).equal(undefined);
+            done();
+          });
+        });
+      });
+
+      it('getSnapshotBulk returns metadata when option is true', function(done) {
+        var db = this.db;
+        commitSnapshotWithMetadata(db, function(err) {
+          db.getSnapshotBulk('testcollection', ['test2', 'test'], null, {metadata: true}, function(err, resultMap) {
+            if (err) return done(err);
+            expect(resultMap.test.m).eql({test: 3});
             done();
           });
         });
@@ -346,6 +398,32 @@ module.exports = function(options) {
               expect(ops).eql([op0]);
               done();
             });
+          });
+        });
+      });
+
+      it('getOps does not return committed metadata by default', function(done) {
+        var op = {v: 0, create: {type: 'json0', data: {x: 5, y: 6}}, m: {test: 3}};
+        var db = this.db;
+        submit(db, 'testcollection', 'test', op, function(err, succeeded) {
+          if (err) return done(err);
+          db.getOps('testcollection', 'test', null, null, null, function(err, ops) {
+            if (err) return done(err);
+            expect(ops[0].m).eql(undefined);
+            done();
+          });
+        });
+      });
+
+      it('getOps returns metadata when option is true', function(done) {
+        var op = {v: 0, create: {type: 'json0', data: {x: 5, y: 6}}, m: {test: 3}};
+        var db = this.db;
+        submit(db, 'testcollection', 'test', op, function(err, succeeded) {
+          if (err) return done(err);
+          db.getOps('testcollection', 'test', null, null, {metadata: true}, function(err, ops) {
+            if (err) return done(err);
+            expect(ops[0].m).eql({test: 3});
+            done();
           });
         });
       });
@@ -452,6 +530,32 @@ module.exports = function(options) {
           });
         });
       });
+
+      it('getOpsBulk does not return committed metadata by default', function(done) {
+        var op = {v: 0, create: {type: 'json0', data: {x: 5, y: 6}}, m: {test: 3}};
+        var db = this.db;
+        submit(db, 'testcollection', 'test', op, function(err, succeeded) {
+          if (err) return done(err);
+          db.getOpsBulk('testcollection', {test: null}, null, null, function(err, opsMap) {
+            if (err) return done(err);
+            expect(opsMap.test[0].m).equal(undefined);
+            done();
+          });
+        });
+      });
+
+      it('getOpsBulk returns metadata when option is true', function(done) {
+        var op = {v: 0, create: {type: 'json0', data: {x: 5, y: 6}}, m: {test: 3}};
+        var db = this.db;
+        submit(db, 'testcollection', 'test', op, function(err, succeeded) {
+          if (err) return done(err);
+          db.getOpsBulk('testcollection', {test: null}, null, {metadata: true}, function(err, opsMap) {
+            if (err) return done(err);
+            expect(opsMap.test[0].m).eql({test: 3});
+            done();
+          });
+        });
+      });
     });
 
     describe('getOpsToSnapshot', function() {
@@ -470,10 +574,42 @@ module.exports = function(options) {
           });
         });
       });
+
+      it('getOpsToSnapshot does not return committed metadata by default', function(done) {
+        var op = {v: 0, create: {type: 'json0', data: {x: 5, y: 6}}, m: {test: 3}};
+        var db = this.db;
+        submit(db, 'testcollection', 'test', op, function(err, succeeded) {
+          if (err) return done(err);
+          db.getSnapshot('testcollection', 'test', {$submit: true}, null, function(err, snapshot) {
+            if (err) return done(err);
+            db.getOpsToSnapshot('testcollection', 'test', 0, snapshot, null, function(err, ops) {
+              if (err) return done(err);
+              expect(ops[0].m).equal(undefined);
+              done();
+            });
+          });
+        });
+      });
+
+      it('getOpsToSnapshot returns metadata when option is true', function(done) {
+        var op = {v: 0, create: {type: 'json0', data: {x: 5, y: 6}}, m: {test: 3}};
+        var db = this.db;
+        submit(db, 'testcollection', 'test', op, function(err, succeeded) {
+          if (err) return done(err);
+          db.getSnapshot('testcollection', 'test', {$submit: true}, null, function(err, snapshot) {
+            if (err) return done(err);
+            db.getOpsToSnapshot('testcollection', 'test', 0, snapshot, {metadata: true}, function(err, ops) {
+              if (err) return done(err);
+              expect(ops[0].m).eql({test: 3});
+              done();
+            });
+          });
+        });
+      });
     });
 
     describe('query', function() {
-      it('returns data in the collection', function(done) {
+      it('query returns data in the collection', function(done) {
         var snapshot = {v: 1, type: 'json0', data: {x: 5, y: 6}};
         var db = this.db;
         db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, null, function(err, succeeded) {
@@ -487,11 +623,33 @@ module.exports = function(options) {
         });
       });
 
-      it('returns nothing when there is no data', function(done) {
+      it('query returns nothing when there is no data', function(done) {
         this.db.query('testcollection', {x: 5}, null, null, function(err, results) {
           if (err) return done(err);
           expect(results).eql([]);
           done();
+        });
+      });
+
+      it('query does not return committed metadata by default', function(done) {
+        var db = this.db;
+        commitSnapshotWithMetadata(db, function(err) {
+          db.query('testcollection', {x: 5}, null, null, function(err, results) {
+            if (err) return done(err);
+            expect(results[0].m).equal(undefined);
+            done();
+          });
+        });
+      });
+
+      it('query returns metadata when option is true', function(done) {
+        var db = this.db;
+        commitSnapshotWithMetadata(db, function(err) {
+          db.query('testcollection', {x: 5}, null, {metadata: true}, function(err, results) {
+            if (err) return done(err);
+            expect(results[0].m).eql({test: 3});
+            done();
+          });
         });
       });
     });


### PR DESCRIPTION
By default, DB adapters should not return metadata on snapshots or ops, as this is not sent to clients and is intended only for use in debugging on the server or custom user extension. Updates the built in MemoryDB adapter to behave this way.

Also adds the option and tests that DB adapters should support to return this metadata if requested.