### PR TITLE
Read docs middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,17 +123,15 @@ Register a new middleware.
   One of:
   * `'connect'`: A new client connected to the server.
   * `'op'`: An operation was loaded from the database.
-  * `'doc'`: DEPRECATED: A snapshot was loaded from the database.
-  * `'readDoc'`: A single snapshot was loaded from the database.
-  * `'readDocs'`: Snapshots were loaded from the database as the result of a query
-  * `'readDocBulk'`: Snapshots were loaded from the database in bulk by id
+  * `'doc'`: DEPRECATED: A snapshot was loaded from the database. Please use 'readDocs'
+  * `'readDocs'`: Snapshot(s) were loaded from the database for a fetch or subscribe of a query or document
   * `'query'`: A query is about to be sent to the database
   * `'submit'`: An operation is about to be submitted to the database
   * `'apply'`: An operation is about to be applied to a snapshot
     before being committed to the database
   * `'commit'`: An operation was applied to a snapshot; The operation
     and new snapshot are about to be written to the database.
-  * `'after submit'`: An operation was successfully submitted to
+  * `'afterSubmit'`: An operation was successfully submitted to
     the database.
   * `'receive'`: Received a message from a client
 * `fn` _(Function(request, callback))_
@@ -144,9 +142,7 @@ Register a new middleware.
   * `req`: The HTTP request being handled
   * `collection`: The collection name being handled
   * `id`: The document id being handled
-  * `snapshot`: The retrieved snapshot for `doc` and `readDoc` actions
   * `snapshots`: The retrieved snapshots for the `readDocs` action
-  * `snapshotMap`: The map of snapshots by id for the `readDocBulk` action
   * `query`: The query object being handled
   * `op`: The op being handled
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ Register a new middleware.
   One of:
   * `'connect'`: A new client connected to the server.
   * `'op'`: An operation was loaded from the database.
-  * `'doc'`: DEPRECATED: A snapshot was loaded from the database. Please use 'readDocs'
-  * `'readDocs'`: Snapshot(s) were loaded from the database for a fetch or subscribe of a query or document
+  * `'doc'`: DEPRECATED: A snapshot was loaded from the database. Please use 'readSnapshots'
+  * `'readSnapshots'`: Snapshot(s) were loaded from the database for a fetch or subscribe of a query or document
   * `'query'`: A query is about to be sent to the database
   * `'submit'`: An operation is about to be submitted to the database
   * `'apply'`: An operation is about to be applied to a snapshot
@@ -142,7 +142,7 @@ Register a new middleware.
   * `req`: The HTTP request being handled
   * `collection`: The collection name being handled
   * `id`: The document id being handled
-  * `snapshots`: The retrieved snapshots for the `readDocs` action
+  * `snapshots`: The retrieved snapshots for the `readSnapshots` action
   * `query`: The query object being handled
   * `op`: The op being handled
 

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -65,14 +65,14 @@ Backend.prototype.MIDDLEWARE_ACTIONS = {
   // Received a message from a client
   receive: 'receive',
   // Snapshot(s) were received from the database and are about to be returned to a client
-  readDocs: 'readDocs',
+  readSnapshots: 'readSnapshots',
   // An operation is about to be submitted to the database
   submit: 'submit'
 };
 
 Backend.prototype._shimDocAction = function() {
   var backend = this;
-  this.use(this.MIDDLEWARE_ACTIONS.readDocs, function(request, callback) {
+  this.use(this.MIDDLEWARE_ACTIONS.readSnapshots, function(request, callback) {
     async.each(request.snapshots, function(snapshot, eachCb) {
       var docRequest = {collection: request.collection, id: snapshot.id, snapshot: snapshot};
       backend.trigger(backend.MIDDLEWARE_ACTIONS.doc, request.agent, docRequest, eachCb);
@@ -256,7 +256,7 @@ Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, s
     }
   }
   var request = {collection: collection, snapshots: snapshots};
-  this.trigger(this.MIDDLEWARE_ACTIONS.readDocs, agent, request, callback);
+  this.trigger(this.MIDDLEWARE_ACTIONS.readSnapshots, agent, request, callback);
 };
 
 Backend.prototype._getSnapshotProjection = function(db, projection) {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -51,46 +51,31 @@ Backend.prototype.MIDDLEWARE_ACTIONS = {
   // DEPRECATED: Synonym for 'afterSubmit'
   'after submit': 'after submit',
   // An operation is about to be applied to a snapshot before being committed to the database
-  'apply': 'apply',
+  apply: 'apply',
   // An operation was applied to a snapshot; The operation and new snapshot are about to be written to the database.
-  'commit': 'commit',
+  commit: 'commit',
   // A new client connected to the server.
-  'connect': 'connect',
+  connect: 'connect',
   // DEPRECATED: A snapshot was loaded from the database.
-  'doc': 'doc',
-  // An operation was loaded from the database.
-  'op': 'op',
+  doc: 'doc',
+  // An operation was loaded from the database
+  op: 'op',
   // A query is about to be sent to the database
-  'query': 'query',
+  query: 'query',
   // Received a message from a client
-  'receive': 'receive',
-  // A snapshot was loaded from the database.
-  'readDoc': 'readDoc',
-  // Snapshots were loaded from the database as the result of a query
-  'readDocs': 'readDocs',
-  // Snapshots were loaded from the database in bulk by id
-  'readDocBulk': 'readDocBulk',
+  receive: 'receive',
+  // Snapshot(s) were received from the database and are about to be returned to a client
+  readDocs: 'readDocs',
   // An operation is about to be submitted to the database
-  'submit': 'submit'
+  submit: 'submit'
 };
 
 Backend.prototype._shimDocAction = function() {
   var backend = this;
-  this.use(this.MIDDLEWARE_ACTIONS.readDoc, function(request, callback) {
-    return backend.trigger(backend.MIDDLEWARE_ACTIONS.doc, request.agent, request, callback);
-  });
-
   this.use(this.MIDDLEWARE_ACTIONS.readDocs, function(request, callback) {
     async.each(request.snapshots, function(snapshot, eachCb) {
       var docRequest = {collection: request.collection, id: snapshot.id, snapshot: snapshot};
-      return backend.trigger(backend.MIDDLEWARE_ACTIONS.doc, request.agent, docRequest, eachCb);
-    }, callback);
-  });
-
-  this.use(this.MIDDLEWARE_ACTIONS.readDocBulk, function(request, callback) {
-    async.forEachOf(request.snapshotMap, function(snapshot, id, eachCb) {
-      var docRequest = {collection: request.collection, id: id, snapshot: snapshot};
-      return backend.trigger(backend.MIDDLEWARE_ACTIONS.doc, request.agent, docRequest, eachCb);
+      backend.trigger(backend.MIDDLEWARE_ACTIONS.doc, request.agent, docRequest, eachCb);
     }, callback);
   });
 };
@@ -262,17 +247,6 @@ Backend.prototype._sanitizeOpsBulk = function(agent, projection, collection, ops
   }, callback);
 };
 
-Backend.prototype._sanitizeSnapshot = function(agent, projection, collection, id, snapshot, callback) {
-  if (projection) {
-    try {
-      projections.projectSnapshot(projection.fields, snapshot);
-    } catch (err) {
-      return callback(err);
-    }
-  }
-  this.trigger(this.MIDDLEWARE_ACTIONS.readDoc, agent, {collection: collection, id: id, snapshot: snapshot}, callback);
-};
-
 Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, callback) {
   if (projection) {
     try {
@@ -281,24 +255,21 @@ Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, s
       return callback(err);
     }
   }
-
-  this.trigger(this.MIDDLEWARE_ACTIONS.readDocs, agent, {collection: collection, id: null, snapshots: snapshots}, callback);
-};
-
-Backend.prototype._sanitizeSnapshotBulk = function(agent, projection, collection, snapshotMap, callback) {
-  if (projection) {
-    try {
-      projections.projectSnapshotBulk(projection.fields, snapshotMap);
-    } catch (err) {
-      return callback(err);
-    }
-  }
-
-  this.trigger(this.MIDDLEWARE_ACTIONS.readDocBulk, agent, {collection: collection, id: null, snapshotMap: snapshotMap}, callback);
+  var request = {collection: collection, snapshots: snapshots};
+  this.trigger(this.MIDDLEWARE_ACTIONS.readDocs, agent, request, callback);
 };
 
 Backend.prototype._getSnapshotProjection = function(db, projection) {
   return (db.projectsSnapshots) ? null : projection;
+};
+
+Backend.prototype._getSnapshotsFromMap = function(ids, snapshotMap) {
+  var snapshots = new Array(ids.length);
+  for (var i = 0; i < ids.length; i++) {
+    var id = ids[i];
+    snapshots[i] = snapshotMap[id];
+  }
+  return snapshots;
 };
 
 // Non inclusive - gets ops from [from, to). Ie, all relevant ops. If to is
@@ -363,7 +334,8 @@ Backend.prototype.fetch = function(agent, index, id, callback) {
   backend.db.getSnapshot(collection, id, fields, null, function(err, snapshot) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
-    backend._sanitizeSnapshot(agent, snapshotProjection, collection, id, snapshot, function(err) {
+    var snapshots = [snapshot];
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, function(err) {
       if (err) return callback(err);
       backend.emit('timing', 'fetch', Date.now() - start, request);
       callback(null, snapshot);
@@ -386,7 +358,8 @@ Backend.prototype.fetchBulk = function(agent, index, ids, callback) {
   backend.db.getSnapshotBulk(collection, ids, fields, null, function(err, snapshotMap) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
-    backend._sanitizeSnapshotBulk(agent, snapshotProjection, collection, snapshotMap, function(err) {
+    var snapshots = backend._getSnapshotsFromMap(ids, snapshotMap);
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, function(err) {
       if (err) return callback(err);
       backend.emit('timing', 'fetchBulk', Date.now() - start, request);
       callback(null, snapshotMap);

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -33,8 +33,13 @@ function Backend(options) {
   this.agentsCount = 0;
   this.remoteAgentsCount = 0;
 
+  // The below shims are for backwards compatibility. These options will be
+  // removed in a future major version
   if (!options.disableDocAction) {
     this._shimDocAction();
+  }
+  if (!options.disableSpaceDelimitedActions) {
+    this._shimAfterSubmit();
   }
 }
 module.exports = Backend;
@@ -42,6 +47,8 @@ emitter.mixin(Backend);
 
 Backend.prototype.MIDDLEWARE_ACTIONS = {
   // An operation was successfully submitted to the database.
+  afterSubmit: 'afterSubmit',
+  // DEPRECATED: Synonym for 'afterSubmit'
   'after submit': 'after submit',
   // An operation is about to be applied to a snapshot before being committed to the database
   'apply': 'apply',
@@ -85,6 +92,15 @@ Backend.prototype._shimDocAction = function() {
       var docRequest = {collection: request.collection, id: id, snapshot: snapshot};
       return backend.trigger(backend.MIDDLEWARE_ACTIONS.doc, request.agent, docRequest, eachCb);
     }, callback);
+  });
+};
+
+// Shim for backwards compatibility with deprecated middleware action name.
+// The action 'after submit' is now 'afterSubmit'.
+Backend.prototype._shimAfterSubmit = function() {
+  var backend = this;
+  this.use(backend.MIDDLEWARE_ACTIONS.afterSubmit, function(request, callback) {
+    backend.trigger(backend.MIDDLEWARE_ACTIONS['after submit'], request.agent, request, callback);
   });
 };
 
@@ -211,7 +227,7 @@ Backend.prototype.submit = function(agent, index, id, op, options, callback) {
     if (err) return callback(err);
     request.submit(function(err) {
       if (err) return callback(err);
-      backend.trigger(backend.MIDDLEWARE_ACTIONS['after submit'], agent, request, function(err) {
+      backend.trigger(backend.MIDDLEWARE_ACTIONS.afterSubmit, agent, request, function(err) {
         if (err) return callback(err);
         backend._sanitizeOps(agent, request.projection, request.collection, id, request.ops, function(err) {
           if (err) return callback(err);

--- a/lib/projections.js
+++ b/lib/projections.js
@@ -1,7 +1,6 @@
 var json0 = require('ot-json0').type;
 
 exports.projectSnapshot = projectSnapshot;
-exports.projectSnapshotBulk = projectSnapshotBulk;
 exports.projectSnapshots = projectSnapshots;
 exports.projectOp = projectOp;
 exports.isSnapshotAllowed = isSnapshotAllowed;
@@ -15,13 +14,6 @@ function projectSnapshot(fields, snapshot) {
     throw new Error(4023, 'Cannot project snapshots of type ' + snapshot.type);
   }
   snapshot.data = projectData(fields, snapshot.data);
-}
-
-function projectSnapshotBulk(fields, snapshotMap) {
-  for (var key in snapshotMap) {
-    var snapshot = snapshotMap[key];
-    projectSnapshot(fields, snapshot);
-  }
 }
 
 function projectSnapshots(fields, snapshots) {

--- a/lib/query-emitter.js
+++ b/lib/query-emitter.js
@@ -185,7 +185,8 @@ QueryEmitter.prototype.queryPoll = function(callback) {
       if (inserted.length) {
         emitter.db.getSnapshotBulk(emitter.collection, inserted, emitter.fields, null, function(err, snapshotMap) {
           if (err) return emitter._finishPoll(err, callback, pending);
-          emitter.backend._sanitizeSnapshotBulk(emitter.agent, emitter.snapshotProjection, emitter.collection, snapshotMap, function(err) {
+          var snapshots = emitter.backend._getSnapshotsFromMap(inserted, snapshotMap);
+          emitter.backend._sanitizeSnapshots(emitter.agent, emitter.snapshotProjection, emitter.collection, snapshots, function(err) {
             if (err) return emitter._finishPoll(err, callback, pending);
             emitter._emitTiming('queryEmitter.pollGetSnapshotBulk', start);
             var diff = mapDiff(idsDiff, snapshotMap);
@@ -232,10 +233,10 @@ QueryEmitter.prototype.queryPollDoc = function(id, callback) {
       // delay in sending to the client anyway
       emitter.db.getSnapshot(emitter.collection, id, emitter.fields, null, function(err, snapshot) {
         if (err) return callback(err);
-        emitter.backend._sanitizeSnapshot(emitter.agent, emitter.snapshotProjection, emitter.collection, id, snapshot, function(err) {
+        var snapshots = [snapshot];
+        emitter.backend._sanitizeSnapshots(emitter.agent, emitter.snapshotProjection, emitter.collection, snapshots, function(err) {
           if (err) return callback(err);
-          var values = [snapshot];
-          emitter.onDiff([new arraydiff.InsertDiff(index, values)]);
+          emitter.onDiff([new arraydiff.InsertDiff(index, snapshots)]);
           emitter._emitTiming('queryEmitter.pollDocGetSnapshot', start);
           callback();
         });

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -72,7 +72,7 @@ describe('middleware', function() {
     });
 
     it('calls back with an error that is yielded by fetch', function(done) {
-      this.backend.use('readDocs', passError);
+      this.backend.use('readSnapshots', passError);
       this.backend.fetch({}, 'dogs', 'fido', getErrorTest(done));
     });
 
@@ -82,7 +82,7 @@ describe('middleware', function() {
     });
 
     it('calls back with an error that is yielded by subscribe', function(done) {
-      this.backend.use('readDocs', passError);
+      this.backend.use('readSnapshots', passError);
       this.backend.subscribe({}, 'dogs', 'fido', null, getErrorTest(done));
     });
 
@@ -93,7 +93,7 @@ describe('middleware', function() {
       });
 
       it('calls back with an error that is yielded by ' + queryMethod, function(done) {
-        this.backend.use('readDocs', passError);
+        this.backend.use('readSnapshots', passError);
         this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, getErrorTest(done));
       });
     });
@@ -105,7 +105,7 @@ describe('middleware', function() {
       });
 
       it('calls back with an error that is yielded by ' + bulkMethod, function(done) {
-        this.backend.use('readDocs', passError);
+        this.backend.use('readSnapshots', passError);
         this.backend[bulkMethod]({}, 'dogs', ['fido', 'spot'], getErrorTest(done));
       });
     });
@@ -183,7 +183,7 @@ describe('middleware', function() {
     });
   });
 
-  describe('readDocs', function() {
+  describe('readSnapshots', function() {
     function expectFido(request) {
       expect(request.collection).to.equal('dogs');
       expect(request.snapshots[0]).to.have.property('id', 'fido');
@@ -197,7 +197,7 @@ describe('middleware', function() {
 
     function expectFidoOnly(backend, done) {
       var doneAfter = util.callAfter(1, done);
-      backend.use('readDocs', function(request, next) {
+      backend.use('readSnapshots', function(request, next) {
         expect(request.snapshots).to.have.length(1);
         expectFido(request);
         doneAfter();
@@ -208,7 +208,7 @@ describe('middleware', function() {
 
     function expectFidoAndSpot(backend, done) {
       var doneAfter = util.callAfter(1, done);
-      backend.use('readDocs', function(request, next) {
+      backend.use('readSnapshots', function(request, next) {
         expect(request.snapshots).to.have.length(2);
         expectFido(request);
         expectSpot(request);

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -1,6 +1,7 @@
 var async = require('async');
 var Backend = require('../lib/backend');
 var expect = require('expect.js');
+var util = require('./util');
 var types = require('../lib/types');
 
 describe('middleware', function() {
@@ -8,6 +9,17 @@ describe('middleware', function() {
   beforeEach(function() {
     this.backend = new Backend();
   });
+
+  var expectedError = new Error('Bad dog!');
+  function passError(_request, next) {
+    return next(expectedError);
+  }
+  function getErrorTest(done) {
+    return function(err) {
+      expect(err).to.eql(expectedError);
+      done();
+    };
+  }
 
   describe('use', function() {
 
@@ -48,236 +60,182 @@ describe('middleware', function() {
 
   });
 
-  describe('doc', function() {
+  function testReadDoc(expectFidoOnly, expectFidoAndSpot) {
     beforeEach('Add fido to db', function(done) {
       this.snapshot = {v: 1, type: 'json0', data: {age: 3}};
       this.backend.db.commit('dogs', 'fido', {v: 0, create: {}}, this.snapshot, null, done);
     });
 
+    it('is triggered when a document is retrieved with fetch', function(done) {
+      var doneAfter = expectFidoOnly(this.backend, done);
+      this.backend.fetch({}, 'dogs', 'fido', doneAfter);
+    });
+
+    it('calls back with an error that is yielded by fetch', function(done) {
+      this.backend.use('readDocs', passError);
+      this.backend.fetch({}, 'dogs', 'fido', getErrorTest(done));
+    });
+
+    it('is triggered when a document is retrieved with subscribe', function(done) {
+      var doneAfter = expectFidoOnly(this.backend, done);
+      this.backend.subscribe({}, 'dogs', 'fido', null, doneAfter);
+    });
+
+    it('calls back with an error that is yielded by subscribe', function(done) {
+      this.backend.use('readDocs', passError);
+      this.backend.subscribe({}, 'dogs', 'fido', null, getErrorTest(done));
+    });
+
+    ['queryFetch', 'querySubscribe'].forEach(function(queryMethod) {
+      it('is triggered when multiple documents are retrieved with ' + queryMethod, function(done) {
+        var doneAfter = expectFidoOnly(this.backend, done);
+        this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, doneAfter);
+      });
+
+      it('calls back with an error that is yielded by ' + queryMethod, function(done) {
+        this.backend.use('readDocs', passError);
+        this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, getErrorTest(done));
+      });
+    });
+
+    ['fetchBulk', 'subscribeBulk'].forEach(function(bulkMethod) {
+      it('is triggered when a document is retrieved with ' + bulkMethod, function(done) {
+        var doneAfter = expectFidoAndSpot(this.backend, done);
+        this.backend[bulkMethod]({}, 'dogs', ['fido', 'spot'], doneAfter);
+      });
+
+      it('calls back with an error that is yielded by ' + bulkMethod, function(done) {
+        this.backend.use('readDocs', passError);
+        this.backend[bulkMethod]({}, 'dogs', ['fido', 'spot'], getErrorTest(done));
+      });
+    });
+  }
+
+  describe('doc', function() {
     describe('with default options for backend constructor', function() {
+      function expectFido(request) {
+        expect(request.collection).to.equal('dogs');
+        expect(request.id).to.equal('fido');
+        expect(request.snapshot).to.have.property('data').eql({age: 3});
+      }
+      function expectSpot(request) {
+        expect(request.collection).to.equal('dogs');
+        expect(request.id).to.equal('spot');
+        expect(request.snapshot).to.have.property('type').equal(null);
+      }
 
-      it('is triggered when a single document is fetched', function(done) {
-        this.backend.use('doc', function(request, next) {
-          expect(request.collection).to.eql('dogs');
-          expect(request.id).to.eql('fido');
-          next();
-          return done();
-        });
-
-        this.backend.fetch({}, 'dogs', 'fido', function(err) {
-          if (err) throw(err);
-        });
-      });
-
-      it('calls back with an error that is yielded by fetch', function(done) {
-        var expectedError = new Error('Bad dog!');
-        this.backend.use('doc', function(_request, next) {
-          return next(expectedError);
-        });
-
-        this.backend.fetch({}, 'dogs', 'fido', function(err) {
-          expect(err).to.eql(expectedError);
-          done();
-        });
-      });
-
-      it('is triggered when a multiple documents are fetched by ids', function(done) {
-        this.backend.use('doc', function(request, next) {
-          expect(request.collection).to.eql('dogs');
-          expect(request.id).to.eql('fido');
+      function expectFidoOnly(backend, done) {
+        var doneAfter = util.callAfter(1, done);
+        backend.use('doc', function(request, next) {
+          expectFido(request);
+          doneAfter();
           next();
         });
+        return doneAfter;
+      }
 
-        this.backend.fetchBulk({}, 'dogs', ['fido'], done);
-      });
-
-      it('calls back with an error that is yielded by fetchBulk', function(done) {
-        var expectedError = new Error('Bad dogs!');
-        this.backend.use('doc', function(_request, next) {
-          return next(expectedError);
+      function expectFidoAndSpot(backend, done) {
+        var doneAfter = util.callAfter(2, done);
+        var i = 0;
+        backend.use('doc', function(request, next) {
+          doneAfter();
+          if (doneAfter.called === 1) {
+            expectFido(request);
+          } else {
+            expectSpot(request);
+          }
+          next();
         });
+        return doneAfter;
+      }
 
-        this.backend.fetchBulk({}, 'dogs', ['fido'], function(err) {
-          expect(err).to.eql(expectedError);
-          done();
-        });
-      });
-
-      ['queryFetch', 'querySubscribe'].forEach((function(queryMethod) {
-        it('is triggered when multiple documents are retrieved with ' + queryMethod, function(done) {
-          this.backend.use('doc', function(request, next) {
-            expect(request.collection).to.eql('dogs');
-            expect(request.id).to.eql('fido');
-            next();
-          });
-
-          this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, done);
-        });
-
-        it('calls back with an error that is yielded by ' + queryMethod, function(done) {
-          var expectedError = new Error('Bad dog!');
-          this.backend.use('doc', function(_request, next) {
-            return next(expectedError);
-          });
-
-          this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, function(err) {
-            expect(err).to.eql(expectedError);
-            done();
-          });
-        });
-
-      }).bind(this));
-
+      testReadDoc(expectFidoOnly, expectFidoAndSpot);
     });
 
     describe('with disableDocAction option set to true for backend constructor', function() {
-
       beforeEach('Create backend with disableDocAction option', function() {
         this.backend = new Backend({disableDocAction: true});
       });
 
-      it('is not triggered when a document is fetched', function(done) {
-        this.backend.use('doc', function(_request, _next) {
-          throw(new Error('doc should not have been triggered'));
-        });
-
+      it('is not triggered when a document is retrieved with fetch', function(done) {
+        this.backend.use('doc', passError);
         this.backend.fetch({}, 'dogs', 'fido', done);
       });
 
-      it('is not triggered when multiple documents are fetched by id', function(done) {
-        this.backend.use('doc', function(_request, _next) {
-          throw(new Error('doc should not have been triggered'));
-        });
-
-        this.backend.fetchBulk({}, 'dogs', ['fido'], done);
+      it('is not triggered when a document is retrieved with subscribe', function(done) {
+        this.backend.use('doc', passError);
+        this.backend.subscribe({}, 'dogs', 'fido', null, done);
       });
 
-      ['queryFetch', 'querySubscribe'].forEach((function(queryMethod) {
+      ['queryFetch', 'querySubscribe'].forEach(function(queryMethod) {
         it('is not triggered when multiple documents are retrieved with ' + queryMethod, function(done) {
-          this.backend.use('doc', function(request, next) {
-            throw(new Error('doc should not have been triggered'));
-          });
-
+          this.backend.use('doc', passError);
           this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, done);
         });
+      });
 
-        it('calls back with an error that is yielded by ' + queryMethod, function(done) {
-          var expectedError = new Error('Bad dog!');
-          this.backend.use('doc', function(_request, next) {
-            throw(new Error('doc should not have been triggered'));
-          });
-
-          this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, done);
+      ['fetchBulk', 'subscribeBulk'].forEach(function(bulkMethod) {
+        it('is not triggered when a document is retrieved with ' + bulkMethod, function(done) {
+          this.backend.use('doc', passError);
+          this.backend[bulkMethod]({}, 'dogs', ['fido', 'spot'], done);
         });
-
-      }).bind(this));
-    });
-
-  });
-
-  describe('readDoc', function() {
-    beforeEach('Add fido to db', function(done) {
-      this.snapshot = {v: 1, type: 'json0', data: {age: 3}};
-      this.backend.db.commit('dogs', 'fido', {v: 0, create: {}}, this.snapshot, null, done);
-    });
-
-    it('is triggered when a single document is fetched', function(done) {
-      this.backend.use('readDoc', function(request, next) {
-        expect(request.collection).to.eql('dogs');
-        expect(request.id).to.eql('fido');
-        next();
-      });
-
-      this.backend.fetch({}, 'dogs', 'fido', done);
-    });
-
-    it('calls back with an error that is yielded by fetch', function(done) {
-      var expectedError = new Error('Bad dog!');
-      this.backend.use('readDoc', function(_request, next) {
-        return next(expectedError);
-      });
-
-      this.backend.fetch({}, 'dogs', 'fido', function(err) {
-        expect(err).to.eql(expectedError);
-        done();
       });
     });
-  });
-
-  describe('readDocBulk', function() {
-
-    it('is triggered when multiple documents are fetched by ids', function(done) {
-      this.backend.use('readDocBulk', function(request, next) {
-        expect(request.collection).to.eql('dogs');
-        expect(request.snapshotMap).to.have.property('fido');
-        expect(request.snapshotMap).to.have.property('spot');
-        next();
-      });
-
-      this.backend.fetchBulk({}, 'dogs', ['fido', 'spot'], done);
-    });
-
-    it('calls back with an error that is yielded by fetchBulk', function(done) {
-      var expectedError = new Error('Bad dogs!');
-      this.backend.use('readDocBulk', function(_request, next) {
-        return next(expectedError);
-      });
-
-      this.backend.fetchBulk({}, 'dogs', ['fido', 'spot'], function(err) {
-        expect(err).to.eql(expectedError);
-        done();
-      });
-    });
-
   });
 
   describe('readDocs', function() {
-    beforeEach('Add fido to db', function(done) {
-      this.snapshot = {v: 1, type: 'json0', data: {age: 3}};
-      this.backend.db.commit('dogs', 'fido', {v: 0, create: {}}, this.snapshot, null, done);
-    });
+    function expectFido(request) {
+      expect(request.collection).to.equal('dogs');
+      expect(request.snapshots[0]).to.have.property('id', 'fido');
+      expect(request.snapshots[0]).to.have.property('data').eql({age: 3});
+    }
+    function expectSpot(request) {
+      expect(request.collection).to.equal('dogs');
+      expect(request.snapshots[1]).to.have.property('id', 'spot');
+      expect(request.snapshots[1]).to.have.property('type').equal(null);
+    }
 
-    ['queryFetch', 'querySubscribe'].forEach((function(queryMethod) {
-      it('is triggered when multiple documents are retrieved with ' + queryMethod, function(done) {
-        this.backend.use('readDocs', function(request, next) {
-          expect(request.collection).to.eql('dogs');
-          expect(request.snapshots).to.have.length(1);
-          expect(request.snapshots[0]).to.have.property('id', 'fido');
-          expect(request.snapshots[0]).to.have.property('data').eql({age: 3});
-          next();
-        });
-
-        this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, done);
-      });
-
-      it('calls back with an error that is yielded by ' + queryMethod, function(done) {
-        var expectedError = new Error('Bad dog!');
-        this.backend.use('readDocs', function(_request, next) {
-          return next(expectedError);
-        });
-
-        this.backend[queryMethod]({}, 'dogs', {age: 3}, {}, function(err) {
-          expect(err).to.eql(expectedError);
-          done();
-        });
-      });
-
-    }).bind(this));
-
-  });
-
-  describe('submit', function() {
-
-    it('gets options passed to backend.submit', function(done) {
-      this.backend.use('submit', function(request, next) {
-        expect(request.options).eql({testOption: true});
+    function expectFidoOnly(backend, done) {
+      var doneAfter = util.callAfter(1, done);
+      backend.use('readDocs', function(request, next) {
+        expect(request.snapshots).to.have.length(1);
+        expectFido(request);
+        doneAfter();
         next();
       });
-      var op = {create: {type: types.defaultType.uri}};
-      var options = {testOption: true};
-      this.backend.submit(null, 'dogs', 'fido', op, options, done);
-    });
+      return doneAfter;
+    }
 
+    function expectFidoAndSpot(backend, done) {
+      var doneAfter = util.callAfter(1, done);
+      backend.use('readDocs', function(request, next) {
+        expect(request.snapshots).to.have.length(2);
+        expectFido(request);
+        expectSpot(request);
+        doneAfter();
+        next();
+      });
+      return doneAfter;
+    }
+
+    testReadDoc(expectFidoOnly, expectFidoAndSpot);
+  });
+
+  describe('submit lifecycle', function() {
+    // DEPRECATED: 'after submit' is a synonym for 'afterSubmit'
+    ['submit', 'apply', 'commit', 'afterSubmit', 'after submit'].forEach(function(action) {
+      it(action + ' gets options passed to backend.submit', function(done) {
+        var doneAfter = util.callAfter(1, done);
+        this.backend.use(action, function(request, next) {
+          expect(request.options).eql({testOption: true});
+          doneAfter();
+          next();
+        });
+        var op = {create: {type: types.defaultType.uri}};
+        var options = {testOption: true};
+        this.backend.submit(null, 'dogs', 'fido', op, options, doneAfter);
+      });
+    });
   });
 
 });

--- a/test/util.js
+++ b/test/util.js
@@ -14,3 +14,28 @@ exports.pluck = function(docs, key) {
   }
   return values;
 };
+
+// Wrap a done function to call back only after a specified number of calls.
+// For example, `var callbackAfter = callAfter(1, callback)` means that if
+// `callbackAfter` is called once, it won't call back. If it is called twice
+// or more, it won't call back for the first time, but it will call back for
+// each following time. Calls back immediately if called with an error.
+//
+// Return argument is a function with the property `calls`. This property
+// starts at zero and increments for each call.
+exports.callAfter = function(calls, callback) {
+  if (typeof calls !== 'number') {
+    throw new Error('Required `calls` argument must be a number');
+  }
+  if (typeof callback !== 'function') {
+    throw new Error('Required `callback` argument must be a function');
+  }
+  var callbackAfter = function(err) {
+    callbackAfter.called++;
+    if (err) return callback(err);
+    if (callbackAfter.called <= calls) return;
+    callback();
+  };
+  callbackAfter.called = 0;
+  return callbackAfter;
+};


### PR DESCRIPTION
Upon further reflection and thanks to advice from @l8on and @ericyhwang, simplify read middleware API to single `readSnapshots` middleware action. Update tests accordingly.

Also, since we moved to camelCased actions, rename `after submit` to `afterSubmit` and shim space delimited action name by default for initial backwards compatibility until a future major version.