### PR TITLE
Fix flaky maxSubmitRetries test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ node_js:
   - "8"
   - "6"
   - "4"
-script: "npm run jshint && npm run test-cover"
+script: "ln -s .. node_modules/sharedb; npm run jshint && npm run test-cover"
 # Send coverage data to Coveralls
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/test/client/submit.js
+++ b/test/client/submit.js
@@ -519,16 +519,28 @@ describe('client submit', function() {
         if (err) return done(err);
         var docCallback;
         var doc2Callback;
+        // The submit retry happens just after an op is committed. This hook into the middleware
+        // catches both ops just before they're about to be committed. This ensures that both ops
+        // are certainly working on the same snapshot (ie one op hasn't been committed before the
+        // other fetches the snapshot to apply to). By storing the callbacks, we can then
+        // manually trigger the callbacks, first calling doc, and when we know that's been committed,
+        // we then commit doc2.
         backend.use('commit', function (request, callback) {
           if (request.op.op[0].na === 2) docCallback = callback;
           if (request.op.op[0].na === 7) doc2Callback = callback;
 
+          // Wait until both ops have been applied to the same snapshot and are about to be committed
           if (docCallback && doc2Callback) {
+            // Trigger the first op's commit and then the second one later, which will cause the
+            // second op to retry
             docCallback();
           }
         });
         doc.submitOp({p: ['age'], na: 2}, function (error) {
           if (error) return done(error);
+          // When we know the first op has been committed, we try to commit the second op, which will
+          // fail because it's working on an out-of-date snapshot. It will retry, but exceed the
+          // maxSubmitRetries limit of 0
           doc2Callback();
         });
         doc2.submitOp({p: ['age'], na: 7}, function (error) {


### PR DESCRIPTION
This is a slightly speculative fix for a test that fails intermittently
on `sharedb-mongo`. I believe these intermittent failures are due to a
race condition in a concurrency test.

The test works by attempting to fire two commits off at the same time,
and hoping that one of them is committed just before the other, so that
a `SubmitRequest.retry` is triggered whilst the `maxSubmitRetries` is
set to `0`, resulting in an error that is expected.

However, I believe it's possible for these commits to (in some cases)
happen sequentially rather than concurrently, and fail to error.

This change attempts to force them into this retry condition by:

  - Catching both ops in the `commit` middleware, _just_ before they're
    about to be committed (and hit a `retry` if applicable)
  - Waiting until both ops have reached this state
  - Triggering the first op's `commit`
  - Then in the callback of that op, triggering the second op's `commit`
  - The second op should now find that the first op has beaten it to
    committing, and trigger a `retry`