### PR TITLE
Expose `fetchSnapshot` requested version in `readSnapshots` middleware

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -77,6 +77,13 @@ Backend.prototype.MIDDLEWARE_ACTIONS = {
   submit: 'submit'
 };
 
+Backend.prototype.SNAPSHOT_TYPES = {
+  // The current snapshot is being fetched (eg through backend.fetch)
+  current: 'current',
+  // An historical snapshot is being fetched (eg through backend.fetchSnapshot)
+  historical: 'historical'
+};
+
 Backend.prototype._shimDocAction = function() {
   if (warnDeprecatedDoc) {
     warnDeprecatedDoc = false;
@@ -264,15 +271,7 @@ Backend.prototype._sanitizeOpsBulk = function(agent, projection, collection, ops
   }, callback);
 };
 
-Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, request, callback) {
-  if (typeof request === 'function') {
-    callback = request;
-    request = {};
-  }
-
-  request.collection = collection;
-  request.snapshots = snapshots;
-
+Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, snapshotType, callback) {
   if (projection) {
     try {
       projections.projectSnapshots(projection.fields, snapshots);
@@ -280,6 +279,12 @@ Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, s
       return callback(err);
     }
   }
+
+  var request = {
+    collection: collection,
+    snapshots: snapshots,
+    snapshotType: snapshotType
+  };
 
   this.trigger(this.MIDDLEWARE_ACTIONS.readSnapshots, agent, request, callback);
 };
@@ -360,7 +365,7 @@ Backend.prototype.fetch = function(agent, index, id, callback) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
-    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, function(err) {
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, backend.SNAPSHOT_TYPES.current, function(err) {
       if (err) return callback(err);
       backend.emit('timing', 'fetch', Date.now() - start, request);
       callback(null, snapshot);
@@ -384,7 +389,7 @@ Backend.prototype.fetchBulk = function(agent, index, ids, callback) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = backend._getSnapshotsFromMap(ids, snapshotMap);
-    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, function(err) {
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, backend.SNAPSHOT_TYPES.current, function(err) {
       if (err) return callback(err);
       backend.emit('timing', 'fetchBulk', Date.now() - start, request);
       callback(null, snapshotMap);
@@ -572,7 +577,7 @@ Backend.prototype._query = function(agent, request, callback) {
   var backend = this;
   request.db.query(request.collection, request.query, request.fields, request.options, function(err, snapshots, extra) {
     if (err) return callback(err);
-    backend._sanitizeSnapshots(agent, request.snapshotProjection, request.collection, snapshots, function(err) {
+    backend._sanitizeSnapshots(agent, request.snapshotProjection, request.collection, snapshots, backend.SNAPSHOT_TYPES.current, function(err) {
       callback(err, snapshots, extra);
     });
   });
@@ -610,8 +615,8 @@ Backend.prototype.fetchSnapshot = function(agent, index, id, version, callback) 
     if (error) return callback(error);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
-    var middlewareRequest = { v: version };
-    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, middlewareRequest, function (error) {
+    var snapshotType = backend.SNAPSHOT_TYPES.historical;
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, snapshotType, function (error) {
       if (error) return callback(error);
       backend.emit('timing', 'fetchSnapshot', Date.now() - start, request);
       callback(null, snapshot);

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -264,7 +264,15 @@ Backend.prototype._sanitizeOpsBulk = function(agent, projection, collection, ops
   }, callback);
 };
 
-Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, callback) {
+Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, request, callback) {
+  if (typeof request === 'function') {
+    callback = request;
+    request = {};
+  }
+
+  request.collection = collection;
+  request.snapshots = snapshots;
+
   if (projection) {
     try {
       projections.projectSnapshots(projection.fields, snapshots);
@@ -272,7 +280,7 @@ Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, s
       return callback(err);
     }
   }
-  var request = {collection: collection, snapshots: snapshots};
+
   this.trigger(this.MIDDLEWARE_ACTIONS.readSnapshots, agent, request, callback);
 };
 
@@ -602,7 +610,8 @@ Backend.prototype.fetchSnapshot = function(agent, index, id, version, callback) 
     if (error) return callback(error);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
-    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, function (error) {
+    var middlewareRequest = { v: version };
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, middlewareRequest, function (error) {
       if (error) return callback(error);
       backend.emit('timing', 'fetchSnapshot', Date.now() - start, request);
       callback(null, snapshot);

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -80,8 +80,8 @@ Backend.prototype.MIDDLEWARE_ACTIONS = {
 Backend.prototype.SNAPSHOT_TYPES = {
   // The current snapshot is being fetched (eg through backend.fetch)
   current: 'current',
-  // An historical snapshot is being fetched (eg through backend.fetchSnapshot)
-  historical: 'historical'
+  // A specific snapshot is being fetched by version (eg through backend.fetchSnapshot)
+  byVersion: 'byVersion'
 };
 
 Backend.prototype._shimDocAction = function() {
@@ -615,7 +615,7 @@ Backend.prototype.fetchSnapshot = function(agent, index, id, version, callback) 
     if (error) return callback(error);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
-    var snapshotType = backend.SNAPSHOT_TYPES.historical;
+    var snapshotType = backend.SNAPSHOT_TYPES.byVersion;
     backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, snapshotType, function (error) {
       if (error) return callback(error);
       backend.emit('timing', 'fetchSnapshot', Date.now() - start, request);

--- a/lib/query-emitter.js
+++ b/lib/query-emitter.js
@@ -186,7 +186,8 @@ QueryEmitter.prototype.queryPoll = function(callback) {
         emitter.db.getSnapshotBulk(emitter.collection, inserted, emitter.fields, null, function(err, snapshotMap) {
           if (err) return emitter._finishPoll(err, callback, pending);
           var snapshots = emitter.backend._getSnapshotsFromMap(inserted, snapshotMap);
-          emitter.backend._sanitizeSnapshots(emitter.agent, emitter.snapshotProjection, emitter.collection, snapshots, function(err) {
+          var snapshotType = emitter.backend.SNAPSHOT_TYPES.current;
+          emitter.backend._sanitizeSnapshots(emitter.agent, emitter.snapshotProjection, emitter.collection, snapshots, snapshotType, function(err) {
             if (err) return emitter._finishPoll(err, callback, pending);
             emitter._emitTiming('queryEmitter.pollGetSnapshotBulk', start);
             var diff = mapDiff(idsDiff, snapshotMap);
@@ -234,7 +235,8 @@ QueryEmitter.prototype.queryPollDoc = function(id, callback) {
       emitter.db.getSnapshot(emitter.collection, id, emitter.fields, null, function(err, snapshot) {
         if (err) return callback(err);
         var snapshots = [snapshot];
-        emitter.backend._sanitizeSnapshots(emitter.agent, emitter.snapshotProjection, emitter.collection, snapshots, function(err) {
+        var snapshotType = emitter.backend.SNAPSHOT_TYPES.current;
+        emitter.backend._sanitizeSnapshots(emitter.agent, emitter.snapshotProjection, emitter.collection, snapshots, snapshotType, function(err) {
           if (err) return callback(err);
           emitter.onDiff([new arraydiff.InsertDiff(index, snapshots)]);
           emitter._emitTiming('queryEmitter.pollDocGetSnapshot', start);

--- a/test/client/snapshot-request.js
+++ b/test/client/snapshot-request.js
@@ -228,7 +228,7 @@ describe('SnapshotRequest', function () {
         backend.use(backend.MIDDLEWARE_ACTIONS.readSnapshots,
           function (request) {
             expect(request.snapshots[0]).to.eql(v3);
-            expect(request.v).to.be(3);
+            expect(request.snapshotType).to.be(backend.SNAPSHOT_TYPES.historical);
             done();
           }
         );

--- a/test/client/snapshot-request.js
+++ b/test/client/snapshot-request.js
@@ -228,11 +228,12 @@ describe('SnapshotRequest', function () {
         backend.use(backend.MIDDLEWARE_ACTIONS.readSnapshots,
           function (request) {
             expect(request.snapshots[0]).to.eql(v3);
+            expect(request.v).to.be(3);
             done();
           }
         );
 
-        backend.connect().fetchSnapshot('books', 'don-quixote', function () { });
+        backend.connect().fetchSnapshot('books', 'don-quixote', 3, function () { });
       });
 
       it('can have its snapshot manipulated in the middleware', function (done) {

--- a/test/client/snapshot-request.js
+++ b/test/client/snapshot-request.js
@@ -228,7 +228,7 @@ describe('SnapshotRequest', function () {
         backend.use(backend.MIDDLEWARE_ACTIONS.readSnapshots,
           function (request) {
             expect(request.snapshots[0]).to.eql(v3);
-            expect(request.snapshotType).to.be(backend.SNAPSHOT_TYPES.historical);
+            expect(request.snapshotType).to.be(backend.SNAPSHOT_TYPES.byVersion);
             done();
           }
         );


### PR DESCRIPTION
In the `readSnapshots` middleware, it's currently impossible to
determine whether a snapshot is being returned as the result of a
`fetch` or a `fetchSnaphot`.

This change adds a version `v` field to the `request` when the
middleware is invoked from `fetchSnapshot`. This field is populated with
the value of the requested version, and can be used to determine that
the snapshot is the result of a `fetchSnapshot` rather than a `fetch`.