### PR TITLE
Add new middleware events for document reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.swp
 *.DS_Store
 
+# WebStorm
+.idea/
+
 # Emacs
 \#*\#
 

--- a/README.md
+++ b/README.md
@@ -123,9 +123,12 @@ Register a new middleware.
   One of:
   * `'connect'`: A new client connected to the server.
   * `'op'`: An operation was loaded from the database.
-  * `'doc'`: A snapshot was loaded from the database.
+  * `'doc'`: DEPRECATED: A snapshot was loaded from the database.
+  * `'readDoc'`: A single snapshot was loaded from the database.
+  * `'readDocs'`: Snapshots were loaded from the database as the result of a query
+  * `'readDocBulk'`: Snapshots were loaded from the database in bulk by id
   * `'query'`: A query is about to be sent to the database
-  * `'submit'`: An operation is about to be submited to the database
+  * `'submit'`: An operation is about to be submitted to the database
   * `'apply'`: An operation is about to be applied to a snapshot
     before being committed to the database
   * `'commit'`: An operation was applied to a snapshot; The operation
@@ -141,6 +144,9 @@ Register a new middleware.
   * `req`: The HTTP request being handled
   * `collection`: The collection name being handled
   * `id`: The document id being handled
+  * `snapshot`: The retrieved snapshot for `doc` and `readDoc` actions
+  * `snapshots`: The retrieved snapshots for the `readDocs` action
+  * `snapshotMap`: The map of snapshots by id for the `readDocBulk` action
   * `query`: The query object being handled
   * `op`: The op being handled
 

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -195,55 +195,45 @@ Backend.prototype._sanitizeOpsBulk = function(agent, projection, collection, ops
 };
 
 Backend.prototype._sanitizeSnapshot = function(agent, projection, collection, id, snapshot, callback) {
-  try {
-    this._projectSnapshot(projection, snapshot);
-  } catch (err) {
-    return callback(err);
-  }
-
-  var backend = this;
-  this.trigger('docs', agent, {collection: collection, id: null, snapshots: [snapshot]}, function(err) {
-    if (err) { return callback(err); }
-    backend.trigger('doc', agent, {collection: collection, id: id, snapshot: snapshot}, callback);
-  });
-};
-
-Backend.prototype._projectSnapshot = function(projection, snapshot) {
   if (projection) {
-    projections.projectSnapshot(projection.fields, snapshot);
+    try {
+      projections.projectSnapshot(projection.fields, snapshot);
+    } catch (err) {
+      return process.nextTick(function() {
+        callback(err);
+      });
+    }
   }
+
+  this.trigger('doc', agent, {collection: collection, id: id, snapshot: snapshot}, callback);
 };
 
 Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, callback) {
-  try {
-    this._projectSnapshots(projection, snapshots);
-  } catch (err) {
-    return callback(err);
-  }
-
-  var backend = this;
-  this.trigger('docs', agent, {collection: collection, id: null, snapshots: snapshots}, function(err) {
-    if (err) { return callback(err); }
-
-    async.each(snapshots, function(snapshot, eachCb) {
-      backend.trigger('doc', agent, {collection: collection, id: snapshot.id, snapshot: snapshot}, eachCb);
-    }, callback);
-  });
-};
-
-Backend.prototype._projectSnapshots = function(projection, snapshots) {
   if (projection) {
-    projections.projectSnapshots(projection.fields, snapshots);
+    try {
+      projections.projectSnapshots(projection.fields, snapshots);
+    } catch (err) {
+      return process.nextTick(function() {
+        callback(err);
+      });
+    }
   }
+
+  this.trigger('queryDocs', agent, {collection: collection, id: null, snapshots: snapshots}, callback);
 };
 
 Backend.prototype._sanitizeSnapshotBulk = function(agent, projection, collection, snapshotMap, callback) {
-  var snapshots = [];
-  for (var id in snapshotMap) {
-    snapshots.push(snapshotMap[id]);
+  if (projection) {
+    try {
+      projections.projectSnapshotBulk(projection.fields, snapshotMap);
+    } catch (err) {
+      return process.nextTick(function() {
+        callback(err);
+      });
+    }
   }
 
-  return this._sanitizeSnapshots(agent, projection, collection, snapshots, callback);
+  this.trigger('docBulk', agent, {collection: collection, id: null, snapshotMap: snapshotMap}, callback);
 };
 
 Backend.prototype._getSnapshotProjection = function(db, projection) {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -75,13 +75,15 @@ Backend.prototype._shimDocAction = function() {
 
   this.use(this.MIDDLEWARE_ACTIONS.readDocs, function(request, callback) {
     async.each(request.snapshots, function(snapshot, eachCb) {
-      return backend.trigger(backend.MIDDLEWARE_ACTIONS.doc, request.agent, {collection: request.collection, id: snapshot.id, snapshot: snapshot}, eachCb);
+      var docRequest = {collection: request.collection, id: snapshot.id, snapshot: snapshot};
+      return backend.trigger(backend.MIDDLEWARE_ACTIONS.doc, request.agent, docRequest, eachCb);
     }, callback);
   });
 
   this.use(this.MIDDLEWARE_ACTIONS.readDocBulk, function(request, callback) {
     async.forEachOf(request.snapshotMap, function(snapshot, id, eachCb) {
-      return backend.trigger(backend.MIDDLEWARE_ACTIONS.doc, request.agent, {collection: request.collection, id: id, snapshot: snapshot}, eachCb);
+      var docRequest = {collection: request.collection, id: id, snapshot: snapshot};
+      return backend.trigger(backend.MIDDLEWARE_ACTIONS.doc, request.agent, docRequest, eachCb);
     }, callback);
   });
 };
@@ -249,9 +251,7 @@ Backend.prototype._sanitizeSnapshot = function(agent, projection, collection, id
     try {
       projections.projectSnapshot(projection.fields, snapshot);
     } catch (err) {
-      return process.nextTick(function() {
-        callback(err);
-      });
+      return callback(err);
     }
   }
   this.trigger(this.MIDDLEWARE_ACTIONS.readDoc, agent, {collection: collection, id: id, snapshot: snapshot}, callback);
@@ -262,9 +262,7 @@ Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, s
     try {
       projections.projectSnapshots(projection.fields, snapshots);
     } catch (err) {
-      return process.nextTick(function() {
-        callback(err);
-      });
+      return callback(err);
     }
   }
 
@@ -276,9 +274,7 @@ Backend.prototype._sanitizeSnapshotBulk = function(agent, projection, collection
     try {
       projections.projectSnapshotBulk(projection.fields, snapshotMap);
     } catch (err) {
-      return process.nextTick(function() {
-        callback(err);
-      });
+      return callback(err);
     }
   }
 

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -32,9 +32,59 @@ function Backend(options) {
   // The number of open agents for monitoring and testing memory leaks
   this.agentsCount = 0;
   this.remoteAgentsCount = 0;
+
+  if (!options.disableDocAction) {
+    this._shimDocAction();
+  }
 }
 module.exports = Backend;
 emitter.mixin(Backend);
+
+Backend.prototype.MIDDLEWARE_ACTIONS = {
+  // An operation was successfully submitted to the database.
+  'after submit': 'after submit',
+  // An operation is about to be applied to a snapshot before being committed to the database
+  'apply': 'apply',
+  // An operation was applied to a snapshot; The operation and new snapshot are about to be written to the database.
+  'commit': 'commit',
+  // A new client connected to the server.
+  'connect': 'connect',
+  // DEPRECATED: A snapshot was loaded from the database.
+  'doc': 'doc',
+  // An operation was loaded from the database.
+  'op': 'op',
+  // A query is about to be sent to the database
+  'query': 'query',
+  // Received a message from a client
+  'receive': 'receive',
+  // A snapshot was loaded from the database.
+  'readDoc': 'readDoc',
+  // Snapshots were loaded from the database as the result of a query
+  'readDocs': 'readDocs',
+  // Snapshots were loaded from the database in bulk by id
+  'readDocBulk': 'readDocBulk',
+  // An operation is about to be submitted to the database
+  'submit': 'submit'
+};
+
+Backend.prototype._shimDocAction = function() {
+  var backend = this;
+  this.use(this.MIDDLEWARE_ACTIONS.readDoc, function(request, callback) {
+    return backend.trigger(backend.MIDDLEWARE_ACTIONS.doc, request.agent, request, callback);
+  });
+
+  this.use(this.MIDDLEWARE_ACTIONS.readDocs, function(request, callback) {
+    async.each(request.snapshots, function(snapshot, eachCb) {
+      return backend.trigger(backend.MIDDLEWARE_ACTIONS.doc, request.agent, {collection: request.collection, id: snapshot.id, snapshot: snapshot}, eachCb);
+    }, callback);
+  });
+
+  this.use(this.MIDDLEWARE_ACTIONS.readDocBulk, function(request, callback) {
+    async.forEachOf(request.snapshotMap, function(snapshot, id, eachCb) {
+      return backend.trigger(backend.MIDDLEWARE_ACTIONS.doc, request.agent, {collection: request.collection, id: id, snapshot: snapshot}, eachCb);
+    }, callback);
+  });
+};
 
 Backend.prototype.close = function(callback) {
   var wait = 3;
@@ -82,7 +132,7 @@ Backend.prototype.connect = function(connection, req) {
  */
 Backend.prototype.listen = function(stream, req) {
   var agent = new Agent(this, stream);
-  this.trigger('connect', agent, {stream: stream, req: req}, function(err) {
+  this.trigger(this.MIDDLEWARE_ACTIONS.connect, agent, {stream: stream, req: req}, function(err) {
     if (err) return agent.close(err);
     agent._open();
   });
@@ -155,11 +205,11 @@ Backend.prototype.submit = function(agent, index, id, op, options, callback) {
   if (err) return callback(err);
   var request = new SubmitRequest(this, agent, index, id, op, options);
   var backend = this;
-  backend.trigger('submit', agent, request, function(err) {
+  backend.trigger(backend.MIDDLEWARE_ACTIONS.submit, agent, request, function(err) {
     if (err) return callback(err);
     request.submit(function(err) {
       if (err) return callback(err);
-      backend.trigger('after submit', agent, request, function(err) {
+      backend.trigger(backend.MIDDLEWARE_ACTIONS['after submit'], agent, request, function(err) {
         if (err) return callback(err);
         backend._sanitizeOps(agent, request.projection, request.collection, id, request.ops, function(err) {
           if (err) return callback(err);
@@ -179,7 +229,7 @@ Backend.prototype._sanitizeOp = function(agent, projection, collection, id, op, 
       return callback(err);
     }
   }
-  this.trigger('op', agent, {collection: collection, id: id, op: op}, callback);
+  this.trigger(this.MIDDLEWARE_ACTIONS.op, agent, {collection: collection, id: id, op: op}, callback);
 };
 Backend.prototype._sanitizeOps = function(agent, projection, collection, id, ops, callback) {
   var backend = this;
@@ -204,8 +254,7 @@ Backend.prototype._sanitizeSnapshot = function(agent, projection, collection, id
       });
     }
   }
-
-  this.trigger('doc', agent, {collection: collection, id: id, snapshot: snapshot}, callback);
+  this.trigger(this.MIDDLEWARE_ACTIONS.doc, agent, {collection: collection, id: id, snapshot: snapshot}, callback);
 };
 
 Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, callback) {
@@ -219,7 +268,7 @@ Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, s
     }
   }
 
-  this.trigger('queryDocs', agent, {collection: collection, id: null, snapshots: snapshots}, callback);
+  this.trigger(this.MIDDLEWARE_ACTIONS.readDocs, agent, {collection: collection, id: null, snapshots: snapshots}, callback);
 };
 
 Backend.prototype._sanitizeSnapshotBulk = function(agent, projection, collection, snapshotMap, callback) {
@@ -233,7 +282,7 @@ Backend.prototype._sanitizeSnapshotBulk = function(agent, projection, collection
     }
   }
 
-  this.trigger('docBulk', agent, {collection: collection, id: null, snapshotMap: snapshotMap}, callback);
+  this.trigger(this.MIDDLEWARE_ACTIONS.readDocBulk, agent, {collection: collection, id: null, snapshotMap: snapshotMap}, callback);
 };
 
 Backend.prototype._getSnapshotProjection = function(db, projection) {
@@ -498,7 +547,7 @@ Backend.prototype._triggerQuery = function(agent, index, query, options, callbac
     snapshotProjection: null,
   };
   var backend = this;
-  backend.trigger('query', agent, request, function(err) {
+  backend.trigger(backend.MIDDLEWARE_ACTIONS.query, agent, request, function(err) {
     if (err) return callback(err);
     // Set the DB reference for the request after the middleware trigger so
     // that the db option can be changed in middleware

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -254,7 +254,7 @@ Backend.prototype._sanitizeSnapshot = function(agent, projection, collection, id
       });
     }
   }
-  this.trigger(this.MIDDLEWARE_ACTIONS.doc, agent, {collection: collection, id: id, snapshot: snapshot}, callback);
+  this.trigger(this.MIDDLEWARE_ACTIONS.readDoc, agent, {collection: collection, id: id, snapshot: snapshot}, callback);
 };
 
 Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, callback) {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -195,26 +195,55 @@ Backend.prototype._sanitizeOpsBulk = function(agent, projection, collection, ops
 };
 
 Backend.prototype._sanitizeSnapshot = function(agent, projection, collection, id, snapshot, callback) {
-  if (projection) {
-    try {
-      projections.projectSnapshot(projection.fields, snapshot);
-    } catch (err) {
-      return callback(err);
-    }
+  try {
+    this._projectSnapshot(projection, snapshot);
+  } catch (err) {
+    return callback(err);
   }
-  this.trigger('doc', agent, {collection: collection, id: id, snapshot: snapshot}, callback);
+
+  var backend = this;
+  this.trigger('docs', agent, {collection: collection, id: null, snapshots: [snapshot]}, function(err) {
+    if (err) { return callback(err); }
+    backend.trigger('doc', agent, {collection: collection, id: id, snapshot: snapshot}, callback);
+  });
 };
+
+Backend.prototype._projectSnapshot = function(projection, snapshot) {
+  if (projection) {
+    projections.projectSnapshot(projection.fields, snapshot);
+  }
+};
+
 Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, callback) {
+  try {
+    this._projectSnapshots(projection, snapshots);
+  } catch (err) {
+    return callback(err);
+  }
+
   var backend = this;
-  async.each(snapshots, function(snapshot, eachCb) {
-    backend._sanitizeSnapshot(agent, projection, collection, snapshot.id, snapshot, eachCb);
-  }, callback);
+  this.trigger('docs', agent, {collection: collection, id: null, snapshots: snapshots}, function(err) {
+    if (err) { return callback(err); }
+
+    async.each(snapshots, function(snapshot, eachCb) {
+      backend.trigger('doc', agent, {collection: collection, id: snapshot.id, snapshot: snapshot}, eachCb);
+    }, callback);
+  });
 };
+
+Backend.prototype._projectSnapshots = function(projection, snapshots) {
+  if (projection) {
+    projections.projectSnapshots(projection.fields, snapshots);
+  }
+};
+
 Backend.prototype._sanitizeSnapshotBulk = function(agent, projection, collection, snapshotMap, callback) {
-  var backend = this;
-  async.forEachOf(snapshotMap, function(snapshot, id, eachCb) {
-    backend._sanitizeSnapshot(agent, projection, collection, id, snapshot, eachCb);
-  }, callback);
+  var snapshots = [];
+  for (var id in snapshotMap) {
+    snapshots.push(snapshotMap[id]);
+  }
+
+  return this._sanitizeSnapshots(agent, projection, collection, snapshots, callback);
 };
 
 Backend.prototype._getSnapshotProjection = function(db, projection) {

--- a/lib/projections.js
+++ b/lib/projections.js
@@ -1,6 +1,7 @@
 var json0 = require('ot-json0').type;
 
 exports.projectSnapshot = projectSnapshot;
+exports.projectSnapshots = projectSnapshots;
 exports.projectOp = projectOp;
 exports.isSnapshotAllowed = isSnapshotAllowed;
 exports.isOpAllowed = isOpAllowed;
@@ -13,6 +14,13 @@ function projectSnapshot(fields, snapshot) {
     throw new Error(4023, 'Cannot project snapshots of type ' + snapshot.type);
   }
   snapshot.data = projectData(fields, snapshot.data);
+}
+
+function projectSnapshots(fields, snapshots) {
+  for (var i = 0; i < snapshots.length; i++) {
+    var snapshot = snapshots[i];
+    projectSnapshot(fields, snapshot);
+  }
 }
 
 function projectOp(fields, op) {

--- a/lib/projections.js
+++ b/lib/projections.js
@@ -19,7 +19,7 @@ function projectSnapshot(fields, snapshot) {
 
 function projectSnapshotBulk(fields, snapshotMap) {
   for (var key in snapshotMap) {
-    var snapshot = snapshots[key];
+    var snapshot = snapshotMap[key];
     projectSnapshot(fields, snapshot);
   }
 }

--- a/lib/projections.js
+++ b/lib/projections.js
@@ -1,6 +1,7 @@
 var json0 = require('ot-json0').type;
 
 exports.projectSnapshot = projectSnapshot;
+exports.projectSnapshotBulk = projectSnapshotBulk;
 exports.projectSnapshots = projectSnapshots;
 exports.projectOp = projectOp;
 exports.isSnapshotAllowed = isSnapshotAllowed;
@@ -14,6 +15,13 @@ function projectSnapshot(fields, snapshot) {
     throw new Error(4023, 'Cannot project snapshots of type ' + snapshot.type);
   }
   snapshot.data = projectData(fields, snapshot.data);
+}
+
+function projectSnapshotBulk(fields, snapshotMap) {
+  for (var key in snapshotMap) {
+    var snapshot = snapshots[key];
+    projectSnapshot(fields, snapshot);
+  }
 }
 
 function projectSnapshots(fields, snapshots) {

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -2,7 +2,6 @@ var async = require('async');
 var Backend = require('../lib/backend');
 var expect = require('expect.js');
 var types = require('../lib/types');
-var pry = require('pryjs');
 
 describe('middleware', function() {
 
@@ -62,7 +61,7 @@ describe('middleware', function() {
           expect(request.collection).to.eql('dogs');
           expect(request.id).to.eql('fido');
           next();
-          return done()
+          return done();
         });
 
         this.backend.fetch({}, 'dogs', 'fido', function(err) {
@@ -79,7 +78,7 @@ describe('middleware', function() {
         this.backend.fetch({}, 'dogs', 'fido', function(err) {
           expect(err).to.eql(expectedError);
           done();
-        })
+        });
       });
 
       it('is triggered when a multiple documents are fetched by ids', function(done) {
@@ -87,7 +86,7 @@ describe('middleware', function() {
           expect(request.collection).to.eql('dogs');
           expect(request.id).to.eql('fido');
           next();
-          return done()
+          return done();
         });
 
         this.backend.fetchBulk({}, 'dogs', ['fido'], function(err) {
@@ -104,7 +103,7 @@ describe('middleware', function() {
         this.backend.fetchBulk({}, 'dogs', ['fido'], function(err) {
           expect(err).to.eql(expectedError);
           done();
-        })
+        });
       });
 
       ['queryFetch', 'querySubscribe'].forEach((function(queryMethod) {
@@ -113,12 +112,12 @@ describe('middleware', function() {
             expect(request.collection).to.eql('dogs');
             expect(request.id).to.eql('fido');
             next();
-            return done()
+            return done();
           });
 
           this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, function(err) {
             if (err) throw(err);
-          })
+          });
         });
 
         it('calls back with an error that is yielded by ' + queryMethod, function(done) {
@@ -193,12 +192,12 @@ describe('middleware', function() {
         expect(request.collection).to.eql('dogs');
         expect(request.id).to.eql('fido');
         next();
-        return done()
+        return done();
       });
 
       this.backend.fetch({}, 'dogs', 'fido', function(err) {
         if (err) throw(err);
-      })
+      });
     });
 
     it('calls back with an error that is yielded by fetch', function(done) {
@@ -210,7 +209,7 @@ describe('middleware', function() {
       this.backend.fetch({}, 'dogs', 'fido', function(err) {
         expect(err).to.eql(expectedError);
         done();
-      })
+      });
     });
   });
 
@@ -222,7 +221,7 @@ describe('middleware', function() {
         expect(request.snapshotMap).to.have.property('fido');
         expect(request.snapshotMap).to.have.property('spot');
         next();
-        return done()
+        return done();
       });
 
       this.backend.fetchBulk({}, 'dogs', ['fido', 'spot'], function(err) {
@@ -239,7 +238,7 @@ describe('middleware', function() {
       this.backend.fetchBulk({}, 'dogs', ['fido', 'spot'], function(err) {
         expect(err).to.eql(expectedError);
         done();
-      })
+      });
     });
 
   });
@@ -263,7 +262,7 @@ describe('middleware', function() {
 
         this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, function(err) {
           if (err) throw(err);
-        })
+        });
       });
 
       it('calls back with an error that is yielded by ' + queryMethod, function(done) {

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -86,12 +86,9 @@ describe('middleware', function() {
           expect(request.collection).to.eql('dogs');
           expect(request.id).to.eql('fido');
           next();
-          return done();
         });
 
-        this.backend.fetchBulk({}, 'dogs', ['fido'], function(err) {
-          if (err) throw(err);
-        });
+        this.backend.fetchBulk({}, 'dogs', ['fido'], done);
       });
 
       it('calls back with an error that is yielded by fetchBulk', function(done) {
@@ -112,12 +109,9 @@ describe('middleware', function() {
             expect(request.collection).to.eql('dogs');
             expect(request.id).to.eql('fido');
             next();
-            return done();
           });
 
-          this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, function(err) {
-            if (err) throw(err);
-          });
+          this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, done);
         });
 
         it('calls back with an error that is yielded by ' + queryMethod, function(done) {
@@ -192,12 +186,9 @@ describe('middleware', function() {
         expect(request.collection).to.eql('dogs');
         expect(request.id).to.eql('fido');
         next();
-        return done();
       });
 
-      this.backend.fetch({}, 'dogs', 'fido', function(err) {
-        if (err) throw(err);
-      });
+      this.backend.fetch({}, 'dogs', 'fido', done);
     });
 
     it('calls back with an error that is yielded by fetch', function(done) {
@@ -221,12 +212,9 @@ describe('middleware', function() {
         expect(request.snapshotMap).to.have.property('fido');
         expect(request.snapshotMap).to.have.property('spot');
         next();
-        return done();
       });
 
-      this.backend.fetchBulk({}, 'dogs', ['fido', 'spot'], function(err) {
-        if (err) throw(err);
-      });
+      this.backend.fetchBulk({}, 'dogs', ['fido', 'spot'], done);
     });
 
     it('calls back with an error that is yielded by fetchBulk', function(done) {
@@ -257,12 +245,9 @@ describe('middleware', function() {
           expect(request.snapshots[0]).to.have.property('id', 'fido');
           expect(request.snapshots[0]).to.have.property('data').eql({age: 3});
           next();
-          return done();
         });
 
-        this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, function(err) {
-          if (err) throw(err);
-        });
+        this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, done);
       });
 
       it('calls back with an error that is yielded by ' + queryMethod, function(done) {
@@ -287,13 +272,10 @@ describe('middleware', function() {
       this.backend.use('submit', function(request, next) {
         expect(request.options).eql({testOption: true});
         next();
-        return done();
       });
       var op = {create: {type: types.defaultType.uri}};
       var options = {testOption: true};
-      this.backend.submit(null, 'dogs', 'fido', op, options, function(err) {
-        if (err) throw err;
-      });
+      this.backend.submit(null, 'dogs', 'fido', op, options, done);
     });
 
   });

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -1,6 +1,8 @@
+var async = require('async');
 var Backend = require('../lib/backend');
 var expect = require('expect.js');
 var types = require('../lib/types');
+var pry = require('pryjs');
 
 describe('middleware', function() {
 
@@ -47,12 +49,246 @@ describe('middleware', function() {
 
   });
 
+  describe('doc', function() {
+    beforeEach('Add fido to db', function(done) {
+      this.snapshot = {v: 1, type: 'json0', data: {age: 3}};
+      this.backend.db.commit('dogs', 'fido', {v: 0, create: {}}, this.snapshot, null, done);
+    });
+
+    describe('with default options for backend constructor', function() {
+
+      it('is triggered when a single document is fetched', function(done) {
+        this.backend.use('doc', function(request, next) {
+          expect(request.collection).to.eql('dogs');
+          expect(request.id).to.eql('fido');
+          next();
+          return done()
+        });
+
+        this.backend.fetch({}, 'dogs', 'fido', function(err) {
+          if (err) throw(err);
+        });
+      });
+
+      it('calls back with an error that is yielded by fetch', function(done) {
+        var expectedError = new Error('Bad dog!');
+        this.backend.use('doc', function(_request, next) {
+          return next(expectedError);
+        });
+
+        this.backend.fetch({}, 'dogs', 'fido', function(err) {
+          expect(err).to.eql(expectedError);
+          done();
+        })
+      });
+
+      it('is triggered when a multiple documents are fetched by ids', function(done) {
+        this.backend.use('doc', function(request, next) {
+          expect(request.collection).to.eql('dogs');
+          expect(request.id).to.eql('fido');
+          next();
+          return done()
+        });
+
+        this.backend.fetchBulk({}, 'dogs', ['fido'], function(err) {
+          if (err) throw(err);
+        });
+      });
+
+      it('calls back with an error that is yielded by fetchBulk', function(done) {
+        var expectedError = new Error('Bad dogs!');
+        this.backend.use('doc', function(_request, next) {
+          return next(expectedError);
+        });
+
+        this.backend.fetchBulk({}, 'dogs', ['fido'], function(err) {
+          expect(err).to.eql(expectedError);
+          done();
+        })
+      });
+
+      ['queryFetch', 'querySubscribe'].forEach((function(queryMethod) {
+        it('is triggered when multiple documents are retrieved with ' + queryMethod, function(done) {
+          this.backend.use('doc', function(request, next) {
+            expect(request.collection).to.eql('dogs');
+            expect(request.id).to.eql('fido');
+            next();
+            return done()
+          });
+
+          this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, function(err) {
+            if (err) throw(err);
+          })
+        });
+
+        it('calls back with an error that is yielded by ' + queryMethod, function(done) {
+          var expectedError = new Error('Bad dog!');
+          this.backend.use('doc', function(_request, next) {
+            return next(expectedError);
+          });
+
+          this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, function(err) {
+            expect(err).to.eql(expectedError);
+            done();
+          });
+        });
+
+      }).bind(this));
+
+    });
+
+    describe('with disableDocAction option set to true for backend constructor', function() {
+
+      beforeEach('Create backend with disableDocAction option', function() {
+        this.backend = new Backend({disableDocAction: true});
+      });
+
+      it('is not triggered when a document is fetched', function(done) {
+        this.backend.use('doc', function(_request, _next) {
+          throw(new Error('doc should not have been triggered'));
+        });
+
+        this.backend.fetch({}, 'dogs', 'fido', done);
+      });
+
+      it('is not triggered when multiple documents are fetched by id', function(done) {
+        this.backend.use('doc', function(_request, _next) {
+          throw(new Error('doc should not have been triggered'));
+        });
+
+        this.backend.fetchBulk({}, 'dogs', ['fido'], done);
+      });
+
+      ['queryFetch', 'querySubscribe'].forEach((function(queryMethod) {
+        it('is not triggered when multiple documents are retrieved with ' + queryMethod, function(done) {
+          this.backend.use('doc', function(request, next) {
+            throw(new Error('doc should not have been triggered'));
+          });
+
+          this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, done);
+        });
+
+        it('calls back with an error that is yielded by ' + queryMethod, function(done) {
+          var expectedError = new Error('Bad dog!');
+          this.backend.use('doc', function(_request, next) {
+            throw(new Error('doc should not have been triggered'));
+          });
+
+          this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, done);
+        });
+
+      }).bind(this));
+    });
+
+  });
+
+  describe('readDoc', function() {
+    beforeEach('Add fido to db', function(done) {
+      this.snapshot = {v: 1, type: 'json0', data: {age: 3}};
+      this.backend.db.commit('dogs', 'fido', {v: 0, create: {}}, this.snapshot, null, done);
+    });
+
+    it('is triggered when a single document is fetched', function(done) {
+      this.backend.use('readDoc', function(request, next) {
+        expect(request.collection).to.eql('dogs');
+        expect(request.id).to.eql('fido');
+        next();
+        return done()
+      });
+
+      this.backend.fetch({}, 'dogs', 'fido', function(err) {
+        if (err) throw(err);
+      })
+    });
+
+    it('calls back with an error that is yielded by fetch', function(done) {
+      var expectedError = new Error('Bad dog!');
+      this.backend.use('readDoc', function(_request, next) {
+        return next(expectedError);
+      });
+
+      this.backend.fetch({}, 'dogs', 'fido', function(err) {
+        expect(err).to.eql(expectedError);
+        done();
+      })
+    });
+  });
+
+  describe('readDocBulk', function() {
+
+    it('is triggered when multiple documents are fetched by ids', function(done) {
+      this.backend.use('readDocBulk', function(request, next) {
+        expect(request.collection).to.eql('dogs');
+        expect(request.snapshotMap).to.have.property('fido');
+        expect(request.snapshotMap).to.have.property('spot');
+        next();
+        return done()
+      });
+
+      this.backend.fetchBulk({}, 'dogs', ['fido', 'spot'], function(err) {
+        if (err) throw(err);
+      });
+    });
+
+    it('calls back with an error that is yielded by fetchBulk', function(done) {
+      var expectedError = new Error('Bad dogs!');
+      this.backend.use('readDocBulk', function(_request, next) {
+        return next(expectedError);
+      });
+
+      this.backend.fetchBulk({}, 'dogs', ['fido', 'spot'], function(err) {
+        expect(err).to.eql(expectedError);
+        done();
+      })
+    });
+
+  });
+
+  describe('readDocs', function() {
+    beforeEach('Add fido to db', function(done) {
+      this.snapshot = {v: 1, type: 'json0', data: {age: 3}};
+      this.backend.db.commit('dogs', 'fido', {v: 0, create: {}}, this.snapshot, null, done);
+    });
+
+    ['queryFetch', 'querySubscribe'].forEach((function(queryMethod) {
+      it('is triggered when multiple documents are retrieved with ' + queryMethod, function(done) {
+        this.backend.use('readDocs', function(request, next) {
+          expect(request.collection).to.eql('dogs');
+          expect(request.snapshots).to.have.length(1);
+          expect(request.snapshots[0]).to.have.property('id', 'fido');
+          expect(request.snapshots[0]).to.have.property('data').eql({age: 3});
+          next();
+          return done();
+        });
+
+        this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, function(err) {
+          if (err) throw(err);
+        })
+      });
+
+      it('calls back with an error that is yielded by ' + queryMethod, function(done) {
+        var expectedError = new Error('Bad dog!');
+        this.backend.use('readDocs', function(_request, next) {
+          return next(expectedError);
+        });
+
+        this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, function(err) {
+          expect(err).to.eql(expectedError);
+          done();
+        });
+      });
+
+    }).bind(this));
+
+  });
+
   describe('submit', function() {
 
     it('gets options passed to backend.submit', function(done) {
       this.backend.use('submit', function(request, next) {
         expect(request.options).eql({testOption: true});
-        done();
+        next();
+        return done();
       });
       var op = {create: {type: types.defaultType.uri}};
       var options = {testOption: true};


### PR DESCRIPTION
* Trigger `queryDocs` or `docBulk` middleware action when many documents are fetched at once. * Only trigger `doc` action when retrieving a single doc.

*WIP*
There are no tests, this is not ready for merging. I would like feedback on the general approach before I dive into testing and making this more production ready.