### PR TITLE
[Proposal] Op Event Changes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,14 @@ The document was created. Technically, this means it has a type. `source` will b
 `doc.on('before op'), function(op, source) {...})`
 An operation is about to be applied to the data. `source` will be `false` for ops received from the server and defaults to `true` for ops generated locally.
 
-`doc.on('op', function(op, source) {...})`
-An operation was applied to the data. `source` will be `false` for ops received from the server and defaults to `true` for ops generated locally.
+`doc.on('after op', function(op, source) {...})`
+An operation was entirely applied to the data. `source` will be `false` for ops received from the server and defaults to `true` for ops generated locally.
+
+`doc.on('before component', function(op, source) {...})`
+An operation component is about to be applied to the data. `op` will be part of a shattered operation consisting of an operation with only a single component to be applied. `source` will be `false` for ops received from the server and defaults to `true` for ops generated locally. If incremental apply is disabled or the doc ot type doesn't support shatter(), this event will still emit but with `op` being the entire operation.
+
+`doc.on('after component', function(op, source) {...})`
+An operation component was applied to the data. `op` will be part of a shattered operation consisting of an operation with only a single component that has been applied. `source` will be `false` for ops received from the server and defaults to `true` for ops generated locally. If incremental apply is disabled or the doc ot type doesn't support shatter(), this event will still emit but with `op` being the entire operation.
 
 `doc.on('del', function(data, source) {...})`
 The document was deleted. Document contents before deletion are passed in as an argument. `source` will be `false` for ops received from the server and defaults to `true` for ops generated locally.

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -87,6 +87,10 @@ function Doc(connection, collection, id) {
   // The OT type of this document. An uncreated document has type `null`
   this.type = null;
 
+  // Enable ops be incrementally applied. OT Type must support type.shatter()
+  this.applyLocalOpsIncremental = false;
+  this.applyRemoteOpsIncremental = true;
+
   // The applyStack enables us to track any ops submitted while we are
   // applying an op incrementally. This value is an array when we are
   // performing an incremental apply and null otherwise. When it is an array,
@@ -507,12 +511,11 @@ Doc.prototype._otApply = function(op, source) {
       return this.emit('error', err);
     }
 
-    // Iteratively apply multi-component remote operations and rollback ops
-    // (source === false) for the default JSON0 OT type. It could use
-    // type.shatter(), but since this code is so specific to use cases for the
-    // JSON0 type and ShareDB explicitly bundles the default type, we might as
-    // well write it this way and save needing to iterate through the op
-    // components twice.
+    // The 'before op' event enables clients to pull any necessary data out of
+    // the snapshot before it gets changed
+    this.emit('before op', op.op, source);
+
+    // Iteratively apply multi-component for the OT types that support type.shatter().
     //
     // Ideally, we would not need this extra complexity. However, it is
     // helpful for implementing bindings that update DOM nodes and other
@@ -522,12 +525,15 @@ Doc.prototype._otApply = function(op, source) {
     // that the snapshot only include updates from the particular op component
     // at the time of emission. Eliminating this would require rethinking how
     // such external bindings are implemented.
-    if (!source && this.type === types.defaultType && op.op.length > 1) {
+    if ( (this.type.shatter && op.op.length > 1) && 
+         ( (this.applyLocalOpsIncremental && source) || 
+           (this.applyRemoteOpsIncremental && !source) ) ) {
+
       if (!this.applyStack) this.applyStack = [];
       var stackLength = this.applyStack.length;
-      for (var i = 0; i < op.op.length; i++) {
-        var component = op.op[i];
-        var componentOp = {op: [component]};
+      var shatteredOps = this.type.shatter(op.op);
+      for (var i = 0; i < shatteredOps.length; i++) {
+        var componentOp = {op: shatteredOps[i]};
         // Transform componentOp against any ops that have been submitted
         // sychronously inside of an op event handler since we began apply of
         // our operation
@@ -536,26 +542,27 @@ Doc.prototype._otApply = function(op, source) {
           if (transformErr) return this._hardRollback(transformErr);
         }
         // Apply the individual op component
-        this.emit('before op', componentOp.op, source);
+        this.emit('before component', componentOp.op, source);
         this.data = this.type.apply(this.data, componentOp.op);
-        this.emit('op', componentOp.op, source);
+        this.emit('after component', componentOp.op, source);
       }
       // Pop whatever was submitted since we started applying this op
       this._popApplyStack(stackLength);
-      return;
     }
 
-    // The 'before op' event enables clients to pull any necessary data out of
-    // the snapshot before it gets changed
-    this.emit('before op', op.op, source);
-    // Apply the operation to the local data, mutating it in place
-    this.data = this.type.apply(this.data, op.op);
-    // Emit an 'op' event once the local data includes the changes from the
+    // Apply the full operation to the local data, mutating it in place
+    else {
+      this.emit('before component', op.op, source);
+      this.data = this.type.apply(this.data, op.op);
+      this.emit('after component', op.op, source);
+    }
+
+    // Emit an 'after op' event once the local data includes the changes from the
     // op. For locally submitted ops, this will be synchronously with
     // submission and before the server or other clients have received the op.
     // For ops from other clients, this will be after the op has been
     // committed to the database and published
-    this.emit('op', op.op, source);
+    this.emit('after op', op.op, source);
     return;
   }
 

--- a/test/client/projections.js
+++ b/test/client/projections.js
@@ -115,7 +115,7 @@ describe('client projections', function() {
       var fido = connection2.get('dogs_summary', 'fido');
       fido.subscribe(function(err) {
         if (err) return done(err);
-        fido.on('op', function() {
+        fido.on('after op', function() {
           expect(fido.data).eql(expected);
           expect(fido.version).eql(2);
           done();
@@ -154,7 +154,7 @@ describe('client projections', function() {
       var fido = connection2.get('dogs_summary', 'fido');
       connection2.createSubscribeQuery('dogs_summary', {}, null, function(err) {
         if (err) return done(err);
-        fido.on('op', function() {
+        fido.on('after op', function() {
           expect(fido.data).eql(expected);
           expect(fido.version).eql(2);
           done();

--- a/test/client/subscribe.js
+++ b/test/client/subscribe.js
@@ -174,7 +174,7 @@ describe('client subscribe', function() {
           if (err) return done(err);
           doc.submitOp({p: ['age'], na: 1}, function(err) {
             if (err) return done(err);
-            doc2.on('op', function(op, context) {
+            doc2.on('after op', function(op, context) {
               done();
             });
             doc2[method]();
@@ -343,7 +343,7 @@ describe('client subscribe', function() {
       if (err) return done(err);
       doc2.subscribe(function(err) {
         if (err) return done(err);
-        doc2.on('op', function(op, context) {
+        doc2.on('after op', function(op, context) {
           expect(doc2.version).eql(2);
           expect(doc2.data).eql({age: 4});
           done();
@@ -360,7 +360,7 @@ describe('client subscribe', function() {
       if (err) return done(err);
       doc2.subscribe(function(err) {
         if (err) return done(err);
-        doc2.on('op', function(op, context) {
+        doc2.on('after op', function(op, context) {
           done();
         });
         doc2.connection.close();
@@ -377,7 +377,7 @@ describe('client subscribe', function() {
       if (err) return done(err);
       doc2.subscribe(function(err) {
         if (err) return done(err);
-        doc2.on('op', function(op, context) {
+        doc2.on('after op', function(op, context) {
           done();
         });
         backend.suppressPublish = true;
@@ -393,7 +393,7 @@ describe('client subscribe', function() {
       if (err) return done(err);
       doc2.subscribe(function(err) {
         if (err) return done(err);
-        doc2.on('op', function(op, context) {
+        doc2.on('after op', function(op, context) {
           done();
         });
         doc2.unsubscribe(function(err) {
@@ -411,7 +411,7 @@ describe('client subscribe', function() {
       if (err) return done(err);
       doc2.subscribe(function(err) {
         if (err) return done(err);
-        doc2.on('op', function(op, context) {
+        doc2.on('after op', function(op, context) {
           done();
         });
         doc2.destroy(function(err) {
@@ -441,7 +441,7 @@ describe('client subscribe', function() {
           function(cb) { spot.unsubscribe(cb); }
         ], function(err) {
           if (err) return done(err);
-          fido.on('op', function(op, context) {
+          fido.on('after op', function(op, context) {
             done();
           });
           doc.submitOp({p: ['age'], na: 1}, done);
@@ -459,7 +459,7 @@ describe('client subscribe', function() {
       if (err) return done(err);
       doc2.subscribe(function(err) {
         if (err) return done(err);
-        doc2.on('op', function(op, context) {
+        doc2.on('after op', function(op, context) {
           expect(doc2.version).eql(2);
           expect(doc2.data).eql({age: 4});
           done();
@@ -483,7 +483,7 @@ describe('client subscribe', function() {
       doc2.unsubscribe();
       doc2.subscribe(function(err) {
         if (err) return done(err);
-        doc2.on('op', function(op, context) {
+        doc2.on('after op', function(op, context) {
           done();
         });
         doc.submitOp({p: ['age'], na: 1});
@@ -503,7 +503,7 @@ describe('client subscribe', function() {
           [{p: ['age'], na: 1}],
           [{p: ['age'], na: 5}],
         ];
-        doc2.on('op', function(op, context) {
+        doc2.on('after op', function(op, context) {
           var item = expected.shift();
           expect(op).eql(item);
           if (expected.length) return;
@@ -535,7 +535,7 @@ describe('client subscribe', function() {
       doc2.subscribe(function(err) {
         if (err) return done(err);
         var wait = 4;
-        doc2.on('op', function(op, context) {
+        doc2.on('after op', function(op, context) {
           if (--wait) return;
           expect(doc2.version).eql(5);
           expect(doc2.data).eql({age: 122});


### PR DESCRIPTION
Standardizes events so that they always work the same way, no exceptions. Changed `op` event to `after op`. Added `before component` and `after component` events.
## 

Currently there are 2 events surrounding the application of an operation. They are:
- `before op` - Emitted before op is applied
- `op` - Emitted after op is applied

These behave in a standard way with one exception, when applying remote ops of json0 type. In this case the op is manually shattered, applied incrementally and the events are emitted before and after each "component op" has been applied.

_the comments explain:_

> Ideally, we would not need this extra complexity. However, it is helpful for implementing bindings…

Indeed it can be very helpful to have events triggered on the application of each component. It may also be helpful on a different OT types that support it. Or even on local ops as well as remote ops, depending on the application. 

That said, it also remains useful to have events that treat the op more atomically… before any portion of an op has been applied and after an op has been fully applied.
## 

Unfortunately in its current implementation it’s either one of the other (atomic or incremental) and it’s not up to the user to decide. It’s only based on a hardcoded data type’s remote ops.

This creates several interesting issues, an important one in particular is that there is no way to run code only after an entire json0 remote op has been applied. Which is relevant, if your app operations are meant to be treated as ‘atomic’. Such that they change the doc in a way that only makes sense after the op has been applied in its entirety. 

_As an example:_ One might want to render after an entire op has been applied. However, when applying json0 remote ops they are split up and the `op` event would be run multiple times. The doc.data may only make sense to render once the entire op has been applied, but you aren’t sure which `op` event is the last one… Another cases could be needing to transform a complex cursor by an full operation.

**Generally the issues are:**
1. No way to process json0 remote ops atomically.
2. No way to process other OT types incrementally.
3. No way to process local ops incrementally.
4. No way to decide if ops should be applied atomically or incrementally.
5. Events change meaning depending on type and source.

What would be nice is if we could listen to both op level and component level events. Have operations applied atomically or shattered if the type supports it. For both remote and local ops, if desired.
## 

I'd like to **propose** that rather than changing the meaning of the `before op` and `op` events based on OT type and source. The two events should more appropriately be four separate events:
- `before op` - emit before any portion of the op is applied.
- `before component` - emit before each component op is applied.
- `after component` - emit after each component op has been applied.
- `after op` - emit after the entire op has been applied.

And whether ops are applied atomically or incrementally should be based upon… 

``` javascript
  // if OT type implements .shatter() 
  doc.type.shatter !== undefined;

  // and upon two properties of the doc object
  doc.applyLocalOpsIncremental = false;
  doc.applyRemoteOpsIncremental = true;
```

**Benefits of this design:**
- Allows any OT type to define .shatter() and emit granular events.
- Enables `after op` to always emit entire ops, including remote json0 ops.
- Enables `before op` to always emit entire ops, including remote json0 ops.
- Enables ability to decide whether ops should be applied atomically or incrementally.
- Events always work the same way, no confusion.

**Design decisions**
- `before component` and `after component` will always fire. A single component op or an OT type that doesn’t support `shatter`, will emit the entire op. I did this to make transitioning `op` events to `after component` always work. However, I think the case could be made for not emitting these events if apply incrementally is disabled or shatter undefined.
- `applyLocalOpsIncremental` defaults to `false` and `applyRemoteOpsIncremental` defaults to `true`. This was only chosen to remain consistent with ShareDBs current implementation. I think ultimately it would make more sense for both to either be `true`… or possibly `false`, but most importantly consistent.
## 

I created this pull request to show the implementation of the ideas above. Please check it out and let me know your thoughts. 

I realized that by recommending an update to the event system, it means developers implementing ShareDB would need to update their code. So I’d like to hear fellow developer’s thoughts and input. These changes would require developers to implement the following updates:

``` javascript
on(‘begin op’)    // to… either on(‘begin op’) or on(‘begin component’)
on(‘op’)          // to… either on(‘after op’) or on(‘after component`)
```

In most cases, `begin op` would stay the same and `op` would change to `after op`. Only when granular events are specifically needed would a developer change events to use `before component` or `after component`.
## 

Thanks for everyone’s work on this awesome library, especially @nateps for continually improving it. It really is a hidden gem in the code universe.
