### PR TITLE
Make example instructions in readme a bit more clear

### DIFF
--- a/examples/leaderboard/README.md
+++ b/examples/leaderboard/README.md
@@ -5,27 +5,31 @@
 This is a port of [https://github.com/percolatestudio/react-leaderboard](Leaderboard) to
 ShareDB.
 
-In this demo, data is not persisted. To persiste data, run a Mongo
+In this demo, data is not persisted. To persist data, run a Mongo
 server and initialize ShareDB with the
 [ShareDBMongo](https://github.com/share/sharedb-mongo) database adapter.
 
-## Build client JavaScript file
+## Run this example
+
+First, install dependencies.
+
+Note: Make sure you're in the `examples/leaderboard` folder so that it uses the `package.json` located here).
+
+```
+npm install
+```
+
+Then build the client JavaScript file.
 ```
 npm run build
 ```
 
-## Run server
+Get the server running.
 ```
-num run build
-```
-
-## Run server
-```
-npm install
 npm start
 ```
 
-## Run app in browser
-Load [http://localhost:8080](http://localhost:8080)
+Finally, open the example app in the browser. It runs on port 8080 by default:
+[http://localhost:8080](http://localhost:8080)
 
-
+For testing out the real-time aspects of this demo, you'll want to open two browser windows!


### PR DESCRIPTION
When trying to run this example locally I noticed the instructions were a bit confusing. Just added a bit of clarity.