### PR TITLE
[WIP] Promisify client-facing methods

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -1,6 +1,7 @@
 var emitter = require('../emitter');
 var ShareDBError = require('../error');
 var types = require('../types');
+var util = require('../util');
 
 /**
  * A Doc is a client's view on a sharejs document.
@@ -102,6 +103,7 @@ function Doc(connection, collection, id) {
 emitter.mixin(Doc);
 
 Doc.prototype.destroy = function(callback) {
+  var { promise, callback } = util.promisify(callback);
   var doc = this;
   doc.whenNothingPending(function() {
     doc.connection._destroyDoc(doc);
@@ -110,6 +112,8 @@ Doc.prototype.destroy = function(callback) {
     }
     if (callback) callback();
   });
+
+  return promise;
 };
 
 
@@ -148,6 +152,7 @@ Doc.prototype._setType = function(newType) {
 // @param snapshot.type
 // @param callback
 Doc.prototype.ingestSnapshot = function(snapshot, callback) {
+  var { promise, callback } = util.promisify(callback);
   if (!snapshot) return callback && callback();
 
   if (typeof snapshot.v !== 'number') {
@@ -192,15 +197,16 @@ Doc.prototype.ingestSnapshot = function(snapshot, callback) {
     this.type.deserialize(snapshot.data) :
     snapshot.data;
   this.emit('load');
-  callback && callback();
+  return callback && callback();
 };
 
 Doc.prototype.whenNothingPending = function(callback) {
+  var { promise, callback } = util.promisify(callback);
   if (this.hasPending()) {
     this.once('nothing pending', callback);
-    return;
+    return promise;
   }
-  callback();
+  return callback();
 };
 
 Doc.prototype.hasPending = function() {
@@ -371,28 +377,33 @@ Doc.prototype._resubscribe = function() {
 
 // Request the current document snapshot or ops that bring us up to date
 Doc.prototype.fetch = function(callback) {
+  var { promise, callback } = util.promisify(callback);
   if (this.connection.canSend) {
     var isDuplicate = this.connection.sendFetch(this);
     pushActionCallback(this.inflightFetch, isDuplicate, callback);
-    return;
+    return promise;
   }
   this.pendingFetch.push(callback);
+  return promise;
 };
 
 // Fetch the initial document and keep receiving updates
 Doc.prototype.subscribe = function(callback) {
+  var { promise, callback } = util.promisify(callback);
   this.wantSubscribe = true;
   if (this.connection.canSend) {
     var isDuplicate = this.connection.sendSubscribe(this);
     pushActionCallback(this.inflightSubscribe, isDuplicate, callback);
-    return;
+    return promise;
   }
   this.pendingFetch.push(callback);
+  return promise;
 };
 
 // Unsubscribe. The data will stay around in local memory, but we'll stop
 // receiving updates
 Doc.prototype.unsubscribe = function(callback) {
+  var { promise, callback } = util.promisify(callback);
   this.wantSubscribe = false;
   // The subscribed state should be conservative in indicating when we are
   // subscribed on the server. We'll actually be unsubscribed some time
@@ -402,9 +413,10 @@ Doc.prototype.unsubscribe = function(callback) {
   if (this.connection.canSend) {
     var isDuplicate = this.connection.sendUnsubscribe(this);
     pushActionCallback(this.inflightUnsubscribe, isDuplicate, callback);
-    return;
+    return promise;
   }
   if (callback) process.nextTick(callback);
+  return promise;
 };
 
 function pushActionCallback(inflight, isDuplicate, callback) {
@@ -739,6 +751,7 @@ Doc.prototype._tryCompose = function(op) {
 //
 // @fires before op, op, after op
 Doc.prototype.submitOp = function(component, options, callback) {
+  var { promise, callback } = util.promisify(callback);
   if (typeof options === 'function') {
     callback = options;
     options = null;
@@ -746,6 +759,7 @@ Doc.prototype.submitOp = function(component, options, callback) {
   var op = {op: component};
   var source = options && options.source;
   this._submit(op, source, callback);
+  return promise;
 };
 
 // Create the document, which in ShareJS semantics means to set its type. Every
@@ -758,6 +772,7 @@ Doc.prototype.submitOp = function(component, options, callback) {
 // @param options  {source: ...}
 // @param callback  called when operation submitted
 Doc.prototype.create = function(data, type, options, callback) {
+  var { promise, callback } = util.promisify(callback);
   if (typeof type === 'function') {
     callback = type;
     options = null;
@@ -777,6 +792,7 @@ Doc.prototype.create = function(data, type, options, callback) {
   var op = {create: {type: type, data: data}};
   var source = options && options.source;
   this._submit(op, source, callback);
+  return promise;
 };
 
 // Delete the document. This creates and submits a delete operation to the
@@ -787,6 +803,7 @@ Doc.prototype.create = function(data, type, options, callback) {
 // @param options  {source: ...}
 // @param callback  called when operation submitted
 Doc.prototype.del = function(options, callback) {
+  var { promise, callback } = util.promisify(callback);
   if (typeof options === 'function') {
     callback = options;
     options = null;
@@ -799,6 +816,7 @@ Doc.prototype.del = function(options, callback) {
   var op = {del: true};
   var source = options && options.source;
   this._submit(op, source, callback);
+  return promise;
 };
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,3 +1,4 @@
+var Promise = require('es6-promise').Promise;
 
 exports.doNothing = doNothing;
 function doNothing() {}
@@ -5,4 +6,30 @@ function doNothing() {}
 exports.hasKeys = function(object) {
   for (var key in object) return true;
   return false;
+};
+
+exports.promisify = function(callback) {
+  var promise;
+
+  // Don't create a Promise if a callback was provided, to avoid unnecessary confusion with logic forks
+  if (typeof callback !== 'function') {
+    promise = new Promise(function (resolve, reject) {
+      callback = function (error, result) {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(result);
+        }
+
+        // Return the promise from the callback so that we can have early exits from functions like:
+        // return callback()
+        return promise;
+      };
+    });
+  }
+
+  return {
+    promise: promise,
+    callback: callback
+  };
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "arraydiff": "^0.1.1",
     "async": "^1.4.2",
     "deep-is": "^0.1.3",
+    "es6-promise": "^4.2.4",
     "hat": "0.0.3",
     "make-error": "^1.1.1",
     "ot-json0": "^1.0.1"


### PR DESCRIPTION
This change makes client-facing methods return a `Promise` when no `callback` is provided.

## Motivation

 - As a consumer of ShareDB using modern JavaScript with `Promise`s and `async`/`await`, I'm bored of using callbacks, which are inconsistent with the rest of my codebase
 - As a contributor to ShareDB, I'm bored of tests with deeply nested callbacks (and other maintenance burdens imposed by callbacks)

## Work so far

This is a work-in-progress pull request in order to get opinions on how people feel about this as a feature; and how it should be implemented.

So far, I have added a `promisify` method to `util`, which has the following signature:

`util.promisify = function(callback): { promise, callback }`

If a `callback` is provided, then `promise` is `undefined`, and the returned `callback` is the same as the provided `callback`. This is to avoid clients inadvertently creating logic forks, where code follows both a callback and a `Promise`.

If `callback` is not a `function`, then the returned `callback` is a `function` that will `resolve` or `reject` the returned `promise`.

Also, for exiting functions early, `callback()` will return the `promise`, so you can write things like: `if (condition) return callback();`.

## Discussion

Through this work I've discovered at least two points for discussion:

 - Implementing this in `Doc` as it currently is means that `emit` is basically never called, because `callback` will now _always_ be defined. I don't know enough about how people use these events, but we could potentially have consumers configure ShareDB to enable promises? If promises are not enabled, then `util.promisify` will _always_ return the same `callback` as provided (even if it's falsy).
 - The signature for a `Query` callback is `callback(error, results, extra)`, but a `Promise` can only `resolve` a single argument. Should we combine this into `{ results, extra }` for the purposes of a `Promise`?
 - Do we bother including a polyfill for `Promise`, or just not bother promisifying if `Promise` is undefined? (And if we avoid a polyfill, how do I get the linter to calm down without targeting ES6?)