### PR TITLE
Add a `NoOpMilestoneDB` implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,3 +420,5 @@ The `41xx` and `51xx` codes are reserved for use by ShareDB DB adapters, and the
 * 5016 - _unsubscribe PubSub method unimplemented
 * 5017 - _publish PubSub method unimplemented
 * 5018 - Required QueryEmitter listener not assigned
+* 5019 - getMilestoneSnapshot MilestoneDB method unimplemented
+* 5020 - saveMilestoneSnapshot MilestoneDB method unimplemented

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -3,7 +3,7 @@ var Agent = require('./agent');
 var Connection = require('./client/connection');
 var emitter = require('./emitter');
 var MemoryDB = require('./db/memory');
-var MilestoneDB = require('./milestone-db');
+var NoOpMilestoneDB = require('./milestone-db/no-op');
 var MemoryPubSub = require('./pubsub/memory');
 var ot = require('./ot');
 var projections = require('./projections');
@@ -25,7 +25,7 @@ function Backend(options) {
   this.pubsub = options.pubsub || new MemoryPubSub();
   // This contains any extra databases that can be queried
   this.extraDbs = options.extraDbs || {};
-  this.milestoneDb = options.milestoneDb || new MilestoneDB();
+  this.milestoneDb = options.milestoneDb || new NoOpMilestoneDB();
 
   // Map from projected collection -> {type, fields}
   this.projections = {};

--- a/lib/client/snapshot-request.js
+++ b/lib/client/snapshot-request.js
@@ -11,7 +11,7 @@ function SnapshotRequest(connection, requestId, collection, id, version, callbac
     throw new Error('Callback is required for SnapshotRequest');
   }
 
-  if (!this.isValidVersion(version)) {
+  if (!util.isValidVersion(version)) {
     throw new Error('Snapshot version must be a positive integer or null');
   }
 
@@ -25,18 +25,6 @@ function SnapshotRequest(connection, requestId, collection, id, version, callbac
   this.sent = false;
 }
 emitter.mixin(SnapshotRequest);
-
-SnapshotRequest.prototype.isValidVersion = function (version) {
-  if (version === null) {
-    return true;
-  }
-
-  if (!util.isInteger(version)) {
-    return false;
-  }
-
-  return version >= 0;
-}
 
 SnapshotRequest.prototype.send = function () {
   if (!this.connection.canSend) {

--- a/lib/milestone-db/index.js
+++ b/lib/milestone-db/index.js
@@ -1,5 +1,6 @@
 var emitter = require('../emitter');
 var ShareDBError = require('../error');
+var util = require('../util');
 
 module.exports = MilestoneDB;
 function MilestoneDB(options) {
@@ -39,4 +40,9 @@ MilestoneDB.prototype.saveMilestoneSnapshot = function (collection, snapshot, ca
   var error = new ShareDBError(5020, 'saveMilestoneSnapshot MilestoneDB method unimplemented');
   if (callback) return process.nextTick(callback, error);
   this.emit('error', error);
+};
+
+MilestoneDB.prototype._isValidVersion = function (version) {
+  if (version == null) return true;
+  return util.isInteger(version) && version >= 0;
 };

--- a/lib/milestone-db/index.js
+++ b/lib/milestone-db/index.js
@@ -43,6 +43,5 @@ MilestoneDB.prototype.saveMilestoneSnapshot = function (collection, snapshot, ca
 };
 
 MilestoneDB.prototype._isValidVersion = function (version) {
-  if (version == null) return true;
-  return util.isInteger(version) && version >= 0;
+  return util.isValidVersion(version);
 };

--- a/lib/milestone-db/index.js
+++ b/lib/milestone-db/index.js
@@ -1,4 +1,5 @@
 var emitter = require('../emitter');
+var ShareDBError = require('../error');
 
 module.exports = MilestoneDB;
 function MilestoneDB(options) {
@@ -23,17 +24,19 @@ MilestoneDB.prototype.close = function(callback) {
  *   the signature (error, snapshot) => void;
  */
 MilestoneDB.prototype.getMilestoneSnapshot = function (collection, id, version, callback) {
-  process.nextTick(callback, null, undefined);
+  var error = new ShareDBError(5019, 'getMilestoneSnapshot MilestoneDB method unimplemented');
+  if (callback) return process.nextTick(callback, error);
+  this.emit('error', error);
 };
 
 /**
  * @param {string} collection - name of the snapshot's collection
  * @param {Snapshot} snapshot - the milestone snapshot to save
  * @param {Function} callback (optional) - a callback to invoke after the snapshot has been saved.
- *   Should have the signature (error, wasSaved) => void;
+ *   Should have the signature (error) => void;
  */
 MilestoneDB.prototype.saveMilestoneSnapshot = function (collection, snapshot, callback) {
-  var saved = false;
-  if (callback) return process.nextTick(callback, null, saved);
-  this.emit('save', saved, collection, snapshot);
+  var error = new ShareDBError(5020, 'saveMilestoneSnapshot MilestoneDB method unimplemented');
+  if (callback) return process.nextTick(callback, error);
+  this.emit('error', error);
 };

--- a/lib/milestone-db/memory.js
+++ b/lib/milestone-db/memory.js
@@ -24,8 +24,8 @@ MemoryMilestoneDB.prototype = Object.create(MilestoneDB.prototype);
 
 MemoryMilestoneDB.prototype.getMilestoneSnapshot = function (collection, id, version, callback) {
   if (!callback) callback = function () {};
-  if (!collection) return process.nextTick(callback, new ShareDBError(4001, 'Invalid collection'));
-  if (!id) return process.nextTick(callback, new ShareDBError(4001, 'Invalid ID'));
+  if (!collection) return process.nextTick(callback, new ShareDBError(4001, 'Missing collection'));
+  if (!id) return process.nextTick(callback, new ShareDBError(4001, 'Missing ID'));
   if (!this._isValidVersion(version)) return process.nextTick(callback, new ShareDBError(4001, 'Invalid version'));
 
   var milestoneSnapshots = this._getMilestoneSnapshotsSync(collection, id);
@@ -33,7 +33,7 @@ MemoryMilestoneDB.prototype.getMilestoneSnapshot = function (collection, id, ver
   var milestoneSnapshot;
   for (var i = 0; i < milestoneSnapshots.length; i++) {
     var nextMilestoneSnapshot = milestoneSnapshots[i];
-    if (nextMilestoneSnapshot.v <= version || version == null) {
+    if (nextMilestoneSnapshot.v <= version || version === null) {
       milestoneSnapshot = nextMilestoneSnapshot;
     } else {
       break;
@@ -49,8 +49,8 @@ MemoryMilestoneDB.prototype.saveMilestoneSnapshot = function (collection, snapsh
     this.emit('save', collection, snapshot);
   }.bind(this);
 
-  if (!collection) return callback(new ShareDBError(4001, 'Invalid collection'));
-  if (!snapshot) return callback(new ShareDBError(4001, 'Invalid snapshot'));
+  if (!collection) return callback(new ShareDBError(4001, 'Missing collection'));
+  if (!snapshot) return callback(new ShareDBError(4001, 'Missing snapshot'));
 
   var milestoneSnapshots = this._getMilestoneSnapshotsSync(collection, snapshot.id);
   milestoneSnapshots.push(snapshot);

--- a/lib/milestone-db/memory.js
+++ b/lib/milestone-db/memory.js
@@ -1,4 +1,5 @@
 var MilestoneDB = require('./index');
+var ShareDBError = require('../error');
 
 /**
  * In-memory ShareDB milestone database
@@ -22,12 +23,17 @@ function MemoryMilestoneDB(options) {
 MemoryMilestoneDB.prototype = Object.create(MilestoneDB.prototype);
 
 MemoryMilestoneDB.prototype.getMilestoneSnapshot = function (collection, id, version, callback) {
+  if (!callback) callback = function () {};
+  if (!collection) return process.nextTick(callback, new ShareDBError(4001, 'Invalid collection'));
+  if (!id) return process.nextTick(callback, new ShareDBError(4001, 'Invalid ID'));
+  if (!this._isValidVersion(version)) return process.nextTick(callback, new ShareDBError(4001, 'Invalid version'));
+
   var milestoneSnapshots = this._getMilestoneSnapshotsSync(collection, id);
 
   var milestoneSnapshot;
   for (var i = 0; i < milestoneSnapshots.length; i++) {
     var nextMilestoneSnapshot = milestoneSnapshots[i];
-    if (nextMilestoneSnapshot.v <= version || version === null) {
+    if (nextMilestoneSnapshot.v <= version || version == null) {
       milestoneSnapshot = nextMilestoneSnapshot;
     } else {
       break;
@@ -38,10 +44,13 @@ MemoryMilestoneDB.prototype.getMilestoneSnapshot = function (collection, id, ver
 };
 
 MemoryMilestoneDB.prototype.saveMilestoneSnapshot = function (collection, snapshot, callback) {
-  if (!snapshot) {
-    if (callback) return process.nextTick(callback, null);
+  callback = callback || function (error) {
+    if (error) return this.emit('error', error);
     this.emit('save', collection, snapshot);
-  }
+  }.bind(this);
+
+  if (!collection) return callback(new ShareDBError(4001, 'Invalid collection'));
+  if (!snapshot) return callback(new ShareDBError(4001, 'Invalid snapshot'));
 
   var milestoneSnapshots = this._getMilestoneSnapshotsSync(collection, snapshot.id);
   milestoneSnapshots.push(snapshot);
@@ -49,8 +58,7 @@ MemoryMilestoneDB.prototype.saveMilestoneSnapshot = function (collection, snapsh
     return a.v - b.v;
   });
 
-  if (callback) return process.nextTick(callback, null);
-  this.emit('save', collection, snapshot);
+  process.nextTick(callback, null);
 };
 
 MemoryMilestoneDB.prototype._getMilestoneSnapshotsSync = function (collection, id) {

--- a/lib/milestone-db/memory.js
+++ b/lib/milestone-db/memory.js
@@ -38,10 +38,9 @@ MemoryMilestoneDB.prototype.getMilestoneSnapshot = function (collection, id, ver
 };
 
 MemoryMilestoneDB.prototype.saveMilestoneSnapshot = function (collection, snapshot, callback) {
-  var saved = false;
   if (!snapshot) {
-    if (callback) return process.nextTick(callback, null, saved);
-    this.emit('save', saved, collection, snapshot);
+    if (callback) return process.nextTick(callback, null);
+    this.emit('save', collection, snapshot);
   }
 
   var milestoneSnapshots = this._getMilestoneSnapshotsSync(collection, snapshot.id);
@@ -50,9 +49,8 @@ MemoryMilestoneDB.prototype.saveMilestoneSnapshot = function (collection, snapsh
     return a.v - b.v;
   });
 
-  saved = true;
-  if (callback) return process.nextTick(callback, null, saved);
-  this.emit('save', saved, collection, snapshot);
+  if (callback) return process.nextTick(callback, null);
+  this.emit('save', collection, snapshot);
 };
 
 MemoryMilestoneDB.prototype._getMilestoneSnapshotsSync = function (collection, id) {

--- a/lib/milestone-db/no-op.js
+++ b/lib/milestone-db/no-op.js
@@ -1,0 +1,23 @@
+var MilestoneDB = require('./index');
+
+/**
+ * A no-op implementation of the MilestoneDB class.
+ *
+ * This class exists as a simple, silent default drop-in for ShareDB, which allows the backend to call its methods with
+ * no effect.
+ */
+module.exports = NoOpMilestoneDB;
+function NoOpMilestoneDB(options) {
+  MilestoneDB.call(this, options);
+}
+
+NoOpMilestoneDB.prototype = Object.create(MilestoneDB.prototype);
+
+NoOpMilestoneDB.prototype.getMilestoneSnapshot = function (collection, id, version, callback) {
+  process.nextTick(callback, null, undefined);
+};
+
+NoOpMilestoneDB.prototype.saveMilestoneSnapshot = function (collection, snapshot, callback) {
+  if (callback) return process.nextTick(callback, null);
+  this.emit('save', collection, snapshot);
+};

--- a/lib/milestone-db/no-op.js
+++ b/lib/milestone-db/no-op.js
@@ -14,7 +14,8 @@ function NoOpMilestoneDB(options) {
 NoOpMilestoneDB.prototype = Object.create(MilestoneDB.prototype);
 
 NoOpMilestoneDB.prototype.getMilestoneSnapshot = function (collection, id, version, callback) {
-  process.nextTick(callback, null, undefined);
+  var snapshot = undefined;
+  process.nextTick(callback, null, snapshot);
 };
 
 NoOpMilestoneDB.prototype.saveMilestoneSnapshot = function (collection, snapshot, callback) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -13,3 +13,8 @@ exports.isInteger = Number.isInteger || function (value) {
     isFinite(value) &&
     Math.floor(value) === value;
 };
+
+exports.isValidVersion = function (version) {
+  if (version === null) return true;
+  return exports.isInteger(version) && version >= 0;
+};

--- a/test/milestone-db.js
+++ b/test/milestone-db.js
@@ -1,8 +1,89 @@
 var expect = require('expect.js');
 var Backend = require('../lib/backend');
 var MilestoneDB = require('../lib/milestone-db');
+var NoOpMilestoneDB = require('../lib/milestone-db/no-op');
 var Snapshot = require('../lib/snapshot');
 var util = require('./util');
+
+describe('Base class', function () {
+  var db;
+
+  beforeEach(function () {
+    db = new MilestoneDB();
+  });
+
+  it('calls back with an error when trying to get a snapshot', function (done) {
+    db.getMilestoneSnapshot('books', '123', 1, function (error) {
+      expect(error.code).to.be(5019);
+      done();
+    });
+  });
+
+  it('emits an error when trying to get a snapshot', function (done) {
+    db.on('error', function (error) {
+      expect(error.code).to.be(5019);
+      done();
+    });
+
+    db.getMilestoneSnapshot('books', '123', 1);
+  });
+
+  it('calls back with an error when trying to save a snapshot', function (done) {
+    db.saveMilestoneSnapshot('books', {}, function (error) {
+      expect(error.code).to.be(5020);
+      done();
+    });
+  });
+
+  it('emits an error when trying to save a snapshot', function (done) {
+    db.on('error', function (error) {
+      expect(error.code).to.be(5020);
+      done();
+    });
+
+    db.saveMilestoneSnapshot('books', {});
+  });
+});
+
+describe('NoOpMilestoneDB', function () {
+  var db;
+
+  beforeEach(function () {
+    db = new NoOpMilestoneDB();
+  });
+
+  it('does not error when trying to save and fetch a snapshot', function (done) {
+    var snapshot = new Snapshot(
+      'catcher-in-the-rye',
+      2,
+      'http://sharejs.org/types/JSONv0',
+      { title: 'Catcher in the Rye' },
+      null
+    );
+
+    util.callInSeries([
+      function (next) {
+        db.saveMilestoneSnapshot('books', snapshot, next);
+      },
+      function (next) {
+        db.getMilestoneSnapshot('books', 'catcher-in-the-rye', null, next);
+      },
+      function (snapshot, next) {
+        expect(snapshot).to.be(undefined);
+        next();
+      },
+      done
+    ]);
+  });
+
+  it('emits an event when saving without a callback', function (done) {
+    db.on('save', function () {
+      done();
+    });
+
+    db.saveMilestoneSnapshot('books', undefined);
+  });
+});
 
 module.exports = function (options) {
   var create = options.create;
@@ -22,47 +103,6 @@ module.exports = function (options) {
 
     afterEach(function (done) {
       db.close(done);
-    });
-
-    describe('base class', function () {
-      beforeEach(function () {
-        db = new MilestoneDB();
-        backend = new Backend({ milestoneDb: db });
-      });
-
-      it('does not error when trying to save and fetch a snapshot', function (done) {
-        var snapshot = new Snapshot(
-          'catcher-in-the-rye',
-          2,
-          'http://sharejs.org/types/JSONv0',
-          { title: 'Catcher in the Rye' },
-          null
-        );
-
-        util.callInSeries([
-          function (next) {
-            db.saveMilestoneSnapshot('books', snapshot, next);
-          },
-          function (wasSaved, next) {
-            expect(wasSaved).to.be(false);
-            db.getMilestoneSnapshot('books', 'catcher-in-the-rye', null, next);
-          },
-          function (snapshot, next) {
-            expect(snapshot).to.be(undefined);
-            next();
-          },
-          done
-        ]);
-      });
-
-      it('emits an event when saving without a callback', function (done) {
-        db.on('save', function (saved) {
-          expect(saved).to.be(false);
-          done();
-        });
-
-        db.saveMilestoneSnapshot('books', undefined);
-      });
     });
 
     it('can call close() without a callback', function (done) {
@@ -86,8 +126,7 @@ module.exports = function (options) {
         function (next) {
           db.saveMilestoneSnapshot('books', snapshot, next);
         },
-        function (wasSaved, next) {
-          expect(wasSaved).to.be(true);
+        function (next) {
           db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 2, next);
         },
         function (retrievedSnapshot, next) {
@@ -127,13 +166,13 @@ module.exports = function (options) {
         function (next) {
           db.saveMilestoneSnapshot('books', snapshot1, next);
         },
-        function (wasSaved, next) {
+        function (next) {
           db.saveMilestoneSnapshot('books', snapshot2, next);
         },
-        function (wasSaved, next) {
+        function (next) {
           db.saveMilestoneSnapshot('books', snapshot10, next);
         },
-        function (wasSaved, next) {
+        function (next) {
           db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 4, next);
         },
         function (snapshot, next) {
@@ -165,10 +204,10 @@ module.exports = function (options) {
         function (next) {
           db.saveMilestoneSnapshot('books', snapshot2, next);
         },
-        function (wasSaved, next) {
+        function (next) {
           db.saveMilestoneSnapshot('books', snapshot1, next);
         },
-        function (wasSaved, next) {
+        function (next) {
           db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 4, next);
         },
         function (snapshot, next) {
@@ -200,10 +239,10 @@ module.exports = function (options) {
         function (next) {
           db.saveMilestoneSnapshot('books', snapshot1, next);
         },
-        function (wasSaved, next) {
+        function (next) {
           db.saveMilestoneSnapshot('books', snapshot2, next);
         },
-        function (wasSaved, next) {
+        function (next) {
           db.getMilestoneSnapshot('books', 'catcher-in-the-rye', null, next);
         },
         function (snapshot, next) {
@@ -253,8 +292,7 @@ module.exports = function (options) {
         null
       );
 
-      db.on('save', function (saved, collection, snapshot) {
-        expect(saved).to.be(true);
+      db.on('save', function (collection, snapshot) {
         expect(collection).to.be('books');
         expect(snapshot).to.eql(snapshot);
         done();
@@ -263,17 +301,11 @@ module.exports = function (options) {
       db.saveMilestoneSnapshot('books', snapshot);
     });
 
-    it('does not error when the snapshot is undefined', function (done) {
-      db.saveMilestoneSnapshot('books', undefined, done);
-    });
-
-    it('emits an event when a snapshot does not save', function (done) {
-      db.on('save', function (saved) {
-        expect(saved).to.be(false);
+    it('errors when the snapshot is undefined', function (done) {
+      db.saveMilestoneSnapshot('books', undefined, function (error) {
+        expect(error).to.be.ok;
         done();
       });
-
-      db.saveMilestoneSnapshot('books', undefined);
     });
 
     describe('milestones enabled for every version', function () {
@@ -289,8 +321,7 @@ module.exports = function (options) {
       });
 
       it('stores a milestone snapshot on commit', function (done) {
-        db.on('save', function (saved, collection, snapshot) {
-          expect(saved).to.be(true);
+        db.on('save', function (collection, snapshot) {
           expect(collection).to.be('books');
           expect(snapshot.data).to.eql({ title: 'Catcher in the Rye' });
           done();
@@ -314,7 +345,7 @@ module.exports = function (options) {
       });
 
       it('only stores even-numbered versions', function (done) {
-        db.on('save', function (saved, collection, snapshot) {
+        db.on('save', function (collection, snapshot) {
           if (snapshot.v !== 4) return;
 
           util.callInSeries([
@@ -374,7 +405,7 @@ module.exports = function (options) {
           callback();
         });
 
-        db.on('save', function (saved, collection, snapshot) {
+        db.on('save', function (collection, snapshot) {
           if (snapshot.v !== 4) return;
 
           util.callInSeries([

--- a/test/milestone-db.js
+++ b/test/milestone-db.js
@@ -253,39 +253,11 @@ module.exports = function (options) {
       ]);
     });
 
-    it('fetches the most recent snapshot when the version is undefined', function (done) {
-      var snapshot1 = new Snapshot(
-        'catcher-in-the-rye',
-        1,
-        'http://sharejs.org/types/JSONv0',
-        { title: 'Catcher in the Rye' },
-        null
-      );
-
-      var snapshot2 = new Snapshot(
-        'catcher-in-the-rye',
-        2,
-        'http://sharejs.org/types/JSONv0',
-        { title: 'Catcher in the Rye', author: 'J.D. Salinger' },
-        null
-      );
-
-      util.callInSeries([
-        function (next) {
-          db.saveMilestoneSnapshot('books', snapshot1, next);
-        },
-        function (next) {
-          db.saveMilestoneSnapshot('books', snapshot2, next);
-        },
-        function (next) {
-          db.getMilestoneSnapshot('books', 'catcher-in-the-rye', undefined, next);
-        },
-        function (snapshot, next) {
-          expect(snapshot).to.eql(snapshot2);
-          next();
-        },
-        done
-      ]);
+    it('errors when fetching an undefined version', function (done) {
+      db.getMilestoneSnapshot('books', 'catcher-in-the-rye', undefined, function (error) {
+        expect(error).to.be.ok();
+        done();
+      });
     });
 
     it('errors when fetching version -1', function (done) {

--- a/test/milestone-db.js
+++ b/test/milestone-db.js
@@ -253,6 +253,84 @@ module.exports = function (options) {
       ]);
     });
 
+    it('fetches the most recent snapshot when the version is undefined', function (done) {
+      var snapshot1 = new Snapshot(
+        'catcher-in-the-rye',
+        1,
+        'http://sharejs.org/types/JSONv0',
+        { title: 'Catcher in the Rye' },
+        null
+      );
+
+      var snapshot2 = new Snapshot(
+        'catcher-in-the-rye',
+        2,
+        'http://sharejs.org/types/JSONv0',
+        { title: 'Catcher in the Rye', author: 'J.D. Salinger' },
+        null
+      );
+
+      util.callInSeries([
+        function (next) {
+          db.saveMilestoneSnapshot('books', snapshot1, next);
+        },
+        function (next) {
+          db.saveMilestoneSnapshot('books', snapshot2, next);
+        },
+        function (next) {
+          db.getMilestoneSnapshot('books', 'catcher-in-the-rye', undefined, next);
+        },
+        function (snapshot, next) {
+          expect(snapshot).to.eql(snapshot2);
+          next();
+        },
+        done
+      ]);
+    });
+
+    it('errors when fetching version -1', function (done) {
+      db.getMilestoneSnapshot('books', 'catcher-in-the-rye', -1, function (error) {
+        expect(error).to.be.ok();
+        done();
+      });
+    });
+
+    it('errors when fetching version "foo"', function (done) {
+      db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 'foo', function (error) {
+        expect(error).to.be.ok();
+        done();
+      });
+    });
+
+    it('errors when fetching a null collection', function (done) {
+      db.getMilestoneSnapshot(null, 'catcher-in-the-rye', 1, function (error) {
+        expect(error).to.be.ok();
+        done();
+      });
+    });
+
+    it('errors when fetching a null ID', function (done) {
+      db.getMilestoneSnapshot('books', null, 1, function (error) {
+        expect(error).to.be.ok();
+        done();
+      });
+    });
+
+    it('errors when saving a null collection', function (done) {
+      var snapshot = new Snapshot(
+        'catcher-in-the-rye',
+        1,
+        'http://sharejs.org/types/JSONv0',
+        { title: 'Catcher in the Rye' },
+        null
+      );
+
+      db.saveMilestoneSnapshot(null, snapshot, function (error) {
+        expect(error).to.be.ok();
+        done();
+      });
+    });
+
     it('returns undefined if no snapshot exists', function (done) {
       util.callInSeries([
         function (next) {
@@ -303,7 +381,7 @@ module.exports = function (options) {
 
     it('errors when the snapshot is undefined', function (done) {
       db.saveMilestoneSnapshot('books', undefined, function (error) {
-        expect(error).to.be.ok;
+        expect(error).to.be.ok();
         done();
       });
     });


### PR DESCRIPTION
This change updates our `MilestoneDB` base class to be an empty shell
that throws whenever any of its methods are called in order to help
implementers.

We then also introduce a `NoOpMilestoneDB` implementation, which
implements all the methods, but does nothing. This is so that we can
drop this implementation into the `Backend` as a sensible default that
does nothing at all when called (instead of eg using `MemoryMilestoneDB`
and having the surprising behaviour of working until you restart your
application).

As part of this, the base call signature of the `saveMilestoneSnapshot`
callback is changed to remove the `wasSaved` flag. A snapshot should be
assumed to have saved if no error is returned in that callback.