### PR TITLE
Remove unused Duplex variable in example

### DIFF
--- a/examples/leaderboard/server/index.js
+++ b/examples/leaderboard/server/index.js
@@ -6,7 +6,6 @@ var ShareDBMingoMemory = require('sharedb-mingo-memory');
 var WebSocketJSONStream = require('websocket-json-stream');
 var WebSocket = require('ws');
 var util = require('util');
-var Duplex = require('stream').Duplex;
 
 // Start ShareDB
 var share = ShareDB({db: new ShareDBMingoMemory()});


### PR DESCRIPTION
This PR removes a variable that is defined, but not used.

Verified that the behavior of the example remains the same.