### PR TITLE
Fix Doc.prototype.destroy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - 6
-  - 5
-  - 4
-  - 0.10
+  - "9"
+  - "8"
+  - "6"
+  - "4"
 script: "npm run jshint && npm run test-cover"
 # Send coverage data to Coveralls
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "10"
-  - "9"
   - "8"
   - "6"
 script: "npm run jshint && npm run test-cover"

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -104,7 +104,9 @@ emitter.mixin(Doc);
 Doc.prototype.destroy = function(callback) {
   var doc = this;
   doc.whenNothingPending(function() {
-    if (doc.wantSubscribe) doc.unsubscribe();
+    if (doc.wantSubscribe) {
+      doc.unsubscribe();
+    }
     doc.connection._destroyDoc(doc);
     if (callback) callback();
   });

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -105,10 +105,15 @@ Doc.prototype.destroy = function(callback) {
   var doc = this;
   doc.whenNothingPending(function() {
     if (doc.wantSubscribe) {
-      doc.unsubscribe();
+      doc.unsubscribe(function(err) {
+        if (!err) doc.connection._destroyDoc(doc);
+        if (callback) return callback(err);
+        if (err) this.emit('error', err); 
+      });
+    } else {
+      doc.connection._destroyDoc(doc);
+      if (callback) callback();
     }
-    doc.connection._destroyDoc(doc);
-    if (callback) callback();
   });
 };
 

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -104,10 +104,8 @@ emitter.mixin(Doc);
 Doc.prototype.destroy = function(callback) {
   var doc = this;
   doc.whenNothingPending(function() {
+    if (doc.wantSubscribe) doc.unsubscribe();
     doc.connection._destroyDoc(doc);
-    if (doc.wantSubscribe) {
-      return doc.unsubscribe(callback);
-    }
     if (callback) callback();
   });
 };

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -106,9 +106,13 @@ Doc.prototype.destroy = function(callback) {
   doc.whenNothingPending(function() {
     if (doc.wantSubscribe) {
       doc.unsubscribe(function(err) {
-        if (!err) doc.connection._destroyDoc(doc);
-        if (callback) return callback(err);
-        if (err) this.emit('error', err); 
+        if (err) {
+          if (callback) callback(err);
+          else this.emit('error', err);
+          return;
+        }
+        doc.connection._destroyDoc(doc);
+        if (callback) callback();
       });
     } else {
       doc.connection._destroyDoc(doc);

--- a/test/client/subscribe.js
+++ b/test/client/subscribe.js
@@ -405,8 +405,10 @@ describe('client subscribe', function() {
   });
 
   it('doc destroy stops op updates', function(done) {
-    var doc = this.backend.connect().get('dogs', 'fido');
-    var doc2 = this.backend.connect().get('dogs', 'fido');
+    var connection1 = this.backend.connect();
+    var connection2 = this.backend.connect();
+    var doc = connection1.get('dogs', 'fido');
+    var doc2 = connection2.get('dogs', 'fido');
     doc.create({age: 3}, function(err) {
       if (err) return done(err);
       doc2.subscribe(function(err) {
@@ -416,6 +418,7 @@ describe('client subscribe', function() {
         });
         doc2.destroy(function(err) {
           if (err) return done(err);
+          expect(connection2.getExisting('dogs', 'fido')).equal(undefined);
           doc.submitOp({p: ['age'], na: 1}, done);
         });
       });

--- a/test/client/subscribe.js
+++ b/test/client/subscribe.js
@@ -414,7 +414,7 @@ describe('client subscribe', function() {
       doc2.subscribe(function(err) {
         if (err) return done(err);
         doc2.on('op', function(op, context) {
-          done();
+          done(new Error('Should not get op event'));
         });
         doc2.destroy(function(err) {
           if (err) return done(err);
@@ -422,6 +422,17 @@ describe('client subscribe', function() {
           doc.submitOp({p: ['age'], na: 1}, done);
         });
       });
+    });
+  });
+
+  it('doc destroy removes doc from connection when doc is not subscribed', function(done) {
+    var connection = this.backend.connect();
+    var doc = connection.get('dogs', 'fido');
+    expect(connection.getExisting('dogs', 'fido')).equal(doc);
+    doc.destroy(function(err) {
+      if (err) return done(err);
+      expect(connection.getExisting('dogs', 'fido')).equal(undefined);
+      done();
     });
   });
 


### PR DESCRIPTION
It fixes the issue where a document is re-added to a collection after calling `destroy`, causing a memory leak.

It should also fix https://github.com/share/sharedb/issues/161.

Re not waiting for the unsubscribe callback in `destroy`, I think it is not necessary because:

- unsubscribe cannot fail on the server side (as far as I see),
- unsubscribe is performed automatically on disconnect,
- the doc is marked as unsubscribed immediately on the client side.