### PR TITLE
Implement undo/redo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = LF
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - "9"
   - "8"
   - "6"
-  - "4"
 script: "npm run jshint && npm run test-cover"
 # Send coverage data to Coveralls
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -44,6 +44,13 @@ var types = require('../types');
  * - `load ()` Fired when a new snapshot is ingested from a fetch, subscribe, or query
  */
 
+var OPERATION_TYPES = {
+  UNDOABLE: 'UNDOABLE', // basic operation that can be undone
+  FIXED: 'FIXED', // basic operation that cannot be undone
+  UNDO: 'UNDO', // undo operation
+  REDO: 'REDO' // redo operation
+};
+
 module.exports = Doc;
 function Doc(connection, collection, id) {
   emitter.EventEmitter.call(this);
@@ -56,6 +63,19 @@ function Doc(connection, collection, id) {
   this.version = null;
   this.type = null;
   this.data = undefined;
+
+  // Undo stack for local operations.
+  this.undoStack = [];
+  // Redo stack for local operations.
+  this.redoStack = [];
+  // The max number of undo operations to keep on the stack.
+  this.undoLimit = 100;
+  // The max time difference between operations in milliseconds,
+  // which still allows the operations to be composed on the undoStack.
+  this.undoComposeTimeout = 1000;
+  // The timestamp of the previous reversible operation. Used to determine if
+  // the next reversible operation can be composed on the undoStack.
+  this.previousUndoableOperationTime = -Infinity;
 
   // Array of callbacks or nulls as placeholders
   this.inflightFetch = [];
@@ -191,6 +211,7 @@ Doc.prototype.ingestSnapshot = function(snapshot, callback) {
   this.data = (this.type && this.type.deserialize) ?
     this.type.deserialize(snapshot.data) :
     snapshot.data;
+  this._clearUndoRedo();
   this.emit('load');
   callback && callback();
 };
@@ -318,7 +339,7 @@ Doc.prototype._handleOp = function(err, message) {
   }
 
   this.version++;
-  this._otApply(message, false);
+  this._otApply(message);
   return;
 };
 
@@ -500,7 +521,8 @@ function transformX(client, server) {
  *
  * @private
  */
-Doc.prototype._otApply = function(op, source) {
+Doc.prototype._otApply = function(op, options) {
+  var source = options && options.source || false;
   if (op.op) {
     if (!this.type) {
       var err = new ShareDBError(4015, 'Cannot apply op to uncreated document. ' + this.collection + '.' + this.id);
@@ -537,8 +559,8 @@ Doc.prototype._otApply = function(op, source) {
         }
         // Apply the individual op component
         this.emit('before op', componentOp.op, source);
-        this.data = this.type.apply(this.data, componentOp.op);
-        this.emit('op', componentOp.op, source);
+        this._applyOp(componentOp, options);
+        this.emit('op', componentOp.op, source, 'FIXED');
       }
       // Pop whatever was submitted since we started applying this op
       this._popApplyStack(stackLength);
@@ -549,13 +571,13 @@ Doc.prototype._otApply = function(op, source) {
     // the snapshot before it gets changed
     this.emit('before op', op.op, source);
     // Apply the operation to the local data, mutating it in place
-    this.data = this.type.apply(this.data, op.op);
+    var operationType = this._applyOp(op, options);
     // Emit an 'op' event once the local data includes the changes from the
     // op. For locally submitted ops, this will be synchronously with
     // submission and before the server or other clients have received the op.
     // For ops from other clients, this will be after the op has been
     // committed to the database and published
-    this.emit('op', op.op, source);
+    this.emit('op', op.op, source, operationType);
     return;
   }
 
@@ -566,6 +588,7 @@ Doc.prototype._otApply = function(op, source) {
         this.type.createDeserialized(op.create.data) :
         this.type.deserialize(this.type.create(op.create.data)) :
       this.type.create(op.create.data);
+    this._clearUndoRedo();
     this.emit('create', source);
     return;
   }
@@ -573,11 +596,167 @@ Doc.prototype._otApply = function(op, source) {
   if (op.del) {
     var oldData = this.data;
     this._setType(null);
+    this._clearUndoRedo();
     this.emit('del', oldData, source);
     return;
   }
 };
 
+// Applies `op` to `this.data` and updates the undo/redo stacks.
+Doc.prototype._applyOp = function(op, options) {
+  var undoOp = options && options.undoOp || null;
+  var operationType = options && options.operationType || OPERATION_TYPES.FIXED;
+  var fixUpUndoStack = options && options.fixUpUndoStack;
+  var fixUpRedoStack = options && options.fixUpRedoStack;
+  var needsUndoOp = operationType !== OPERATION_TYPES.FIXED || fixUpUndoStack || fixUpRedoStack;
+
+  if (needsUndoOp && undoOp == null) {
+    if (this.type.applyAndInvert) {
+      var result = this.type.applyAndInvert(this.data, op.op);
+      this.data = result[0];
+      undoOp = { op: result[1] };
+
+    } else if (this.type.invert) {
+      this.data = this.type.apply(this.data, op.op);
+      undoOp = { op: this.type.invert(op.op) };
+
+    } else {
+      this.data = this.type.apply(this.data, op.op);
+      operationType = OPERATION_TYPES.FIXED;
+    }
+
+  } else {
+    this.data = this.type.apply(this.data, op.op);
+  }
+
+  switch (operationType) {
+    case OPERATION_TYPES.UNDOABLE:
+      this._updateStacksUndoable(op, undoOp);
+      break;
+    case OPERATION_TYPES.UNDO:
+      this._updateStacksUndo(op, undoOp);
+      break;
+    case OPERATION_TYPES.REDO:
+      this._updateStacksRedo(op, undoOp);
+      break;
+    default:
+      this._updateStacksFixed(op, undoOp, fixUpUndoStack, fixUpRedoStack);
+      break;
+  };
+
+  return operationType;
+};
+
+Doc.prototype._clearUndoRedo = function() {
+  this.undoStack.length = 0;
+  this.redoStack.length = 0;
+  this.previousUndoableOperationTime = -Infinity;
+};
+
+Doc.prototype._updateStacksUndoable = function(op, undoOp) {
+  var now = Date.now();
+
+  if (this.undoStack.length === 0 || now - this.previousUndoableOperationTime > this.undoComposeTimeout) {
+    this.undoStack.push(undoOp);
+
+  } else if (this.type.composeSimilar) {
+    var lastOp = this.undoStack.pop();
+    var composedOp = this.type.composeSimilar(undoOp.op, lastOp.op);
+    if (composedOp != null) {
+      this.undoStack.push({ op: composedOp });
+    } else {
+      this.undoStack.push(lastOp, undoOp);
+    }
+
+  } else if (this.type.compose) {
+    var lastOp = this.undoStack.pop();
+    var composedOp = this.type.compose(undoOp.op, lastOp.op);
+    this.undoStack.push({ op: composedOp });
+
+  } else {
+    this.undoStack.push(undoOp);
+  }
+
+  this.redoStack.length = 0;
+  this.previousUndoableOperationTime = now;
+
+  var isNoop = this.type.isNoop;
+  if (isNoop && isNoop(this.undoStack[this.undoStack.length - 1].op)) {
+    this.undoStack.pop();
+  }
+
+  var itemsToRemove = this.undoStack.length - this.undoLimit;
+  if (itemsToRemove > 0) {
+    this.undoStack.splice(0, itemsToRemove);
+  }
+};
+
+Doc.prototype._updateStacksUndo = function(op, undoOp) {
+  if (!this.type.isNoop || !this.type.isNoop(undoOp.op)) {
+    this.redoStack.push(undoOp);
+  }
+  this.previousUndoableOperationTime = -Infinity;
+};
+
+Doc.prototype._updateStacksRedo = function(op, undoOp) {
+  if (!this.type.isNoop || !this.type.isNoop(undoOp.op)) {
+    this.undoStack.push(undoOp);
+  }
+  this.previousUndoableOperationTime = -Infinity;
+};
+
+Doc.prototype._updateStacksFixed = function(op, undoOp, fixUpUndoStack, fixUpRedoStack) {
+  if (fixUpUndoStack && this.undoStack.length > 0 && this.type.compose && undoOp) {
+    var lastOp = this.undoStack.pop();
+    var composedOp = this.type.compose(undoOp.op, lastOp.op);
+    if (!this.type.isNoop || !this.type.isNoop(composedOp)) {
+      this.undoStack.push({ op: composedOp });
+    }
+  } else {
+    this.undoStack = this._transformStack(this.undoStack, op.op);
+  }
+
+  if (fixUpRedoStack && this.redoStack.length > 0 && this.type.compose && undoOp) {
+    var lastOp = this.redoStack.pop();
+    var composedOp = this.type.compose(undoOp.op, lastOp.op);
+    if (!this.type.isNoop || !this.type.isNoop(composedOp)) {
+      this.redoStack.push({ op: composedOp });
+    }
+  } else {
+    this.redoStack = this._transformStack(this.redoStack, op.op);
+  }
+};
+
+Doc.prototype._transformStack = function(stack, op) {
+  var transform = this.type.transform;
+  var transformX = this.type.transformX;
+  var isNoop = this.type.isNoop;
+  var newStack = [];
+  var newStackIndex = 0;
+
+  for (var i = stack.length - 1; i >= 0; --i) {
+      var stackOp = stack[i].op;
+      var transformedStackOp;
+      var transformedOp;
+
+      if (transformX) {
+        var result = transformX(op, stackOp);
+        transformedOp = result[0];
+        transformedStackOp = result[1];
+      } else {
+        transformedOp = transform(op, stackOp, 'left');
+        transformedStackOp = transform(stackOp, op, 'right');
+      }
+
+      if (!isNoop || !isNoop(transformedStackOp)) {
+          newStack[newStackIndex++] = { op: transformedStackOp };
+      }
+
+      op = transformedOp;
+  }
+
+  return newStack.reverse();
+};
 
 // ***** Sending operations
 
@@ -630,10 +809,14 @@ Doc.prototype._sendOp = function() {
 // @param [op.op]
 // @param [op.del]
 // @param [op.create]
+// @param options { source, operationType, undoOp, fixUpUndoStack, fixUpRedoStack }
 // @param [callback] called when operation is submitted
-Doc.prototype._submit = function(op, source, callback) {
+Doc.prototype._submit = function(op, options, callback) {
+  if (!options) options = {};
+  if (!options.operationType) options.operationType = OPERATION_TYPES.FIXED;
+
   // Locally submitted ops must always have a truthy source
-  if (!source) source = true;
+  if (!options.source) options.source = true;
 
   // The op contains either op, create, delete, or none of the above (a no-op).
   if (op.op) {
@@ -644,10 +827,15 @@ Doc.prototype._submit = function(op, source, callback) {
     }
     // Try to normalize the op. This removes trailing skip:0's and things like that.
     if (this.type.normalize) op.op = this.type.normalize(op.op);
+    // Try to skip processing empty operations.
+    if (this.type.isNoop && this.type.isNoop(op.op)) {
+      if (callback) process.nextTick(callback);
+      return;
+    }
   }
 
   this._pushOp(op, callback);
-  this._otApply(op, source);
+  this._otApply(op, options);
 
   // The call to flush is delayed so if submit() is called multiple times
   // synchronously, all the ops are combined before being sent to the server.
@@ -733,19 +921,150 @@ Doc.prototype._tryCompose = function(op) {
 
 // Submit an operation to the document.
 //
-// @param operation handled by the OT type
-// @param options  {source: ...}
+// @param component operation handled by the OT type
+// @param options.source passed into 'op' event handler
+// @param options.undoable should the operation be undoable
+// @param options.fixUpUndoStack Determines how non-undoable op affects undoStack.
+//        If false (default), op transforms undoStack.
+//        If true, op is inverted and composed into the last operation on the undoStack.
+// @param options.fixUpRedoStack Determines how non-undoable op affects redoStack.
+//        If false (default), op transforms redoStack.
+//        If true, op is inverted and composed into the last operation on the redoStack.
 // @param [callback] called after operation submitted
 //
-// @fires before op, op, after op
+// @fires before op, op
 Doc.prototype.submitOp = function(component, options, callback) {
   if (typeof options === 'function') {
     callback = options;
     options = null;
   }
   var op = {op: component};
-  var source = options && options.source;
-  this._submit(op, source, callback);
+  var submitOptions = {
+    source: options && options.source,
+    operationType: options && options.undoable ? OPERATION_TYPES.UNDOABLE : OPERATION_TYPES.FIXED,
+    fixUpUndoStack: options && options.fixUpUndoStack,
+    fixUpRedoStack: options && options.fixUpRedoStack
+  };
+  this._submit(op, submitOptions, callback);
+};
+
+// Submits new content for the document.
+//
+// This function works only if the type supports `diff` or `diffX`.
+// It diffs the current and new snapshot to generate an operation,
+// which is then submitted as usual.
+//
+// @param snapshot new snapshot data
+// @param options.source passed into 'op' event handler
+// @param options.undoable should the operation be undoable
+// @param options.fixUpUndoStack Determines how non-undoable op affects undoStack.
+//        If false (default), op transforms undoStack.
+//        If true, op is inverted and composed into the last operation on the undoStack.
+// @param options.fixUpRedoStack Determines how non-undoable op affects redoStack.
+//        If false (default), op transforms redoStack.
+//        If true, op is inverted and composed into the last operation on the redoStack.
+// @param options.diffHint a hint passed into diff/diffX
+// @param [callback] called after operation submitted
+
+// @fires before op, op
+Doc.prototype.submitSnapshot = function(snapshot, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = null;
+  }
+  if (!this.type) {
+    var err = new ShareDBError(4015, 'Cannot submit snapshot. Document has not been created. ' + this.collection + '.' + this.id);
+    if (callback) return callback(err);
+    return this.emit('error', err);
+  }
+  if (!this.type.diff && !this.type.diffX) {
+    var err = new ShareDBError(4024, 'Cannot submit snapshot. Document type does not support diff nor diffX. ' + this.collection + '.' + this.id);
+    if (callback) return callback(err);
+    return this.emit('error', err);
+  }
+
+  var undoable = !!(options && options.undoable);
+  var fixUpUndoStack = options && options.fixUpUndoStack;
+  var fixUpRedoStack = options && options.fixUpRedoStack;
+  var diffHint = options && options.diffHint;
+  var needsUndoOp = undoable || fixUpUndoStack || fixUpRedoStack;
+  var op, undoOp;
+
+  if ((needsUndoOp && this.type.diffX) || !this.type.diff) {
+    var diffs = this.type.diffX(this.data, snapshot, diffHint);
+    undoOp = { op: diffs[0] };
+    op = { op: diffs[1] };
+  } else {
+    undoOp = null;
+    op = { op: this.type.diff(this.data, snapshot, diffHint) };
+  }
+
+  var submitOptions = {
+    source: options && options.source,
+    operationType: undoable ? OPERATION_TYPES.UNDOABLE : OPERATION_TYPES.FIXED,
+    undoOp: undoOp,
+    fixUpUndoStack: fixUpUndoStack,
+    fixUpRedoStack: fixUpRedoStack
+  };
+  this._submit(op, submitOptions, callback);
+};
+
+// Returns true, if there are any operations on the undo stack, otherwise false.
+Doc.prototype.canUndo = function() {
+  return this.undoStack.length > 0
+};
+
+// Undoes a submitted operation.
+//
+// @param options {source: ...}
+// @param [callback] called after operation submitted
+// @fires before op, op
+Doc.prototype.undo = function(options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = null;
+  }
+
+  if (!this.canUndo()) {
+    if (callback) process.nextTick(callback);
+    return;
+  }
+
+  var op = this.undoStack.pop();
+  var submitOptions = {
+    source: options && options.source,
+    operationType: OPERATION_TYPES.UNDO
+  };
+  this._submit(op, submitOptions, callback);
+};
+
+// Returns true, if there are any operations on the redo stack, otherwise false.
+Doc.prototype.canRedo = function() {
+  return this.redoStack.length > 0
+};
+
+// Redoes an undone operation.
+//
+// @param options {source:...}
+// @param [callback] called after operation submitted
+// @fires before op, op
+Doc.prototype.redo = function(options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = null;
+  }
+
+  if (!this.canRedo()) {
+    if (callback) process.nextTick(callback);
+    return;
+  }
+
+  var op = this.redoStack.pop()
+  var submitOptions = {
+    source: options && options.source,
+    operationType: OPERATION_TYPES.REDO
+  };
+  this._submit(op, submitOptions, callback);
 };
 
 // Create the document, which in ShareJS semantics means to set its type. Every
@@ -776,7 +1095,7 @@ Doc.prototype.create = function(data, type, options, callback) {
   }
   var op = {create: {type: type, data: data}};
   var source = options && options.source;
-  this._submit(op, source, callback);
+  this._submit(op, { source: source }, callback);
 };
 
 // Delete the document. This creates and submits a delete operation to the
@@ -798,7 +1117,7 @@ Doc.prototype.del = function(options, callback) {
   }
   var op = {del: true};
   var source = options && options.source;
-  this._submit(op, source, callback);
+  this._submit(op, { source: source }, callback);
 };
 
 
@@ -858,7 +1177,7 @@ Doc.prototype._rollback = function(err) {
     // I'm still not 100% sure about this functionality, because its really a
     // local op. Basically, the problem is that if the client's op is rejected
     // by the server, the editor window should update to reflect the undo.
-    this._otApply(op, false);
+    this._otApply(op);
 
     this._clearInflightOp(err);
     return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1528 @@
+{
+  "name": "sharedb",
+  "version": "1.0.0-beta.9",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@teamwork/ot-rich-text": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@teamwork/ot-rich-text/-/ot-rich-text-6.3.3.tgz",
+      "integrity": "sha512-cYHZPTRMY6N7GxJ3SENzHyGVtgLlDfMdtfRs1CG+6+6DzUkfP/VkEIoR+K5jp02DyI5yvMErkyJkv4BvM23sLg==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "arraydiff": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/arraydiff/-/arraydiff-0.1.3.tgz",
+      "integrity": "sha1-hqVDbXty8b3aX9bXTock5C+Dzk0="
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true,
+      "optional": true
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "coveralls": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
+      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      }
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.x.x"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "optional": true
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        },
+        "entities": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0"
+      }
+    },
+    "entities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "requires": {
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
+      }
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "expect.js": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
+      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dev": true,
+      "requires": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "dev": true,
+      "requires": {
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "is-my-json-valid": "^2.12.4",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "hat": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
+      "integrity": "sha1-uwFKnmSzeIrtgAWRdBPU/z1QLYo="
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "requires": {
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      }
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+      "dev": true,
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "istanbul": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "js-yaml": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "jshint": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+      "dev": true,
+      "requires": {
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "3.7.x",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+      "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "log-driver": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g=="
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "~1.33.0"
+      }
+    },
+    "mingo": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-2.2.2.tgz",
+      "integrity": "sha1-vmnUhq5uCsVLl53F9EEtshhR9pM=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "ot-json0": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ot-json0/-/ot-json0-1.1.0.tgz",
+      "integrity": "sha512-wf5fci7GGpMYRDnbbdIFQymvhsbFACMHtxjivQo5KgvAHlxekyfJ9aPsRr6YfFQthQkk4bmsl5yESrZwC/oMYQ=="
+    },
+    "ot-text": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ot-text/-/ot-text-1.0.1.tgz",
+      "integrity": "sha1-P4UPbuhYvDbvRayapR0Gx354388=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+      "dev": true
+    },
+    "quill-delta": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.2.tgz",
+      "integrity": "sha512-grWEQq9woEidPDogtDNxQKmy2LFf9zBC0EU/YTSw6TwKmMjtihTxdnPtPRfrqazB2MSJ7YdCWxmsJ7aQKRSEgg==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.1",
+        "fast-diff": "1.1.2"
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.79.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "caseless": "~0.11.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.1.1",
+        "har-validator": "~2.0.6",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "oauth-sign": "~0.8.1",
+        "qs": "~6.3.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "~0.4.1",
+        "uuid": "^3.0.0"
+      }
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "rich-text": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rich-text/-/rich-text-3.1.0.tgz",
+      "integrity": "sha1-BMlx3tzo64IBDPrP9uegzjXHqCU=",
+      "dev": true,
+      "requires": {
+        "quill-delta": "^3.2.0"
+      }
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.1"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sharedb": {
+      "version": "1.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.0.0-beta.9.tgz",
+      "integrity": "sha1-LX20J83hIJJNLasIzpLZq6134As=",
+      "dev": true,
+      "requires": {
+        "arraydiff": "^0.1.1",
+        "async": "^1.4.2",
+        "deep-is": "^0.1.3",
+        "hat": "0.0.3",
+        "make-error": "^1.1.1",
+        "ot-json0": "^1.0.1"
+      }
+    },
+    "sharedb-mingo-memory": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sharedb-mingo-memory/-/sharedb-mingo-memory-1.0.0.tgz",
+      "integrity": "sha1-vS5171YTCrheE5uMlMVSFv4+TQM=",
+      "dev": true,
+      "requires": {
+        "mingo": "^2.2.0",
+        "sharedb": "^1.0.0-beta"
+      }
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "source-map": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "stringstream": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,11 +12,14 @@
     "ot-json0": "^1.0.1"
   },
   "devDependencies": {
+    "@teamwork/ot-rich-text": "^6.3.3",
     "coveralls": "^2.11.8",
     "expect.js": "^0.3.1",
     "istanbul": "^0.4.2",
     "jshint": "^2.9.2",
     "mocha": "^3.2.0",
+    "ot-text": "^1.0.1",
+    "rich-text": "^3.1.0",
     "sharedb-mingo-memory": "^1.0.0-beta"
   },
   "scripts": {

--- a/test/client/invertible-type.js
+++ b/test/client/invertible-type.js
@@ -1,0 +1,80 @@
+// A simple type for testing undo/redo, where:
+//
+// - snapshot is an integer
+// - operation is an integer
+exports.type = {
+  name: 'invertible-type',
+  uri: 'http://sharejs.org/types/invertible-type',
+  create: create,
+  apply: apply,
+  transform: transform,
+  invert: invert
+};
+
+exports.typeWithDiff = {
+  name: 'invertible-type-with-diff',
+  uri: 'http://sharejs.org/types/invertible-type-with-diff',
+  create: create,
+  apply: apply,
+  transform: transform,
+  invert: invert,
+  diff: diff
+};
+
+exports.typeWithDiffX = {
+  name: 'invertible-type-with-diffX',
+  uri: 'http://sharejs.org/types/invertible-type-with-diffX',
+  create: create,
+  apply: apply,
+  transform: transform,
+  invert: invert,
+  diffX: diffX
+};
+
+exports.typeWithDiffAndDiffX = {
+  name: 'invertible-type-with-diff-and-diffX',
+  uri: 'http://sharejs.org/types/invertible-type-with-diff-and-diffX',
+  create: create,
+  apply: apply,
+  transform: transform,
+  invert: invert,
+  diff: diff,
+  diffX: diffX
+};
+
+exports.typeWithTransformX = {
+  name: 'invertible-type-with-transformX',
+  uri: 'http://sharejs.org/types/invertible-type-with-transformX',
+  create: create,
+  apply: apply,
+  transformX: transformX,
+  invert: invert
+};
+
+function create(data) {
+  return data | 0;
+}
+
+function apply(snapshot, op) {
+  return snapshot + op;
+}
+
+function transform(op1, op2, side) {
+  return op1;
+}
+
+function transformX(op1, op2) {
+  return [ op1, op2 ];
+}
+
+function invert(op) {
+  return -op;
+}
+
+function diff(oldSnapshot, newSnapshot) {
+  return newSnapshot - oldSnapshot;
+}
+
+function diffX(oldSnapshot, newSnapshot) {
+  return [ oldSnapshot - newSnapshot, newSnapshot - oldSnapshot ];
+}

--- a/test/client/undo-redo.js
+++ b/test/client/undo-redo.js
@@ -1,0 +1,1376 @@
+var async = require('async');
+var util = require('../util');
+var errorHandler = util.errorHandler;
+var Backend = require('../../lib/backend');
+var ShareDBError = require('../../lib/error');
+var expect = require('expect.js');
+var types = require('../../lib/types');
+var otText = require('ot-text');
+var otRichText = require('@teamwork/ot-rich-text');
+var invertibleType = require('./invertible-type');
+
+types.register(otText.type);
+types.register(otRichText.type);
+types.register(invertibleType.type);
+types.register(invertibleType.typeWithDiff);
+types.register(invertibleType.typeWithDiffX);
+types.register(invertibleType.typeWithDiffAndDiffX);
+types.register(invertibleType.typeWithTransformX);
+
+describe('client undo/redo', function() {
+  beforeEach(function() {
+    this.backend = new Backend();
+    this.connection = this.backend.connect();
+    this.connection2 = this.backend.connect();
+    this.doc = this.connection.get('dogs', 'fido');
+    this.doc2 = this.connection2.get('dogs', 'fido');
+  });
+
+  afterEach(function(done) {
+    this.backend.close(done);
+  });
+
+  it('submits a fixed operation', function(allDone) {
+    async.series([
+      this.doc.create.bind(this.doc, { test: 5 }),
+      this.doc.submitOp.bind(this.doc, [ { p: [ 'test' ], na: 2 } ]),
+      function(done) {
+        expect(this.doc.version).to.equal(2);
+        expect(this.doc.data).to.eql({ test: 7 });
+        expect(this.doc.canUndo()).to.equal(false);
+        expect(this.doc.canRedo()).to.equal(false);
+        done();
+      }.bind(this)
+    ], allDone);
+  });
+
+  it('receives a remote operation', function(allDone) {
+    async.series([
+      this.doc.subscribe.bind(this.doc),
+      this.doc2.create.bind(this.doc2, { test: 5 }),
+      this.doc2.submitOp.bind(this.doc2, [ { p: [ 'test' ], na: 2 } ]),
+      setTimeout,
+      function(done) {
+        expect(this.doc.version).to.equal(2);
+        expect(this.doc.data).to.eql({ test: 7 });
+        expect(this.doc.canUndo()).to.equal(false);
+        expect(this.doc.canRedo()).to.equal(false);
+        done();
+      }.bind(this)
+    ], allDone);
+  });
+
+  it('submits an undoable operation', function(allDone) {
+    async.series([
+      this.doc.create.bind(this.doc, { test: 5 }),
+      this.doc.submitOp.bind(this.doc, [ { p: [ 'test' ], na: 2 } ], { undoable: true }),
+      function(done) {
+        expect(this.doc.version).to.equal(2);
+        expect(this.doc.data).to.eql({ test: 7 });
+        expect(this.doc.canUndo()).to.equal(true);
+        expect(this.doc.canRedo()).to.equal(false);
+        done();
+      }.bind(this)
+    ], allDone);
+  });
+
+  it('undoes an operation', function(allDone) {
+    async.series([
+      this.doc.create.bind(this.doc, { test: 5 }),
+      this.doc.submitOp.bind(this.doc, [ { p: [ 'test' ], na: 2 } ], { undoable: true }),
+      this.doc.undo.bind(this.doc),
+      function(done) {
+        expect(this.doc.version).to.equal(3);
+        expect(this.doc.data).to.eql({ test: 5 });
+        expect(this.doc.canUndo()).to.equal(false);
+        expect(this.doc.canRedo()).to.equal(true);
+        done();
+      }.bind(this)
+    ], allDone);
+  });
+
+  it('redoes an operation', function(allDone) {
+    async.series([
+      this.doc.create.bind(this.doc, { test: 5 }),
+      this.doc.submitOp.bind(this.doc, [ { p: [ 'test' ], na: 2 } ], { undoable: true }),
+      this.doc.undo.bind(this.doc),
+      this.doc.redo.bind(this.doc),
+      function(done) {
+        expect(this.doc.version).to.equal(4);
+        expect(this.doc.data).to.eql({ test: 7 });
+        expect(this.doc.canUndo()).to.equal(true);
+        expect(this.doc.canRedo()).to.equal(false);
+        done();
+      }.bind(this)
+    ], allDone);
+  });
+
+  it('performs a series of undo and redo operations', function(allDone) {
+    async.series([
+      this.doc.create.bind(this.doc, { test: 5 }),
+      this.doc.submitOp.bind(this.doc, [ { p: [ 'test' ], na: 2 } ], { undoable: true }),
+      this.doc.undo.bind(this.doc),
+      this.doc.redo.bind(this.doc),
+      this.doc.undo.bind(this.doc),
+      this.doc.redo.bind(this.doc),
+      this.doc.undo.bind(this.doc),
+      this.doc.redo.bind(this.doc),
+      function(done) {
+        expect(this.doc.version).to.equal(8);
+        expect(this.doc.data).to.eql({ test: 7 });
+        expect(this.doc.canUndo()).to.equal(true);
+        expect(this.doc.canRedo()).to.equal(false);
+        done();
+      }.bind(this)
+    ], allDone);
+  });
+
+  it('performs a series of undo and redo operations synchronously', function() {
+    this.doc.create({ test: 5 }),
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true }),
+    expect(this.doc.data).to.eql({ test: 7 });
+    this.doc.undo(),
+    expect(this.doc.data).to.eql({ test: 5 });
+    this.doc.redo(),
+    expect(this.doc.data).to.eql({ test: 7 });
+    this.doc.undo(),
+    expect(this.doc.data).to.eql({ test: 5 });
+    this.doc.redo(),
+    expect(this.doc.data).to.eql({ test: 7 });
+    this.doc.undo(),
+    expect(this.doc.data).to.eql({ test: 5 });
+    this.doc.redo(),
+    expect(this.doc.data).to.eql({ test: 7 });
+    expect(this.doc.canUndo()).to.equal(true);
+    expect(this.doc.canRedo()).to.equal(false);
+  });
+
+  it('undoes one of two operations', function(allDone) {
+    this.doc.undoComposeTimeout = -1;
+    async.series([
+      this.doc.create.bind(this.doc, { test: 5 }),
+      this.doc.submitOp.bind(this.doc, [ { p: [ 'test' ], na: 2 } ], { undoable: true }),
+      this.doc.submitOp.bind(this.doc, [ { p: [ 'test' ], na: 3 } ], { undoable: true }),
+      this.doc.undo.bind(this.doc),
+      function(done) {
+        expect(this.doc.version).to.equal(4);
+        expect(this.doc.data).to.eql({ test: 7 });
+        expect(this.doc.canUndo()).to.equal(true);
+        expect(this.doc.canRedo()).to.equal(true);
+        done();
+      }.bind(this)
+    ], allDone);
+  });
+
+  it('undoes two of two operations', function(allDone) {
+    this.doc.undoComposeTimeout = -1;
+    async.series([
+      this.doc.create.bind(this.doc, { test: 5 }),
+      this.doc.submitOp.bind(this.doc, [ { p: [ 'test' ], na: 2 } ], { undoable: true }),
+      this.doc.submitOp.bind(this.doc, [ { p: [ 'test' ], na: 3 } ], { undoable: true }),
+      this.doc.undo.bind(this.doc),
+      this.doc.undo.bind(this.doc),
+      function(done) {
+        expect(this.doc.version).to.equal(5);
+        expect(this.doc.data).to.eql({ test: 5 });
+        expect(this.doc.canUndo()).to.equal(false);
+        expect(this.doc.canRedo()).to.equal(true);
+        done();
+      }.bind(this)
+    ], allDone);
+  });
+
+  it('reoes one of two operations', function(allDone) {
+    this.doc.undoComposeTimeout = -1;
+    async.series([
+      this.doc.create.bind(this.doc, { test: 5 }),
+      this.doc.submitOp.bind(this.doc, [ { p: [ 'test' ], na: 2 } ], { undoable: true }),
+      this.doc.submitOp.bind(this.doc, [ { p: [ 'test' ], na: 3 } ], { undoable: true }),
+      this.doc.undo.bind(this.doc),
+      this.doc.undo.bind(this.doc),
+      this.doc.redo.bind(this.doc),
+      function(done) {
+        expect(this.doc.version).to.equal(6);
+        expect(this.doc.data).to.eql({ test: 7 });
+        expect(this.doc.canUndo()).to.equal(true);
+        expect(this.doc.canRedo()).to.equal(true);
+        done();
+      }.bind(this)
+    ], allDone);
+  });
+
+  it('reoes two of two operations', function(allDone) {
+    this.doc.undoComposeTimeout = -1;
+    async.series([
+      this.doc.create.bind(this.doc, { test: 5 }),
+      this.doc.submitOp.bind(this.doc, [ { p: [ 'test' ], na: 2 } ], { undoable: true }),
+      this.doc.submitOp.bind(this.doc, [ { p: [ 'test' ], na: 3 } ], { undoable: true }),
+      this.doc.undo.bind(this.doc),
+      this.doc.undo.bind(this.doc),
+      this.doc.redo.bind(this.doc),
+      this.doc.redo.bind(this.doc),
+      function(done) {
+        expect(this.doc.version).to.equal(7);
+        expect(this.doc.data).to.eql({ test: 10 });
+        expect(this.doc.canUndo()).to.equal(true);
+        expect(this.doc.canRedo()).to.equal(false);
+        done();
+      }.bind(this)
+    ], allDone);
+  });
+
+  it('calls undo, when canUndo is false', function(done) {
+    expect(this.doc.canUndo()).to.equal(false);
+    this.doc.undo(done);
+  });
+
+  it('calls undo, when canUndo is false - no callback', function() {
+    expect(this.doc.canUndo()).to.equal(false);
+    this.doc.undo();
+  });
+
+  it('calls redo, when canRedo is false', function(done) {
+    expect(this.doc.canRedo()).to.equal(false);
+    this.doc.redo(done);
+  });
+
+  it('calls redo, when canRedo is false - no callback', function() {
+    expect(this.doc.canRedo()).to.equal(false);
+    this.doc.redo();
+  });
+
+  it('preserves source on create', function(done) {
+    this.doc.on('create', function(source) {
+      expect(source).to.equal('test source');
+      done();
+    });
+    this.doc.create({ test: 5 }, null, { source: 'test source' });
+  });
+
+  it('preserves source on del', function(done) {
+    this.doc.on('del', function(oldContent, source) {
+      expect(source).to.equal('test source');
+      done();
+    });
+    this.doc.create({ test: 5 });
+    this.doc.del({ source: 'test source' });
+  });
+
+  it('preserves source on submitOp', function(done) {
+    this.doc.on('op', function(op, source) {
+      expect(source).to.equal('test source');
+      done();
+    });
+    this.doc.create({ test: 5 });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { source: 'test source' });
+  });
+
+  it('preserves source on undo', function(done) {
+    this.doc.create({ test: 5 });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.on('op', function(op, source) {
+      expect(source).to.equal('test source');
+      done();
+    });
+    this.doc.undo({ source: 'test source' });
+  });
+
+  it('preserves source on redo', function(done) {
+    this.doc.create({ test: 5 });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.undo();
+    this.doc.on('op', function(op, source) {
+      expect(source).to.equal('test source');
+      done();
+    });
+    this.doc.redo({ source: 'test source' });
+  });
+
+  it('has source=false on remote operations', function(done) {
+    this.doc.on('op', function(op, source) {
+      expect(source).to.equal(false);
+      done();
+    });
+    this.doc.subscribe(function() {
+      this.doc2.preventCompose = true;
+      this.doc2.create({ test: 5 });
+      this.doc2.submitOp([ { p: [ 'test' ], na: 2 } ]);
+    }.bind(this));
+  });
+
+  it('composes undoable operations within time limit', function(done) {
+    this.doc.create({ test: 5 });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    setTimeout(function() {
+      this.doc.submitOp([ { p: [ 'test' ], na: 3 } ], { undoable: true });
+      expect(this.doc.data).to.eql({ test: 10 });
+      this.doc.undo();
+      expect(this.doc.data).to.eql({ test: 5 });
+      expect(this.doc.canUndo()).to.equal(false);
+      done();
+    }.bind(this), 2);
+  });
+
+  it('composes undoable operations correctly', function() {
+    this.doc.create({ a: 1, b: 2 });
+    this.doc.submitOp([ { p: [ 'a' ], od: 1 } ], { undoable: true });
+    this.doc.submitOp([ { p: [ 'b' ], od: 2 } ], { undoable: true });
+    expect(this.doc.data).to.eql({});
+    expect(this.doc.canRedo()).to.equal(false);
+    var opCalled = false;
+    this.doc.once('op', function(op) {
+      opCalled = true;
+      expect(op).to.eql([ { p: [ 'b' ], oi: 2 }, { p: [ 'a' ], oi: 1 } ]);
+    });
+    this.doc.undo();
+    expect(opCalled).to.equal(true);
+    expect(this.doc.data).to.eql({ a: 1, b: 2 });
+    expect(this.doc.canUndo()).to.equal(false);
+    this.doc.redo();
+    expect(this.doc.data).to.eql({});
+    expect(this.doc.canRedo()).to.equal(false);
+  });
+
+  it('does not compose undoable operations outside time limit', function(done) {
+    this.doc.undoComposeTimeout = 1;
+    this.doc.create({ test: 5 });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    setTimeout(function () {
+      this.doc.submitOp([ { p: [ 'test' ], na: 3 } ], { undoable: true });
+      expect(this.doc.data).to.eql({ test: 10 });
+      this.doc.undo();
+      expect(this.doc.data).to.eql({ test: 7 });
+      expect(this.doc.canUndo()).to.equal(true);
+      this.doc.undo();
+      expect(this.doc.data).to.eql({ test: 5 });
+      expect(this.doc.canUndo()).to.equal(false);
+      done();
+    }.bind(this), 3);
+  });
+
+  it('does not compose undoable operations, if undoComposeTimeout < 0', function() {
+    this.doc.undoComposeTimeout = -1;
+    this.doc.create({ test: 5 });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.submitOp([ { p: [ 'test' ], na: 3 } ], { undoable: true });
+    expect(this.doc.data).to.eql({ test: 10 });
+    this.doc.undo();
+    expect(this.doc.data).to.eql({ test: 7 });
+    expect(this.doc.canUndo()).to.equal(true);
+    this.doc.undo();
+    expect(this.doc.data).to.eql({ test: 5 });
+    expect(this.doc.canUndo()).to.equal(false);
+  });
+
+  it('does not compose undoable operations, if type does not support compose nor composeSimilar', function() {
+    this.doc.create(5, invertibleType.type.uri);
+    this.doc.submitOp(2, { undoable: true });
+    expect(this.doc.data).to.equal(7);
+    this.doc.submitOp(2, { undoable: true });
+    expect(this.doc.data).to.equal(9);
+    this.doc.undo();
+    expect(this.doc.data).to.equal(7);
+    this.doc.undo();
+    expect(this.doc.data).to.equal(5);
+    expect(this.doc.canUndo()).to.equal(false);
+    this.doc.redo();
+    expect(this.doc.data).to.equal(7);
+    this.doc.redo();
+    expect(this.doc.data).to.equal(9);
+    expect(this.doc.canRedo()).to.equal(false);
+  });
+
+  it('uses applyAndInvert, if available', function() {
+    this.doc.undoComposeTimeout = -1;
+    this.doc.create([], otRichText.type.uri);
+    this.doc.submitOp([ otRichText.Action.createInsertText('two') ], { undoable: true });
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('two') ]);
+    this.doc.submitOp([ otRichText.Action.createInsertText('one') ], { undoable: true });
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('onetwo') ]);
+    this.doc.undo();
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('two') ]);
+    this.doc.undo();
+    expect(this.doc.data).to.eql([]);
+    this.doc.redo();
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('two') ]);
+    this.doc.redo();
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('onetwo') ]);
+  });
+
+  it('does not add an undo level, if type is not invertible', function() {
+    this.doc.create('two', otText.type.uri);
+    this.doc.submitOp([ 'one' ], { undoable: true });
+    expect(this.doc.data).to.eql('onetwo');
+    expect(this.doc.canUndo()).to.equal(false);
+    expect(this.doc.canRedo()).to.equal(false);
+    this.doc.undo();
+    expect(this.doc.data).to.eql('onetwo');
+    expect(this.doc.canUndo()).to.equal(false);
+    expect(this.doc.canRedo()).to.equal(false);
+  });
+
+  it('composes similar operations', function() {
+    this.doc.create([], otRichText.type.uri);
+    this.doc.submitOp([
+      otRichText.Action.createInsertText('one')
+    ], { undoable: true });
+    this.doc.submitOp([
+      otRichText.Action.createRetain(3),
+      otRichText.Action.createInsertText('two')
+    ], { undoable: true });
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('onetwo') ]);
+    expect(this.doc.canRedo()).to.equal(false);
+    this.doc.undo();
+    expect(this.doc.data).to.eql([]);
+    expect(this.doc.canUndo()).to.equal(false);
+    this.doc.redo();
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('onetwo') ]);
+    expect(this.doc.canRedo()).to.equal(false);
+  });
+
+  it('does not compose dissimilar operations', function() {
+    this.doc.create([
+      otRichText.Action.createInsertText(' ')
+    ], otRichText.type.uri);
+
+    this.doc.submitOp([
+      otRichText.Action.createRetain(1),
+      otRichText.Action.createInsertText('two')
+    ], { undoable: true });
+    expect(this.doc.data).to.eql([
+      otRichText.Action.createInsertText(' two')
+    ]);
+
+    this.doc.submitOp([
+      otRichText.Action.createInsertText('one')
+    ], { undoable: true });
+    expect(this.doc.data).to.eql([
+      otRichText.Action.createInsertText('one two')
+    ]);
+
+    this.doc.undo();
+    expect(this.doc.data).to.eql([
+      otRichText.Action.createInsertText(' two')
+    ]);
+
+    this.doc.undo();
+    expect(this.doc.data).to.eql([
+      otRichText.Action.createInsertText(' ')
+    ]);
+
+    this.doc.redo();
+    expect(this.doc.data).to.eql([
+      otRichText.Action.createInsertText(' two')
+    ]);
+
+    this.doc.redo();
+    expect(this.doc.data).to.eql([
+      otRichText.Action.createInsertText('one two')
+    ]);
+  });
+
+  it('does not add no-ops to the undo stack on undoable operation', function() {
+    var opCalled = false;
+    this.doc.create([ otRichText.Action.createInsertText('test', [ 'key', 'value' ]) ], otRichText.type.uri);
+    this.doc.on('op', function(op, source) {
+      expect(op).to.eql([ otRichText.Action.createRetain(4, [ 'key', 'value' ]) ]);
+      opCalled = true;
+    });
+    this.doc.submitOp([ otRichText.Action.createRetain(4, [ 'key', 'value' ]) ], { undoable: true });
+    expect(opCalled).to.equal(true);
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('test', [ 'key', 'value' ]) ]);
+    expect(this.doc.canUndo()).to.eql(false);
+    expect(this.doc.canRedo()).to.eql(false);
+  });
+
+  it('limits the size of the undo stack', function() {
+    this.doc.undoLimit = 2;
+    this.doc.undoComposeTimeout = -1;
+    this.doc.create({ test: 5 });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    expect(this.doc.data).to.eql({ test: 11 });
+    expect(this.doc.canUndo()).to.equal(true);
+    this.doc.undo();
+    expect(this.doc.canUndo()).to.equal(true);
+    this.doc.undo();
+    expect(this.doc.canUndo()).to.equal(false);
+    this.doc.undo();
+    expect(this.doc.data).to.eql({ test: 7 });
+  });
+
+  it('limits the size of the undo stack, after adjusting the limit', function() {
+    this.doc.undoLimit = 100;
+    this.doc.undoComposeTimeout = -1;
+    this.doc.create({ test: 5 });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.undoLimit = 2;
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    expect(this.doc.data).to.eql({ test: 15 });
+    expect(this.doc.canUndo()).to.equal(true);
+    this.doc.undo();
+    expect(this.doc.canUndo()).to.equal(true);
+    this.doc.undo();
+    expect(this.doc.canUndo()).to.equal(false);
+    this.doc.undo();
+    expect(this.doc.data).to.eql({ test: 11 });
+  });
+
+  it('does not limit the size of the stacks on undo and redo operations', function() {
+    this.doc.undoLimit = 100;
+    this.doc.undoComposeTimeout = -1;
+    this.doc.create({ test: 5 });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.undoLimit = 2;
+    expect(this.doc.data).to.eql({ test: 15 });
+    this.doc.undo();
+    this.doc.undo();
+    this.doc.undo();
+    this.doc.undo();
+    this.doc.undo();
+    expect(this.doc.data).to.eql({ test: 5 });
+    this.doc.redo();
+    this.doc.redo();
+    this.doc.redo();
+    this.doc.redo();
+    this.doc.redo();
+    expect(this.doc.data).to.eql({ test: 15 });
+    this.doc.undo();
+    this.doc.undo();
+    this.doc.undo();
+    this.doc.undo();
+    this.doc.undo();
+    expect(this.doc.data).to.eql({ test: 5 });
+  });
+
+  it('does not compose the next operation after undo', function() {
+    this.doc.create({ test: 5 });
+    this.doc.undoComposeTimeout = -1;
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true }); // not composed
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true }); // not composed
+    this.doc.undoComposeTimeout = 1000;
+    this.doc.undo();
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true }); // not composed
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true }); // composed
+    expect(this.doc.data).to.eql({ test: 11 });
+    expect(this.doc.canUndo()).to.equal(true);
+
+    this.doc.undo();
+    expect(this.doc.data).to.eql({ test: 7 });
+    expect(this.doc.canUndo()).to.equal(true);
+
+    this.doc.undo();
+    expect(this.doc.data).to.eql({ test: 5 });
+    expect(this.doc.canUndo()).to.equal(false);
+  });
+
+  it('does not compose the next operation after undo and redo', function() {
+    this.doc.create({ test: 5 });
+    this.doc.undoComposeTimeout = -1;
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true }); // not composed
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true }); // not composed
+    this.doc.undoComposeTimeout = 1000;
+    this.doc.undo();
+    this.doc.redo();
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true }); // not composed
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true }); // composed
+    expect(this.doc.data).to.eql({ test: 13 });
+    expect(this.doc.canUndo()).to.equal(true);
+
+    this.doc.undo();
+    expect(this.doc.data).to.eql({ test: 9 });
+    expect(this.doc.canUndo()).to.equal(true);
+
+    this.doc.undo();
+    expect(this.doc.data).to.eql({ test: 7 });
+    expect(this.doc.canUndo()).to.equal(true);
+
+    this.doc.undo();
+    expect(this.doc.data).to.eql({ test: 5 });
+    expect(this.doc.canUndo()).to.equal(false);
+  });
+
+  it('clears stacks on del', function() {
+    this.doc.undoComposeTimeout = -1;
+    this.doc.create({ test: 5 });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    this.doc.undo();
+    expect(this.doc.canUndo()).to.equal(true);
+    expect(this.doc.canRedo()).to.equal(true);
+    this.doc.del();
+    expect(this.doc.canUndo()).to.equal(false);
+    expect(this.doc.canRedo()).to.equal(false);
+  });
+
+  it('transforms the stacks by remote operations', function(done) {
+    this.doc2.subscribe();
+    this.doc.subscribe();
+    this.doc.undoComposeTimeout = -1;
+    this.doc.create([], otRichText.type.uri);
+    this.doc.submitOp([ otRichText.Action.createInsertText('4') ], { undoable: true });
+    this.doc.submitOp([ otRichText.Action.createInsertText('3') ], { undoable: true });
+    this.doc.submitOp([ otRichText.Action.createInsertText('2') ], { undoable: true });
+    this.doc.submitOp([ otRichText.Action.createInsertText('1') ], { undoable: true });
+    this.doc.undo();
+    this.doc.undo();
+    setTimeout(function() {
+      this.doc.once('op', function(op, source) {
+        expect(source).to.equal(false);
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC34') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC4') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC4') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC34') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC234') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC1234') ]);
+        done();
+      }.bind(this));
+      this.doc2.submitOp([ otRichText.Action.createInsertText('ABC') ]);
+    }.bind(this));
+  });
+
+  it('transforms the stacks by remote operations and removes no-ops', function(done) {
+    this.doc2.subscribe();
+    this.doc.subscribe();
+    this.doc.undoComposeTimeout = -1;
+    this.doc.create([], otRichText.type.uri);
+    this.doc.submitOp([ otRichText.Action.createInsertText('4') ], { undoable: true });
+    this.doc.submitOp([ otRichText.Action.createInsertText('3') ], { undoable: true });
+    this.doc.submitOp([ otRichText.Action.createInsertText('2') ], { undoable: true });
+    this.doc.submitOp([ otRichText.Action.createInsertText('1') ], { undoable: true });
+    this.doc.undo();
+    this.doc.undo();
+    setTimeout(function() {
+      this.doc.once('op', function(op, source) {
+        expect(source).to.equal(false);
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('4') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([]);
+        expect(this.doc.canUndo()).to.equal(false);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('4') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('24') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('124') ]);
+        expect(this.doc.canRedo()).to.equal(false);
+        done();
+      }.bind(this));
+      this.doc2.submitOp([ otRichText.Action.createDelete(1) ]);
+    }.bind(this));
+  });
+
+  it('transforms the stacks by a local FIXED operation', function() {
+    this.doc.undoComposeTimeout = -1;
+    this.doc.create([], otRichText.type.uri);
+    this.doc.submitOp([ otRichText.Action.createInsertText('4') ], { undoable: true });
+    this.doc.submitOp([ otRichText.Action.createInsertText('3') ], { undoable: true });
+    this.doc.submitOp([ otRichText.Action.createInsertText('2') ], { undoable: true });
+    this.doc.submitOp([ otRichText.Action.createInsertText('1') ], { undoable: true });
+    this.doc.undo();
+    this.doc.undo();
+    this.doc.submitOp([ otRichText.Action.createInsertText('ABC') ]);
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC34') ]);
+    this.doc.undo();
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC4') ]);
+    this.doc.undo();
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC') ]);
+    this.doc.redo();
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC4') ]);
+    this.doc.redo();
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC34') ]);
+    this.doc.redo();
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC234') ]);
+    this.doc.redo();
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ABC1234') ]);
+  });
+
+  it('transforms the stacks by a local FIXED operation and removes no-ops', function() {
+    this.doc.undoComposeTimeout = -1;
+    this.doc.create([], otRichText.type.uri);
+    this.doc.submitOp([ otRichText.Action.createInsertText('4') ], { undoable: true });
+    this.doc.submitOp([ otRichText.Action.createInsertText('3') ], { undoable: true });
+    this.doc.submitOp([ otRichText.Action.createInsertText('2') ], { undoable: true });
+    this.doc.submitOp([ otRichText.Action.createInsertText('1') ], { undoable: true });
+    this.doc.undo();
+    this.doc.undo();
+    this.doc.submitOp([ otRichText.Action.createDelete(1) ]);
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('4') ]);
+    this.doc.undo();
+    expect(this.doc.data).to.eql([]);
+    expect(this.doc.canUndo()).to.equal(false);
+    this.doc.redo();
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('4') ]);
+    this.doc.redo();
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('24') ]);
+    this.doc.redo();
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('124') ]);
+    expect(this.doc.canRedo()).to.equal(false);
+  });
+
+  it('transforms the stacks using transform', function() {
+    this.doc.undoComposeTimeout = -1;
+    this.doc.create(0, invertibleType.type.uri);
+    this.doc.submitOp(1, { undoable: true });
+    this.doc.submitOp(10, { undoable: true });
+    this.doc.submitOp(100, { undoable: true });
+    this.doc.submitOp(1000, { undoable: true });
+    this.doc.undo();
+    this.doc.undo();
+    expect(this.doc.data).to.equal(11);
+    this.doc.submitOp(10000);
+    this.doc.undo();
+    expect(this.doc.data).to.equal(10001);
+    this.doc.undo();
+    expect(this.doc.data).to.equal(10000);
+    this.doc.redo();
+    expect(this.doc.data).to.equal(10001);
+    this.doc.redo();
+    expect(this.doc.data).to.equal(10011);
+    this.doc.redo();
+    expect(this.doc.data).to.equal(10111);
+    this.doc.redo();
+    expect(this.doc.data).to.equal(11111);
+  });
+
+  it('transforms the stacks using transformX', function() {
+    this.doc.undoComposeTimeout = -1;
+    this.doc.create(0, invertibleType.typeWithTransformX.uri);
+    this.doc.submitOp(1, { undoable: true });
+    this.doc.submitOp(10, { undoable: true });
+    this.doc.submitOp(100, { undoable: true });
+    this.doc.submitOp(1000, { undoable: true });
+    this.doc.undo();
+    this.doc.undo();
+    expect(this.doc.data).to.equal(11);
+    this.doc.submitOp(10000);
+    this.doc.undo();
+    expect(this.doc.data).to.equal(10001);
+    this.doc.undo();
+    expect(this.doc.data).to.equal(10000);
+    this.doc.redo();
+    expect(this.doc.data).to.equal(10001);
+    this.doc.redo();
+    expect(this.doc.data).to.equal(10011);
+    this.doc.redo();
+    expect(this.doc.data).to.equal(10111);
+    this.doc.redo();
+    expect(this.doc.data).to.equal(11111);
+  });
+
+  it('skips processing when submitting a no-op (no callback)', function(done) {
+    this.doc.on('op', function() {
+      done(new Error('Should not emit `op`'));
+    });
+    this.doc.create([ otRichText.Action.createInsertText('test') ], otRichText.type.uri);
+    this.doc.submitOp([]);
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('test') ]);
+    done();
+  });
+
+  it('skips processing when submitting a no-op (with callback)', function(done) {
+    this.doc.on('op', function() {
+      done(new Error('Should not emit `op`'));
+    });
+    this.doc.create([ otRichText.Action.createInsertText('test') ], otRichText.type.uri);
+    this.doc.submitOp([], done);
+  });
+
+  it('skips processing when submitting an identical snapshot (no callback)', function(done) {
+    this.doc.on('op', function() {
+      done(new Error('Should not emit `op`'));
+    });
+    this.doc.create([ otRichText.Action.createInsertText('test') ], otRichText.type.uri);
+    this.doc.submitSnapshot([ otRichText.Action.createInsertText('test') ]);
+    expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('test') ]);
+    done();
+  });
+
+  it('skips processing when submitting an identical snapshot (with callback)', function(done) {
+    this.doc.on('op', function() {
+      done(new Error('Should not emit `op`'));
+    });
+    this.doc.create([ otRichText.Action.createInsertText('test') ], otRichText.type.uri);
+    this.doc.submitSnapshot([ otRichText.Action.createInsertText('test') ], done);
+  });
+
+  describe('operationType', function() {
+    it('reports UNDOABLE operationType', function(done) {
+      this.doc.create({ test: 5 });
+      this.doc.on('op', function(op, source, operationType) {
+        expect(source).to.equal(true);
+        expect(operationType).to.equal('UNDOABLE');
+        done();
+      });
+      this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    });
+
+    it('reports UNDO operationType', function(done) {
+      this.doc.create({ test: 5 });
+      this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+      this.doc.on('op', function(op, source, operationType) {
+        expect(source).to.equal(true);
+        expect(operationType).to.equal('UNDO');
+        done();
+      });
+      this.doc.undo();
+    });
+
+    it('reports REDO operationType', function(done) {
+      this.doc.create({ test: 5 });
+      this.doc.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+      this.doc.undo();
+      this.doc.on('op', function(op, source, operationType) {
+        expect(source).to.equal(true);
+        expect(operationType).to.equal('REDO');
+        done();
+      });
+      this.doc.redo();
+    });
+
+    it('reports FIXED operationType (local operation, undoable=false)', function(done) {
+      this.doc.create({ test: 5 });
+      this.doc.on('op', function(op, source, operationType) {
+        expect(source).to.equal(true);
+        expect(operationType).to.equal('FIXED');
+        done();
+      });
+      this.doc.submitOp([ { p: [ 'test' ], na: 2 } ]);
+    });
+
+    it('reports FIXED operationType (local operation, undoable=true but type is not invertible)', function(done) {
+      this.doc.create('', otText.type.uri);
+      this.doc.on('op', function(op, source, operationType) {
+        expect(source).to.equal(true);
+        expect(operationType).to.equal('FIXED');
+        done();
+      });
+      this.doc.submitOp([ 'test' ], { undoable: true });
+    });
+
+    it('reports FIXED operationType (remote operation, undoable=false)', function(done) {
+      this.doc.subscribe();
+      this.doc.on('op', function(op, source, operationType) {
+        expect(source).to.equal(false);
+        expect(operationType).to.equal('FIXED');
+        done();
+      });
+      this.doc2.preventCompose = true;
+      this.doc2.create({ test: 5 });
+      this.doc2.submitOp([ { p: [ 'test' ], na: 2 } ]);
+    });
+
+    it('reports FIXED operationType (remote operation, undoable=true)', function(done) {
+      this.doc.subscribe();
+      this.doc.on('op', function(op, source, operationType) {
+        expect(source).to.equal(false);
+        expect(operationType).to.equal('FIXED');
+        done();
+      });
+      this.doc2.preventCompose = true;
+      this.doc2.create({ test: 5 });
+      this.doc2.submitOp([ { p: [ 'test' ], na: 2 } ], { undoable: true });
+    });
+  });
+
+  describe('fixup operations', function() {
+    describe('basic tests', function() {
+      beforeEach(function() {
+        this.assert = function(text) {
+          var expected = text ? [ otRichText.Action.createInsertText(text) ] : [];
+          expect(this.doc.data).to.eql(expected);
+          return this;
+        };
+        this.submitOp = function(op, options) {
+          this.doc.submitOp([ otRichText.Action.createInsertText(op) ], options);
+          return this;
+        };
+        this.submitSnapshot = function(snapshot, options) {
+          this.doc.submitSnapshot([ otRichText.Action.createInsertText(snapshot) ], options);
+          return this;
+        };
+        this.undo = function() {
+          this.doc.undo();
+          return this;
+        };
+        this.redo = function() {
+          this.doc.redo();
+          return this;
+        };
+
+        this.doc.undoComposeTimeout = -1;
+        this.doc.create([], otRichText.type.uri);
+        this.submitOp('d', { undoable: true }).assert('d');
+        this.submitOp('c', { undoable: true }).assert('cd');
+        this.submitOp('b', { undoable: true }).assert('bcd');
+        this.submitOp('a', { undoable: true }).assert('abcd');
+        this.undo().assert('bcd');
+        this.undo().assert('cd');
+        expect(this.doc.canUndo()).to.equal(true);
+        expect(this.doc.canRedo()).to.equal(true);
+      });
+
+      it('submits an operation (transforms undo stack, transforms redo stack)', function() {
+        this.submitOp('!').assert('!cd');
+        this.undo().assert('!d');
+        this.undo().assert('!');
+        this.redo().assert('!d');
+        this.redo().assert('!cd');
+        this.redo().assert('!bcd');
+        this.redo().assert('!abcd');
+      });
+
+      it('submits an operation (fixes up undo stack, transforms redo stack)', function() {
+        this.submitOp('!', { fixUpUndoStack: true }).assert('!cd');
+        this.undo().assert('d');
+        this.undo().assert('');
+        this.redo().assert('d');
+        this.redo().assert('!cd');
+        this.redo().assert('!bcd');
+        this.redo().assert('!abcd');
+      });
+
+      it('submits an operation (transforms undo stack, fixes up redo stack)', function() {
+        this.submitOp('!', { fixUpRedoStack: true }).assert('!cd');
+        this.undo().assert('!d');
+        this.undo().assert('!');
+        this.redo().assert('!d');
+        this.redo().assert('!cd');
+        this.redo().assert('bcd');
+        this.redo().assert('abcd');
+      });
+
+      it('submits an operation (fixes up undo stack, fixes up redo stack)', function() {
+        this.submitOp('!', { fixUpUndoStack: true, fixUpRedoStack: true }).assert('!cd');
+        this.undo().assert('d');
+        this.undo().assert('');
+        this.redo().assert('d');
+        this.redo().assert('!cd');
+        this.redo().assert('bcd');
+        this.redo().assert('abcd');
+      });
+
+      it('submits a snapshot (transforms undo stack, transforms redo stack)', function() {
+        this.submitSnapshot('!cd').assert('!cd');
+        this.undo().assert('!d');
+        this.undo().assert('!');
+        this.redo().assert('!d');
+        this.redo().assert('!cd');
+        this.redo().assert('!bcd');
+        this.redo().assert('!abcd');
+      });
+
+      it('submits a snapshot (fixes up undo stack, transforms redo stack)', function() {
+        this.submitSnapshot('!cd', { fixUpUndoStack: true }).assert('!cd');
+        this.undo().assert('d');
+        this.undo().assert('');
+        this.redo().assert('d');
+        this.redo().assert('!cd');
+        this.redo().assert('!bcd');
+        this.redo().assert('!abcd');
+      });
+
+      it('submits a snapshot (transforms undo stack, fixes up redo stack)', function() {
+        this.submitSnapshot('!cd', { fixUpRedoStack: true }).assert('!cd');
+        this.undo().assert('!d');
+        this.undo().assert('!');
+        this.redo().assert('!d');
+        this.redo().assert('!cd');
+        this.redo().assert('bcd');
+        this.redo().assert('abcd');
+      });
+
+      it('submits a snapshot (fixes up undo stack, fixes up redo stack)', function() {
+        this.submitSnapshot('!cd', { fixUpUndoStack: true, fixUpRedoStack: true }).assert('!cd');
+        this.undo().assert('d');
+        this.undo().assert('');
+        this.redo().assert('d');
+        this.redo().assert('!cd');
+        this.redo().assert('bcd');
+        this.redo().assert('abcd');
+      });
+    });
+
+    describe('no-ops', function() {
+      it('removes a no-op from the undo stack', function() {
+        this.doc.undoComposeTimeout = -1;
+        this.doc.create([], otRichText.type.uri);
+        this.doc.submitOp([ otRichText.Action.createInsertText('d') ], { undoable: true });
+        this.doc.submitOp([ otRichText.Action.createInsertText('c') ], { undoable: true });
+        this.doc.submitOp([ otRichText.Action.createInsertText('b') ], { undoable: true });
+        this.doc.submitOp([ otRichText.Action.createInsertText('a') ], { undoable: true });
+        this.doc.undo();
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('cd') ]);
+        this.doc.submitOp([ otRichText.Action.createDelete(1) ], { fixUpUndoStack: true });
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('d') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([]);
+        expect(this.doc.canUndo()).to.equal(false);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('d') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('bd') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abd') ]);
+        expect(this.doc.canRedo()).to.equal(false);
+      });
+
+      it('removes a no-op from the redo stack', function() {
+        this.doc.undoComposeTimeout = -1;
+        this.doc.create([ otRichText.Action.createInsertText('abcd') ], otRichText.type.uri);
+        this.doc.submitOp([ otRichText.Action.createDelete(1) ], { undoable: true });
+        this.doc.submitOp([ otRichText.Action.createDelete(1) ], { undoable: true });
+        this.doc.submitOp([ otRichText.Action.createDelete(1) ], { undoable: true });
+        this.doc.submitOp([ otRichText.Action.createDelete(1) ], { undoable: true });
+        this.doc.undo();
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('cd') ]);
+        this.doc.submitOp([ otRichText.Action.createDelete(1) ], { fixUpRedoStack: true });
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('d') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([]);
+        expect(this.doc.canRedo()).to.equal(false);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('d') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('bd') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abd') ]);
+        expect(this.doc.canUndo()).to.equal(false);
+      });
+    });
+  });
+
+  describe('submitSnapshot', function() {
+    describe('basic tests', function() {
+      it('submits a snapshot when document is not created (no callback, no options)', function(done) {
+        this.doc.on('error', function(error) {
+          expect(error).to.be.an(Error);
+          expect(error.code).to.equal(4015);
+          done();
+        });
+        this.doc.submitSnapshot(7);
+      });
+
+      it('submits a snapshot when document is not created (no callback, with options)', function(done) {
+        this.doc.on('error', function(error) {
+          expect(error).to.be.an(Error);
+          expect(error.code).to.equal(4015);
+          done();
+        });
+        this.doc.submitSnapshot(7, { source: 'test' });
+      });
+
+      it('submits a snapshot when document is not created (with callback, no options)', function(done) {
+        this.doc.on('error', done);
+        this.doc.submitSnapshot(7, function(error) {
+          expect(error).to.be.an(Error);
+          expect(error.code).to.equal(4015);
+          done();
+        });
+      });
+
+      it('submits a snapshot when document is not created (with callback, with options)', function(done) {
+        this.doc.on('error', done);
+        this.doc.submitSnapshot(7, { source: 'test' }, function(error) {
+          expect(error).to.be.an(Error);
+          expect(error.code).to.equal(4015);
+          done();
+        });
+      });
+
+      it('submits a snapshot with source (no callback)', function(done) {
+        this.doc.on('op', function(op, source) {
+          expect(op).to.eql([ otRichText.Action.createInsertText('abc') ]);
+          expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abcdef') ]);
+          expect(this.doc.canUndo()).to.equal(false);
+          expect(this.doc.canRedo()).to.equal(false);
+          expect(source).to.equal('test');
+          done();
+        }.bind(this));
+        this.doc.create([ otRichText.Action.createInsertText('def') ], otRichText.type.uri);
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('abcdef') ], { source: 'test' });
+      });
+
+      it('submits a snapshot with source (with callback)', function(done) {
+        var opEmitted = false;
+        this.doc.on('op', function(op, source) {
+          expect(op).to.eql([ otRichText.Action.createInsertText('abc') ]);
+          expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abcdef') ]);
+          expect(source).to.equal('test');
+          expect(this.doc.canUndo()).to.equal(false);
+          expect(this.doc.canRedo()).to.equal(false);
+          opEmitted = true;
+        }.bind(this));
+        this.doc.create([ otRichText.Action.createInsertText('def') ], otRichText.type.uri);
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('abcdef') ], { source: 'test' }, function(error) {
+          expect(opEmitted).to.equal(true);
+          done(error);
+        });
+      });
+
+      it('submits a snapshot without source (no callback)', function(done) {
+        this.doc.on('op', function(op, source) {
+          expect(op).to.eql([ otRichText.Action.createInsertText('abc') ]);
+          expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abcdef') ]);
+          expect(this.doc.canUndo()).to.equal(false);
+          expect(this.doc.canRedo()).to.equal(false);
+          expect(source).to.equal(true);
+          done();
+        }.bind(this));
+        this.doc.create([ otRichText.Action.createInsertText('def') ], otRichText.type.uri);
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('abcdef') ]);
+      });
+
+      it('submits a snapshot without source (with callback)', function(done) {
+        var opEmitted = false;
+        this.doc.on('op', function(op, source) {
+          expect(op).to.eql([ otRichText.Action.createInsertText('abc') ]);
+          expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abcdef') ]);
+          expect(source).to.equal(true);
+          expect(this.doc.canUndo()).to.equal(false);
+          expect(this.doc.canRedo()).to.equal(false);
+          opEmitted = true;
+        }.bind(this));
+        this.doc.create([ otRichText.Action.createInsertText('def') ], otRichText.type.uri);
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('abcdef') ], function(error) {
+          expect(opEmitted).to.equal(true);
+          done(error);
+        });
+      });
+
+      it('submits snapshots and supports undo and redo', function() {
+        this.doc.undoComposeTimeout = -1;
+        this.doc.create([ otRichText.Action.createInsertText('ghi') ], otRichText.type.uri);
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('defghi') ], { undoable: true });
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('defghi') ]);
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('abcdefghi') ], { undoable: true });
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abcdefghi') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('defghi') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ghi') ]);
+        expect(this.doc.canUndo()).to.equal(false);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('defghi') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abcdefghi') ]);
+        expect(this.doc.canRedo()).to.equal(false);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('defghi') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ghi') ]);
+        expect(this.doc.canUndo()).to.equal(false);
+      });
+
+      it('submits snapshots and composes operations', function() {
+        this.doc.create([ otRichText.Action.createInsertText('ghi') ], otRichText.type.uri);
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('defghi') ], { undoable: true });
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('defghi') ]);
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('abcdefghi') ], { undoable: true });
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abcdefghi') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ghi') ]);
+        expect(this.doc.canUndo()).to.equal(false);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abcdefghi') ]);
+        expect(this.doc.canRedo()).to.equal(false);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ghi') ]);
+        expect(this.doc.canUndo()).to.equal(false);
+      });
+
+      it('submits a snapshot and syncs it', function(done) {
+        this.doc2.on('create', function() {
+          this.doc2.submitSnapshot([ otRichText.Action.createInsertText('abcdef') ]);
+        }.bind(this));
+        this.doc.on('op', function(op, source) {
+          expect(op).to.eql([ otRichText.Action.createInsertText('abc') ]);
+          expect(source).to.equal(false);
+          expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abcdef') ]);
+          done();
+        }.bind(this));
+        this.doc2.subscribe();
+        this.doc.subscribe();
+        this.doc.create([ otRichText.Action.createInsertText('def') ], otRichText.type.uri);
+      });
+
+      it('submits undoable and fixed operations', function() {
+        this.doc.undoComposeTimeout = -1;
+        this.doc.create([], otRichText.type.uri);
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('a') ], { undoable: true });
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('ab') ], { undoable: true });
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('abc') ], { undoable: true });
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('abcd') ], { undoable: true });
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('abcde') ], { undoable: true });
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('abcdef') ], { undoable: true });
+        this.doc.undo();
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abcd') ]);
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('abc123d') ]);
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abc123d') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abc123') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ab123') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('a123') ]);
+        this.doc.undo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('123') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('a123') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('ab123') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abc123') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abc123d') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abc123de') ]);
+        this.doc.redo();
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('abc123def') ]);
+      });
+
+      it('submits a snapshot without a diffHint', function() {
+        var opCalled = 0;
+        this.doc.create([ otRichText.Action.createInsertText('aaaa') ], otRichText.type.uri);
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('aaaaa') ], { undoable: true });
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('aaaaa') ]);
+
+        this.doc.once('op', function(op) {
+          expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('aaaa') ]);
+          expect(op).to.eql([ otRichText.Action.createDelete(1) ]);
+          opCalled++;
+        }.bind(this));
+        this.doc.undo();
+
+        this.doc.once('op', function(op) {
+          expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('aaaaa') ]);
+          expect(op).to.eql([ otRichText.Action.createInsertText('a') ]);
+          opCalled++;
+        }.bind(this));
+        this.doc.redo();
+
+        expect(opCalled).to.equal(2);
+      });
+
+      it('submits a snapshot with a diffHint', function() {
+        var opCalled = 0;
+        this.doc.create([ otRichText.Action.createInsertText('aaaa') ], otRichText.type.uri);
+        this.doc.submitSnapshot([ otRichText.Action.createInsertText('aaaaa') ], { undoable: true, diffHint: 2 });
+        expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('aaaaa') ]);
+
+        this.doc.once('op', function(op) {
+          expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('aaaa') ]);
+          expect(op).to.eql([ otRichText.Action.createRetain(2), otRichText.Action.createDelete(1) ]);
+          opCalled++;
+        }.bind(this));
+        this.doc.undo();
+
+        this.doc.once('op', function(op) {
+          expect(this.doc.data).to.eql([ otRichText.Action.createInsertText('aaaaa') ]);
+          expect(op).to.eql([ otRichText.Action.createRetain(2), otRichText.Action.createInsertText('a') ]);
+          opCalled++;
+        }.bind(this));
+        this.doc.redo();
+
+        expect(opCalled).to.equal(2);
+      });
+    });
+
+    describe('no diff nor diffX', function() {
+      it('submits a snapshot (no callback)', function(done) {
+        this.doc.on('error', function(error) {
+          expect(error).to.be.an(Error);
+          expect(error.code).to.equal(4024);
+          done();
+        });
+        this.doc.create(5, invertibleType.type.uri);
+        this.doc.submitSnapshot(7);
+      });
+
+      it('submits a snapshot (with callback)', function(done) {
+        this.doc.on('error', done);
+        this.doc.create(5, invertibleType.type.uri);
+        this.doc.submitSnapshot(7, function(error) {
+          expect(error).to.be.an(Error);
+          expect(error.code).to.equal(4024);
+          done();
+        });
+      });
+    });
+
+    describe('with diff', function () {
+      it('submits a snapshot (non-undoable)', function() {
+        this.doc.create(5, invertibleType.typeWithDiff.uri);
+        this.doc.submitSnapshot(7);
+        expect(this.doc.data).to.equal(7);
+        expect(this.doc.canUndo()).to.equal(false);
+        expect(this.doc.canRedo()).to.equal(false);
+      });
+      it('submits a snapshot (undoable)', function() {
+        this.doc.create(5, invertibleType.typeWithDiff.uri);
+        this.doc.submitSnapshot(7, { undoable: true });
+        expect(this.doc.data).to.equal(7);
+        this.doc.undo();
+        expect(this.doc.data).to.equal(5);
+        this.doc.redo();
+        expect(this.doc.data).to.equal(7);
+      });
+    });
+
+    describe('with diffX', function () {
+      it('submits a snapshot (non-undoable)', function() {
+        this.doc.create(5, invertibleType.typeWithDiffX.uri);
+        this.doc.submitSnapshot(7);
+        expect(this.doc.data).to.equal(7);
+        expect(this.doc.canUndo()).to.equal(false);
+        expect(this.doc.canRedo()).to.equal(false);
+      });
+      it('submits a snapshot (undoable)', function() {
+        this.doc.create(5, invertibleType.typeWithDiffX.uri);
+        this.doc.submitSnapshot(7, { undoable: true });
+        expect(this.doc.data).to.equal(7);
+        this.doc.undo();
+        expect(this.doc.data).to.equal(5);
+        this.doc.redo();
+        expect(this.doc.data).to.equal(7);
+      });
+    });
+
+    describe('with diff and diffX', function () {
+      it('submits a snapshot (non-undoable)', function() {
+        this.doc.create(5, invertibleType.typeWithDiffAndDiffX.uri);
+        this.doc.submitSnapshot(7);
+        expect(this.doc.data).to.equal(7);
+        expect(this.doc.canUndo()).to.equal(false);
+        expect(this.doc.canRedo()).to.equal(false);
+      });
+      it('submits a snapshot (undoable)', function() {
+        this.doc.create(5, invertibleType.typeWithDiffAndDiffX.uri);
+        this.doc.submitSnapshot(7, { undoable: true });
+        expect(this.doc.data).to.equal(7);
+        this.doc.undo();
+        expect(this.doc.data).to.equal(5);
+        this.doc.redo();
+        expect(this.doc.data).to.equal(7);
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Undo/redo for locally submitted operations/snapshots. It works with OT types that implement `invert` or `applyAndInvert`.
- `submitSnapshot` for submitting snapshots, instead of operations. 2 snapshots are compared to generate an operation. It requires `diff` or `diffX` to work.
- Users can choose, if an operation should be undoable or not.
- No empty undo/redo operations, if the OT type supports `isNoop`.
- Customizable undo stack size limit.
- Undo operations can be composed, if OT type supports `compose` or `composeSimilar`.
- Customizable time limit for composing operations.
- Options to control how local, non-undoable operations should affect the undo and redo stacks - transform by default, or compose into the top operation on the stack.

PS. I'll open a separate PR to update https://github.com/ottypes/docs with the new functions.