### PR TITLE
Add documentation for doc.whenNothingPending

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ Invokes the given callback function after
 
  * all ops submitted via `doc.submitOp` have been sent to the server, and
  * all pending fetch, subscribe, and unsubscribe requests have been resolved.
+ 
+Note that `whenNothingPending` does NOT wait for pending `model.query()` calls.
 
 ### Class: `ShareDB.Query`
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ Delete the document locally and send delete operation to the server.
 Call this after you've either fetched or subscribed to the document.
 * `options.source` Argument passed to the `'del'` event locally. This is not sent to the server or other clients. Defaults to `true`.
 
+`doc.whenNothingPending(function(err) {...})`
+Invokes the given callback function after
+
+ * all ops submitted via `doc.submitOp` have been sent to the server, and
+ * all pending fetch, subscribe, and unsubscribe requests have been resolved.
+
 ### Class: `ShareDB.Query`
 
 `query.ready` _(Boolean)_


### PR DESCRIPTION
`doc.whenNothingPending` can be quite useful in application code, and I noticed it was not documented, so I thought I'd add some documentation for it.