### PR TITLE
Do not compose `create` with `op`

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -714,13 +714,6 @@ Doc.prototype._tryCompose = function(op) {
   var last = this.pendingOps[this.pendingOps.length - 1];
   if (!last) return;
 
-  // Compose an op into a create by applying it. This effectively makes the op
-  // invisible, as if the document were created including the op originally
-  if (last.create && op.op) {
-    last.create.data = this.type.apply(last.create.data, op.op);
-    return last;
-  }
-
   // Compose two ops into a single op if supported by the type. Types that
   // support compose must be able to compose any two ops together
   if (last.op && op.op && this.type.compose) {

--- a/test/client/submit.js
+++ b/test/client/submit.js
@@ -119,25 +119,24 @@ describe('client submit', function() {
 
   it('ops submitted sync get composed', function(done) {
     var doc = this.backend.connect().get('dogs', 'fido');
-    doc.create({age: 3});
-    doc.submitOp({p: ['age'], na: 2});
+    doc.create({age: 5});
     doc.submitOp({p: ['age'], na: 2}, function(err) {
       if (err) return done(err);
       expect(doc.data).eql({age: 7});
-      // Version is 1 instead of 3, because the create and ops got composed
-      expect(doc.version).eql(1);
+      // create DOES NOT get composed
+      expect(doc.version).eql(2);
       doc.submitOp({p: ['age'], na: 2});
       doc.submitOp({p: ['age'], na: 2}, function(err) {
         if (err) return done(err);
         expect(doc.data).eql({age: 11});
-        // Ops get composed
-        expect(doc.version).eql(2);
+        // Version is 3 instead of 4, because the ops got composed
+        expect(doc.version).eql(3);
         doc.submitOp({p: ['age'], na: 2});
         doc.del(function(err) {
           if (err) return done(err);
           expect(doc.data).eql(undefined);
           // del DOES NOT get composed
-          expect(doc.version).eql(4);
+          expect(doc.version).eql(5);
           done();
         });
       });


### PR DESCRIPTION
The problem is that the `create` operation contains initial data rather than a snapshot and `apply` requires the first param to be a snapshot. So, the original implementation worked only for the types which have the same type of initial data and snapshots.