### PR TITLE
Emit error on failed resubscribe

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = LF
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -348,13 +348,15 @@ Doc.prototype._onConnectionStateChanged = function() {
 };
 
 Doc.prototype._resubscribe = function() {
+  var doc = this
   var callbacks = this.pendingFetch;
   this.pendingFetch = [];
 
   if (this.wantSubscribe) {
     if (callbacks.length) {
       this.subscribe(function(err) {
-        callEach(callbacks, err);
+        var called = callEach(callbacks, err);
+        if (err && !called) doc.emit('error', err)
       });
       return;
     }
@@ -364,7 +366,8 @@ Doc.prototype._resubscribe = function() {
 
   if (callbacks.length) {
     this.fetch(function(err) {
-      callEach(callbacks, err);
+      var called = callEach(callbacks, err);
+      if (err && !called) doc.emit('error', err)
     });
   }
 };

--- a/test/client/subscribe.js
+++ b/test/client/subscribe.js
@@ -237,6 +237,29 @@ describe('client subscribe', function() {
       });
     });
 
+    it(method + ' emits error passed to doc read middleware after reconnect', function(done) {
+      this.backend.use('doc', function(request, next) {
+        next({message: 'Reject doc read'});
+      });
+      var backend = this.backend;
+      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc2 = this.backend.connect().get('dogs', 'fido');
+      doc.create({age: 3}, function(err) {
+        if (err) return done(err);
+        doc2[method]()
+        doc2.on('error', function(err) {
+          expect(err.message).equal('Reject doc read');
+          expect(doc2.version).eql(null);
+          expect(doc2.data).eql(undefined);
+          done();
+        });
+        doc2.connection.close();
+        process.nextTick(function() {
+          backend.connect(doc2.connection);
+        });
+      });
+    });
+
     it(method + ' will call back when ops are pending', function(done) {
       var doc = this.backend.connect().get('dogs', 'fido');
       doc.create({age: 3}, function(err) {


### PR DESCRIPTION
Normally when a subscribe callback is missing, an error event is generated on error, except for the following scenario addressed by this PR:

1. state === 'connecting'
2. subscribe() - can't subscribe in this state
3. state === 'connected'
4. _resubscribe()
5. Backend returns an error

Expected: doc.emit('error', error)
Actual: no error event
