### PR TITLE
Chaining with `use` method

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -118,6 +118,7 @@ Backend.prototype.use = function(action, fn) {
   }
   var fns = this.middleware[action] || (this.middleware[action] = []);
   fns.push(fn);
+  return this;
 };
 
 /**

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -8,6 +8,15 @@ describe('middleware', function() {
     this.backend = new Backend();
   });
 
+  describe('use', function() {
+
+    it('returns itself to allow chaining', function() {
+      var response = this.backend.use('submit', function(request, next) {});
+      expect(response).equal(this.backend);
+    });
+
+  });
+
   describe('connect', function() {
 
     it('passes the agent on connect', function() {


### PR DESCRIPTION
A quick PR which adds the missing unit test from #69.

Allows code such as:

```
backend.use("submit", function(shareRequest, next) {
    console.log("submit");
    next();
  })
  .use("query", function(shareRequest, next) {
    console.log("query");
    next();
  });
```