### PR TITLE
Fix server crashing on failed publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - 6
-  - 5
-  - 4
-  - 0.10
+  - "6"
+  - "5"
+  - "4"
+  - "0.10"
 script: "npm run jshint && npm run test-cover"
 # Send coverage data to Coveralls
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
+  - "9"
+  - "8"
   - "6"
-  - "5"
   - "4"
-  - "0.10"
 script: "npm run jshint && npm run test-cover"
 # Send coverage data to Coveralls
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/lib/pubsub/index.js
+++ b/lib/pubsub/index.js
@@ -16,6 +16,11 @@ function PubSub(options) {
   // isn't complete until the callback returns from Redis
   // Maps channel -> true
   this.subscribed = {};
+
+  var self = this;
+  this._defaultCallback = function(err) {
+    if (err) return self.emit('error', err);
+  };
 }
 module.exports = PubSub;
 emitter.mixin(PubSub);
@@ -27,22 +32,29 @@ PubSub.prototype.close = function(callback) {
       map[id].destroy();
     }
   }
-  if (callback) callback();
+  if (callback) process.nextTick(callback);
 };
 
 PubSub.prototype._subscribe = function(channel, callback) {
-  callback(new ShareDBError(5015, '_subscribe PubSub method unimplemented'));
+  process.nextTick(function() {
+    callback(new ShareDBError(5015, '_subscribe PubSub method unimplemented'));
+  });
 };
 
 PubSub.prototype._unsubscribe = function(channel, callback) {
-  callback(new ShareDBError(5016, '_unsubscribe PubSub method unimplemented'));
+  process.nextTick(function() {
+    callback(new ShareDBError(5016, '_unsubscribe PubSub method unimplemented'));
+  });
 };
 
 PubSub.prototype._publish = function(channels, data, callback) {
-  callback(new ShareDBError(5017, '_publish PubSub method unimplemented'));
+  process.nextTick(function() {
+    callback(new ShareDBError(5017, '_publish PubSub method unimplemented'));
+  });
 };
 
 PubSub.prototype.subscribe = function(channel, callback) {
+  if (!callback) callback = this._defaultCallback;
   if (this.prefix) {
     channel = this.prefix + ' ' + channel;
   }
@@ -64,6 +76,7 @@ PubSub.prototype.subscribe = function(channel, callback) {
 };
 
 PubSub.prototype.publish = function(channels, data, callback) {
+  if (!callback) callback = this._defaultCallback;
   if (this.prefix) {
     for (var i = 0; i < channels.length; i++) {
       channels[i] = this.prefix + ' ' + channels[i];
@@ -113,9 +126,7 @@ PubSub.prototype._removeStream = function(channel, stream) {
   // complete before we can count on being subscribed again
   delete this.subscribed[channel];
 
-  this._unsubscribe(channel, function(err) {
-    if (err) throw err;
-  });
+  this._unsubscribe(channel, this._defaultCallback);
 };
 
 function shallowCopy(object) {

--- a/lib/pubsub/index.js
+++ b/lib/pubsub/index.js
@@ -1,8 +1,11 @@
+var emitter = require('../emitter');
 var OpStream = require('../op-stream');
 var ShareDBError = require('../error');
 var util = require('../util');
 
 function PubSub(options) {
+  if (!(this instanceof PubSub)) return new PubSub(options);
+  emitter.EventEmitter.call(this);
   this.prefix = options && options.prefix;
   this.nextStreamId = 1;
   this.streamsCount = 0;
@@ -15,6 +18,7 @@ function PubSub(options) {
   this.subscribed = {};
 }
 module.exports = PubSub;
+emitter.mixin(PubSub);
 
 PubSub.prototype.close = function(callback) {
   for (var channel in this.streams) {

--- a/lib/submit-request.js
+++ b/lib/submit-request.js
@@ -1,5 +1,6 @@
 var ot = require('./ot');
 var projections = require('./projections');
+var util = require('./util');
 
 function SubmitRequest(backend, agent, index, id, op, options) {
   this.backend = backend;
@@ -157,7 +158,7 @@ SubmitRequest.prototype.commit = function(callback) {
         // Needed for agent to detect if it can ignore sending the op back to
         // the client that submitted it in subscriptions
         if (request.collection !== request.index) op.i = request.index;
-        backend.pubsub.publish(request.channels, op, noop);
+        backend.pubsub.publish(request.channels, op, util.doNothing);
       }
       callback();
     });
@@ -246,5 +247,3 @@ SubmitRequest.prototype.versionAfterTransformError = function() {
 SubmitRequest.prototype.maxRetriesError = function() {
   return {code: 5004, message: 'Op submit failed. Maximum submit retries exceeded'};
 };
-
-function noop() {}

--- a/lib/submit-request.js
+++ b/lib/submit-request.js
@@ -1,6 +1,5 @@
 var ot = require('./ot');
 var projections = require('./projections');
-var util = require('./util');
 
 function SubmitRequest(backend, agent, index, id, op, options) {
   this.backend = backend;
@@ -158,7 +157,7 @@ SubmitRequest.prototype.commit = function(callback) {
         // Needed for agent to detect if it can ignore sending the op back to
         // the client that submitted it in subscriptions
         if (request.collection !== request.index) op.i = request.index;
-        backend.pubsub.publish(request.channels, op, util.doNothing);
+        backend.pubsub.publish(request.channels, op);
       }
       callback();
     });

--- a/lib/submit-request.js
+++ b/lib/submit-request.js
@@ -157,7 +157,7 @@ SubmitRequest.prototype.commit = function(callback) {
         // Needed for agent to detect if it can ignore sending the op back to
         // the client that submitted it in subscriptions
         if (request.collection !== request.index) op.i = request.index;
-        backend.pubsub.publish(request.channels, op);
+        backend.pubsub.publish(request.channels, op, noop);
       }
       callback();
     });
@@ -246,3 +246,5 @@ SubmitRequest.prototype.versionAfterTransformError = function() {
 SubmitRequest.prototype.maxRetriesError = function() {
   return {code: 5004, message: 'Op submit failed. Maximum submit retries exceeded'};
 };
+
+function noop() {}

--- a/test/pubsub-memory.js
+++ b/test/pubsub-memory.js
@@ -14,30 +14,55 @@ describe('PubSub base class', function() {
     var pubsub = new PubSub();
     pubsub.subscribe('x', function(err) {
       expect(err).an(Error);
+      expect(err.code).to.equal(5015);
       done();
     });
   });
 
-  it('throws an error if _unsubscribe is unimplemented', function(done) {
+  it('emits an error if _subscribe is unimplemented and callback is not provided', function(done) {
+    var pubsub = new PubSub();
+    pubsub.on('error', function(err) {
+      expect(err).an(Error);
+      expect(err.code).to.equal(5015);
+      done();
+    });
+    pubsub.subscribe('x');
+  });
+
+  it('emits an error if _unsubscribe is unimplemented', function(done) {
     var pubsub = new PubSub();
     pubsub._subscribe = function(channel, callback) {
       callback();
     };
     pubsub.subscribe('x', function(err, stream) {
       if (err) return done(err);
-      expect(function() {
-        stream.destroy();
-      }).throwException();
-      done();
+      pubsub.on('error', function(err) {
+        expect(err).to.be.an(Error);
+        expect(err.code).to.equal(5016);
+        done();
+      });
+      stream.destroy();
     });
   });
 
   it('returns an error if _publish is unimplemented', function(done) {
     var pubsub = new PubSub();
+    pubsub.on('error', done);
     pubsub.publish(['x', 'y'], {test: true}, function(err) {
       expect(err).an(Error);
+      expect(err.code).to.equal(5017);
       done();
     });
+  });
+
+  it('emits an error if _publish is unimplemented and callback is not provided', function(done) {
+    var pubsub = new PubSub();
+    pubsub.on('error', function(err) {
+        expect(err).an(Error);
+        expect(err.code).to.equal(5017);
+        done();
+    });
+    pubsub.publish(['x', 'y'], {test: true});
   });
 
   it('can emit events', function(done) {

--- a/test/pubsub-memory.js
+++ b/test/pubsub-memory.js
@@ -39,4 +39,14 @@ describe('PubSub base class', function() {
       done();
     });
   });
+
+  it('can emit events', function(done) {
+      var pubsub = new PubSub();
+      pubsub.on('error', function(err) {
+        expect(err).an(Error);
+        expect(err.message).equal('test error');
+        done();
+      });
+      pubsub.emit('error', new Error('test error'));
+  });
 });

--- a/test/pubsub-memory.js
+++ b/test/pubsub-memory.js
@@ -58,20 +58,20 @@ describe('PubSub base class', function() {
   it('emits an error if _publish is unimplemented and callback is not provided', function(done) {
     var pubsub = new PubSub();
     pubsub.on('error', function(err) {
-        expect(err).an(Error);
-        expect(err.code).to.equal(5017);
-        done();
+      expect(err).an(Error);
+      expect(err.code).to.equal(5017);
+      done();
     });
     pubsub.publish(['x', 'y'], {test: true});
   });
 
   it('can emit events', function(done) {
-      var pubsub = new PubSub();
-      pubsub.on('error', function(err) {
-        expect(err).an(Error);
-        expect(err.message).equal('test error');
-        done();
-      });
-      pubsub.emit('error', new Error('test error'));
+    var pubsub = new PubSub();
+    pubsub.on('error', function(err) {
+      expect(err).an(Error);
+      expect(err.message).equal('test error');
+      done();
+    });
+    pubsub.emit('error', new Error('test error'));
   });
 });

--- a/test/pubsub.js
+++ b/test/pubsub.js
@@ -75,5 +75,14 @@ module.exports = function(create) {
         done();
       });
     });
+
+    it('can emit events', function(done) {
+      this.pubsub.on('error', function(err) {
+        expect(err).an(Error);
+        expect(err.message).equal('test error');
+        done();
+      });
+      this.pubsub.emit('error', new Error('test error'));
+    });
   });
 };


### PR DESCRIPTION
This PR fixes the issue where the entire server crashes when ShareDB fails to publish a message to its PubSub system.

The easiest way to reproduce the problem is to use Redis for PubSub (with node-redis configured to try to restore the connection indefinitely), stop Redis and then send some operations to ShareDB server. ShareDB will then try to publish a message to Redis and crash the server.

The fix is to simply add an empty callback to the `publish` function. This works fine as ShareDB can gracefully recover from losing those messages by reading the missing document revisions from the database (eg MongoDB). For the same reason I don't think it is necessary to propagate the publishing error up, although it certainly is a possibility.