### PR TITLE
Update mocha and fix 2 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 node_js:
   - "10"
-  - "9"
   - "8"
   - "6"
-  - "4"
-script: "npm run jshint && npm run test-cover"
+script: "ln -s .. node_modules/sharedb; npm run jshint && npm run test-cover"
 # Send coverage data to Coveralls
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "expect.js": "^0.3.1",
     "istanbul": "^0.4.2",
     "jshint": "^2.9.2",
-    "mocha": "^3.2.0",
+    "mocha": "^5.2.0",
     "sharedb-mingo-memory": "^1.0.0-beta"
   },
   "scripts": {

--- a/test/client/submit.js
+++ b/test/client/submit.js
@@ -609,7 +609,7 @@ describe('client submit', function() {
           if (err) return done(err);
           doc.pause();
           var calledBack = false;
-          doc.on('error', function(err) {
+          doc.on('error', function() {
             expect(calledBack).equal(true);
             done();
           });

--- a/test/client/submit.js
+++ b/test/client/submit.js
@@ -608,11 +608,16 @@ describe('client submit', function() {
         doc2.del(function(err) {
           if (err) return done(err);
           doc.pause();
+          var calledBack = false;
+          doc.on('error', function(err) {
+            expect(calledBack).equal(true);
+            done();
+          });
           doc.submitOp({p: ['age'], na: 1}, function(err) {
             expect(err).ok();
             expect(doc.version).equal(2);
             expect(doc.data).eql(undefined);
-            done();
+            calledBack = true;
           });
           doc.fetch();
         });
@@ -632,11 +637,16 @@ describe('client submit', function() {
           doc2.create({age: 5}, function(err) {
             if (err) return done(err);
             doc.pause();
+            var calledBack = false;
+            doc.on('error', function() {
+              expect(calledBack).equal(true);
+              done();
+            });
             doc.create({age: 9}, function(err) {
               expect(err).ok();
               expect(doc.version).equal(3);
               expect(doc.data).eql({age: 5});
-              done();
+              calledBack = true;
             });
             doc.fetch();
           });


### PR DESCRIPTION
See https://github.com/mochajs/mocha/releases/tag/v5.0.2.

The tests were failing because mocha@5.0.2+ crashes on unhandled exceptions resulting from unhandled "error" events. Earlier versions ignored those exceptions.

@ericyhwang this PR would also enable us to use the latest mocha version in sharedb-mongo.