### PR TITLE
Fix hasWritePending in op's callback

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -888,9 +888,10 @@ Doc.prototype._hardRollback = function(err) {
 };
 
 Doc.prototype._clearInflightOp = function(err) {
-  var called = callEach(this.inflightOp.callbacks, err);
-
+  var callbacks = this.inflightOp && this.inflightOp.callbacks;
   this.inflightOp = null;
+  var called = callbacks && callEach(callbacks, err);
+
   this.flush();
   this._emitNothingPending();
 

--- a/test/client/submit.js
+++ b/test/client/submit.js
@@ -1044,6 +1044,39 @@ describe('client submit', function() {
     });
   });
 
+  it('hasWritePending is false when create\'s callback is executed', function(done) {
+    var doc = this.backend.connect().get('dogs', 'fido');
+    doc.create({age: 3}, function(err) {
+      if (err) return done(err);
+      expect(doc.hasWritePending()).equal(false);
+      done();
+    });
+  });
+
+  it('hasWritePending is false when submimtOp\'s callback is executed', function(done) {
+    var doc = this.backend.connect().get('dogs', 'fido');
+    doc.create({age: 3}, function(err) {
+      if (err) return done(err);
+      doc.submitOp({p: ['age'], na: 2}, function(err) {
+        if (err) return done(err);
+        expect(doc.hasWritePending()).equal(false);
+        done();
+      });
+    });
+  });
+
+  it('hasWritePending is false when del\'s callback is executed', function(done) {
+    var doc = this.backend.connect().get('dogs', 'fido');
+    doc.create({age: 3}, function(err) {
+      if (err) return done(err);
+      doc.del(function(err) {
+        if (err) return done(err);
+        expect(doc.hasWritePending()).equal(false);
+        done();
+      });
+    });
+  });
+
   describe('type.deserialize', function() {
     it('can create a new doc', function(done) {
       var doc = this.backend.connect().get('dogs', 'fido');


### PR DESCRIPTION
`doc.hasWritePending()` should be false in the op's callback after the last operation is complete.

Additionally, checking for `this.inflightOp` first in `this.inflightOp && this.inflightOp.callbacks` avoids a TypeError which would happen, if [this _otApply](https://github.com/share/sharedb/blob/ea5053b8064876538c61a2284c4f931fa8b52c79/lib/client/doc.js#L861) failed and caused a hard rollback. Unfortunately, I don't have a test for this situation, as it's a rather obscure edge case.