### PR TITLE
Warn about using deprecated features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 node_js:
   - "10"
-  - "9"
   - "8"
   - "6"
-  - "4"
-script: "npm run jshint && npm run test-cover"
+script: "ln -s .. node_modules/sharedb; npm run jshint && npm run test-cover"
 # Send coverage data to Coveralls
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ Register a new middleware.
   One of:
   * `'connect'`: A new client connected to the server.
   * `'op'`: An operation was loaded from the database.
-  * `'doc'`: DEPRECATED: A snapshot was loaded from the database. Please use 'readSnapshots'
   * `'readSnapshots'`: Snapshot(s) were loaded from the database for a fetch or subscribe of a query or document
   * `'query'`: A query is about to be sent to the database
   * `'submit'`: An operation is about to be submitted to the database

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -9,6 +9,8 @@ var projections = require('./projections');
 var QueryEmitter = require('./query-emitter');
 var StreamSocket = require('./stream-socket');
 var SubmitRequest = require('./submit-request');
+var warnDeprecatedDoc = true;
+var warnDeprecatedAfterSubmit = true;
 
 function Backend(options) {
   if (!(this instanceof Backend)) return new Backend(options);
@@ -71,6 +73,11 @@ Backend.prototype.MIDDLEWARE_ACTIONS = {
 };
 
 Backend.prototype._shimDocAction = function() {
+  if (warnDeprecatedDoc) {
+    warnDeprecatedDoc = false;
+    console.warn('DEPRECATED: "doc" middleware action. Use "readSnapshots" instead. Pass `disableDocAction: true` option to ShareDB to disable the "doc" action and this warning.');
+  }
+
   var backend = this;
   this.use(this.MIDDLEWARE_ACTIONS.readSnapshots, function(request, callback) {
     async.each(request.snapshots, function(snapshot, eachCb) {
@@ -83,6 +90,11 @@ Backend.prototype._shimDocAction = function() {
 // Shim for backwards compatibility with deprecated middleware action name.
 // The action 'after submit' is now 'afterSubmit'.
 Backend.prototype._shimAfterSubmit = function() {
+  if (warnDeprecatedAfterSubmit) {
+    warnDeprecatedAfterSubmit = false;
+    console.warn('DEPRECATED: "after submit" middleware action. Use "afterSubmit" instead. Pass `disableSpaceDelimitedActions: true` option to ShareDB to disable the "after submit" action and this warning.');
+  }
+
   var backend = this;
   this.use(backend.MIDDLEWARE_ACTIONS.afterSubmit, function(request, callback) {
     backend.trigger(backend.MIDDLEWARE_ACTIONS['after submit'], request.agent, request, callback);


### PR DESCRIPTION
I've also removed `doc` from README.md because the other deprecated action, "after submit" was not there either.