### PR TITLE
fix leak on duplicate subscription - #260

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -105,7 +105,7 @@ Agent.prototype._subscribeToStream = function(collection, id, stream) {
   stream.on('end', function() {
     // The op stream is done sending, so release its reference
     var streams = agent.subscribedDocs[collection];
-    if (!streams) return;
+    if (!streams || streams[id] !== stream) return;
     delete streams[id];
     if (util.hasKeys(streams)) return;
     delete agent.subscribedDocs[collection];


### PR DESCRIPTION
When we subscribe to the same stream sharedb leak, because of the cross reference between the stream and the agent the leak is even more critical.
close #260