### PR TITLE
adding responsive meta

### DIFF
--- a/examples/rich-text/static/index.html
+++ b/examples/rich-text/static/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>ShareDB Rich Text</title>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
 <link href="quill.snow.css" rel="stylesheet">
 
 <div id="editor"></div>


### PR DESCRIPTION
Adding Responsive Meta Tag

`<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>`

This will be desirable for all mobile devices