### PR TITLE
Remove sharedb-mingo-memory circular dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ node_js:
   - "10"
   - "8"
   - "6"
-script: "ln -s .. node_modules/sharedb; npm run jshint && npm run test-cover"
+script: "npm run jshint && npm run test-cover"
 # Send coverage data to Coveralls
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "expect.js": "^0.3.1",
     "istanbul": "^0.4.2",
     "jshint": "^2.9.2",
-    "mocha": "^5.2.0",
-    "sharedb-mingo-memory": "^1.0.0-beta"
+    "mocha": "^5.2.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha && npm run jshint",

--- a/test/client/query-subscribe.js
+++ b/test/client/query-subscribe.js
@@ -413,14 +413,13 @@ describe('client query subscribe', function() {
 
   it('changing a sorted property moves in a subscribed query', function(done) {
     var connection = this.backend.connect();
-    var matchAllDbQuery = this.matchAllDbQuery;
 
     async.parallel([
       function(cb) { connection.get('dogs', 'fido').create({age: 3}, cb); },
       function(cb) { connection.get('dogs', 'spot').create({age: 5}, cb); }
     ], function(err) {
       if (err) return done(err);
-      var dbQuery = getQuery({query: matchAllDbQuery, sort: [['age', 1]]});
+      var dbQuery = getQuery({query: {}, sort: [['age', 1]]});
       var query = connection.createSubscribeQuery(
         'dogs',
         dbQuery,

--- a/test/db-memory.js
+++ b/test/db-memory.js
@@ -2,11 +2,6 @@ var expect = require('expect.js');
 var DB = require('../lib/db');
 var MemoryDB = require('../lib/db/memory');
 
-// Extend from MemoryDB as defined in this package, not the one that
-// sharedb-mingo-memory depends on.
-var ShareDbMingo = require('sharedb-mingo-memory').extendMemoryDB(MemoryDB);
-var getQuery = require('sharedb-mingo-memory/get-query');
-
 describe('DB base class', function() {
   it('can call db.close() without callback', function() {
     var db = new DB();
@@ -59,10 +54,76 @@ describe('DB base class', function() {
   });
 });
 
+
+// Extension of MemoryDB that supports query filters and sorts on simple
+// top-level properties, which is enough for the core ShareDB tests on
+// query subscription updating.
+function BasicQueryableMemoryDB() {
+  MemoryDB.apply(this, arguments);
+}
+BasicQueryableMemoryDB.prototype = Object.create(MemoryDB.prototype);
+BasicQueryableMemoryDB.prototype.constructor = BasicQueryableMemoryDB;
+
+BasicQueryableMemoryDB.prototype._querySync = function(snapshots, query, options) {
+  if (query.filter) {
+    snapshots = snapshots.filter(function(snapshot) {
+      for (var queryKey in query.filter) {
+        // This fake only supports simple property equality filters, so
+        // throw an error on Mongo-like filter properties with dots.
+        if (queryKey.includes('.')) {
+          throw new Error('Only simple property filters are supported, got:', queryKey);
+        }
+        if (snapshot.data[queryKey] !== query.filter[queryKey]) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }
+
+  if (query.sort) {
+    if (!Array.isArray(query.sort)) {
+      throw new Error('query.sort must be an array');
+    }
+    if (query.sort.length) {
+      snapshots.sort(snapshotComparator(query.sort));
+    }
+  }
+
+  return {snapshots: snapshots};
+};
+
+// sortProperties is an array whose items are each [propertyName, direction].
+function snapshotComparator(sortProperties) {
+  return function(snapshotA, snapshotB) {
+    for (var i = 0; i < sortProperties.length; i++) {
+      var sortProperty = sortProperties[i];
+      var sortKey = sortProperty[0];
+      var sortDirection = sortProperty[1];
+
+      var aPropVal = snapshotA.data[sortKey];
+      var bPropVal = snapshotB.data[sortKey];
+      if (aPropVal < bPropVal) {
+        return -1 * sortDirection;
+      } else if (aPropVal > bPropVal) {
+        return sortDirection;
+      } else if (aPropVal === bPropVal) {
+        continue;
+      } else {
+        throw new Error('Could not compare ' + aPropVal + ' and ' + bPropVal);
+      }
+    }
+    return 0;
+  };
+}
+
+// Run all the DB-based tests against the BasicQueryableMemoryDB.
 require('./db')({
   create: function(callback) {
-    var db = new ShareDbMingo();
+    var db = new BasicQueryableMemoryDB();
     callback(null, db);
   },
-  getQuery: getQuery
+  getQuery: function(options) {
+    return {filter: options.query, sort: options.sort};
+  }
 });


### PR DESCRIPTION
sharedb had depended on sharedb-mingo-memory for 4 tests, mostly relating to query subscriptions. This removes that dependency by faking out enough of MemoryDB in the tests to handle simple queries. (MemoryDB itself returns all documents in a collection given a query.)

I didn't want to put the simple query handling in MemoryDB, as that might lead people to think it may do more than it can. We don't want to re-implement all of Mingo, either.