### PR TITLE
Add missing leaderboard dependency

### DIFF
--- a/examples/leaderboard/package.json
+++ b/examples/leaderboard/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^15.1.0",
     "serve-static": "^1.11.1",
     "sharedb": "^1.0.0-beta",
+    "sharedb-mingo-memory": "^1.0.0-beta",
     "through2": "^2.0.1",
     "underscore": "^1.8.3",
     "websocket-json-stream": "^0.0.3",


### PR DESCRIPTION
Closes #116 

This is the result from `npm install -S sharedb-mingo-memory`. After this install, the demo worked correctly for me.