### PR TITLE
For readSnapshots middleware, add method and parameter properties to first parameter

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -272,7 +272,7 @@ Backend.prototype._sanitizeOpsBulk = function(agent, projection, collection, ops
   }, callback);
 };
 
-Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, snapshotType, callback) {
+Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, requestContext, callback) {
   if (projection) {
     try {
       projections.projectSnapshots(projection.fields, snapshots);
@@ -281,13 +281,10 @@ Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, s
     }
   }
 
-  var request = {
-    collection: collection,
-    snapshots: snapshots,
-    snapshotType: snapshotType
-  };
+  requestContext.collection = collection;
+  requestContext.snapshots = snapshots;
 
-  this.trigger(this.MIDDLEWARE_ACTIONS.readSnapshots, agent, request, callback);
+  this.trigger(this.MIDDLEWARE_ACTIONS.readSnapshots, agent, requestContext, callback);
 };
 
 Backend.prototype._getSnapshotProjection = function(db, projection) {
@@ -353,20 +350,28 @@ Backend.prototype.getOpsBulk = function(agent, index, fromMap, toMap, callback) 
 Backend.prototype.fetch = function(agent, index, id, callback) {
   var start = Date.now();
   var projection = this.projections[index];
-  var collection = (projection) ? projection.target : index;
+  var dbCollection = (projection) ? projection.target : index;
   var fields = projection && projection.fields;
   var backend = this;
   var request = {
     agent: agent,
     index: index,
-    collection: collection,
+    collection: dbCollection,
     id: id
   };
-  backend.db.getSnapshot(collection, id, fields, null, function(err, snapshot) {
+  backend.db.getSnapshot(dbCollection, id, fields, null, function(err, snapshot) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
-    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, backend.SNAPSHOT_TYPES.current, function(err) {
+    var requestContext = {
+      requestMethod: 'fetch',
+      requestParams: {
+        index: index,
+        id: id
+      },
+      snapshotType: backend.SNAPSHOT_TYPES.current
+    };
+    backend._sanitizeSnapshots(agent, snapshotProjection, dbCollection, snapshots, requestContext, function(err) {
       if (err) return callback(err);
       backend.emit('timing', 'fetch', Date.now() - start, request);
       callback(null, snapshot);
@@ -390,7 +395,15 @@ Backend.prototype.fetchBulk = function(agent, index, ids, callback) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = backend._getSnapshotsFromMap(ids, snapshotMap);
-    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, backend.SNAPSHOT_TYPES.current, function(err) {
+    var requestContext = {
+      requestMethod: 'fetchBulk',
+      requestParams: {
+        index: index,
+        ids: ids
+      },
+      snapshotType: backend.SNAPSHOT_TYPES.current
+    };
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, requestContext, function(err) {
       if (err) return callback(err);
       backend.emit('timing', 'fetchBulk', Date.now() - start, request);
       callback(null, snapshotMap);
@@ -578,7 +591,16 @@ Backend.prototype._query = function(agent, request, callback) {
   var backend = this;
   request.db.query(request.collection, request.query, request.fields, request.options, function(err, snapshots, extra) {
     if (err) return callback(err);
-    backend._sanitizeSnapshots(agent, request.snapshotProjection, request.collection, snapshots, backend.SNAPSHOT_TYPES.current, function(err) {
+    var requestContext = {
+      requestMethod: 'query',  // TODO: Should this distinguish between queryFetch and querySubscribe?
+      requestParams: {
+        index: request.index,
+        query: request.query,
+        options: request.options,
+      },
+      snapshotType: backend.SNAPSHOT_TYPES.current
+    };
+    backend._sanitizeSnapshots(agent, request.snapshotProjection, request.collection, snapshots, requestContext, function(err) {
       callback(err, snapshots, extra);
     });
   });
@@ -616,8 +638,16 @@ Backend.prototype.fetchSnapshot = function(agent, index, id, version, callback) 
     if (error) return callback(error);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
-    var snapshotType = backend.SNAPSHOT_TYPES.byVersion;
-    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, snapshotType, function (error) {
+    var requestContext = {
+      requestMethod: 'fetchSnapshot',
+      requestParams: {
+        index: index,
+        id: id,
+        version: version,
+      },
+      snapshotType: backend.SNAPSHOT_TYPES.byVersion
+    };
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, requestContext, function (error) {
       if (error) return callback(error);
       backend.emit('timing', 'fetchSnapshot', Date.now() - start, request);
       callback(null, snapshot);

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -77,6 +77,23 @@ Backend.prototype.MIDDLEWARE_ACTIONS = {
   submit: 'submit'
 };
 
+// Context provided to readSnapshots middleware
+function ReadSnapshotsContext(method, parameters, snapshotType) {
+  this.method = method;
+  this.parameters = parameters;
+  this.snapshotType = snapshotType;
+  this.collection = null;  // Set during _sanitizeSnapshots
+  this.snapshots = null;  // Set during _sanitizeSnapshots
+}
+
+Backend.prototype.READ_SNAPSHOTS_METHODS = {
+  fetch: 'fetch',
+  fetchBulk: 'fetchBulk',
+  fetchSnapshot: 'fetchSnapshot',
+  queryFetch: 'queryFetch',
+  querySubscribe: 'querySubscribe'
+};
+
 Backend.prototype.SNAPSHOT_TYPES = {
   // The current snapshot is being fetched (eg through backend.fetch)
   current: 'current',
@@ -363,14 +380,14 @@ Backend.prototype.fetch = function(agent, index, id, callback) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
-    var requestContext = {
-      method: 'fetch',
-      parameters: {
+    var requestContext = new ReadSnapshotsContext(
+      backend.READ_SNAPSHOTS_METHODS.fetch,
+      {
         index: index,
         id: id
       },
-      snapshotType: backend.SNAPSHOT_TYPES.current
-    };
+      backend.SNAPSHOT_TYPES.current
+    );
     backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, requestContext, function(err) {
       if (err) return callback(err);
       backend.emit('timing', 'fetch', Date.now() - start, request);
@@ -395,14 +412,14 @@ Backend.prototype.fetchBulk = function(agent, index, ids, callback) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = backend._getSnapshotsFromMap(ids, snapshotMap);
-    var requestContext = {
-      method: 'fetchBulk',
-      parameters: {
+    var requestContext =  new ReadSnapshotsContext(
+      backend.READ_SNAPSHOTS_METHODS.fetchBulk,
+      {
         index: index,
         ids: ids
       },
-      snapshotType: backend.SNAPSHOT_TYPES.current
-    };
+      backend.SNAPSHOT_TYPES.current
+    );
     backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, requestContext, function(err) {
       if (err) return callback(err);
       backend.emit('timing', 'fetchBulk', Date.now() - start, request);
@@ -512,7 +529,7 @@ Backend.prototype.queryFetch = function(agent, index, query, options, callback) 
   var backend = this;
   backend._triggerQuery(agent, index, query, options, function(err, request) {
     if (err) return callback(err);
-    backend._query(agent, 'queryFetch', request, function(err, snapshots, extra) {
+    backend._query(agent, backend.READ_SNAPSHOTS_METHODS.queryFetch, request, function(err, snapshots, extra) {
       if (err) return callback(err);
       backend.emit('timing', 'queryFetch', Date.now() - start, request);
       callback(null, snapshots, extra);
@@ -546,7 +563,7 @@ Backend.prototype.querySubscribe = function(agent, index, query, options, callba
         return;
       }
       // Issue query on db to get our initial results
-      backend._query(agent, 'querySubscribe', request, function(err, snapshots, extra) {
+      backend._query(agent, backend.READ_SNAPSHOTS_METHODS.querySubscribe, request, function(err, snapshots, extra) {
         if (err) {
           stream.destroy();
           return callback(err);
@@ -591,15 +608,15 @@ Backend.prototype._query = function(agent, method, request, callback) {
   var backend = this;
   request.db.query(request.collection, request.query, request.fields, request.options, function(err, snapshots, extra) {
     if (err) return callback(err);
-    var requestContext = {
-      method: method,
-      parameters: {
+    var requestContext =  new ReadSnapshotsContext(
+      method,
+      {
         index: request.index,
         query: request.query,
         options: request.options,
       },
-      snapshotType: backend.SNAPSHOT_TYPES.current
-    };
+      backend.SNAPSHOT_TYPES.current
+    );
     backend._sanitizeSnapshots(agent, request.snapshotProjection, request.collection, snapshots, requestContext, function(err) {
       callback(err, snapshots, extra);
     });
@@ -638,15 +655,15 @@ Backend.prototype.fetchSnapshot = function(agent, index, id, version, callback) 
     if (error) return callback(error);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
-    var requestContext = {
-      method: 'fetchSnapshot',
-      parameters: {
+    var requestContext = new ReadSnapshotsContext(
+      backend.READ_SNAPSHOTS_METHODS.fetchSnapshot,
+      {
         index: index,
         id: id,
         version: version,
       },
-      snapshotType: backend.SNAPSHOT_TYPES.byVersion
-    };
+      backend.SNAPSHOT_TYPES.byVersion
+    );
     backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, requestContext, function (error) {
       if (error) return callback(error);
       backend.emit('timing', 'fetchSnapshot', Date.now() - start, request);

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -90,6 +90,7 @@ Backend.prototype.READ_SNAPSHOTS_METHODS = {
   fetch: 'fetch',
   fetchBulk: 'fetchBulk',
   fetchSnapshot: 'fetchSnapshot',
+  fetchSnapshotByTimestamp: 'fetchSnapshotByTimestamp',
   queryFetch: 'queryFetch',
   querySubscribe: 'querySubscribe'
 };
@@ -718,8 +719,16 @@ Backend.prototype.fetchSnapshotByTimestamp = function (agent, index, id, timesta
     if (error) return callback(error);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
-    var snapshotType = backend.SNAPSHOT_TYPES.byTimestamp;
-    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, snapshotType, function (error) {
+    var requestContext = new ReadSnapshotsContext(
+      backend.READ_SNAPSHOTS_METHODS.fetchSnapshotByTimestamp,
+      {
+        index: index,
+        id: id,
+        timestamp: timestamp,
+      },
+      backend.SNAPSHOT_TYPES.byTimestamp
+    );
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, requestContext, function (error) {
       if (error) return callback(error);
       backend.emit('timing', 'fetchSnapshot', Date.now() - start, request);
       callback(null, snapshot);

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -350,28 +350,28 @@ Backend.prototype.getOpsBulk = function(agent, index, fromMap, toMap, callback) 
 Backend.prototype.fetch = function(agent, index, id, callback) {
   var start = Date.now();
   var projection = this.projections[index];
-  var dbCollection = (projection) ? projection.target : index;
+  var collection = (projection) ? projection.target : index;
   var fields = projection && projection.fields;
   var backend = this;
   var request = {
     agent: agent,
     index: index,
-    collection: dbCollection,
+    collection: collection,
     id: id
   };
-  backend.db.getSnapshot(dbCollection, id, fields, null, function(err, snapshot) {
+  backend.db.getSnapshot(collection, id, fields, null, function(err, snapshot) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
     var requestContext = {
-      requestMethod: 'fetch',
-      requestParams: {
+      method: 'fetch',
+      parameters: {
         index: index,
         id: id
       },
       snapshotType: backend.SNAPSHOT_TYPES.current
     };
-    backend._sanitizeSnapshots(agent, snapshotProjection, dbCollection, snapshots, requestContext, function(err) {
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, requestContext, function(err) {
       if (err) return callback(err);
       backend.emit('timing', 'fetch', Date.now() - start, request);
       callback(null, snapshot);
@@ -396,8 +396,8 @@ Backend.prototype.fetchBulk = function(agent, index, ids, callback) {
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = backend._getSnapshotsFromMap(ids, snapshotMap);
     var requestContext = {
-      requestMethod: 'fetchBulk',
-      requestParams: {
+      method: 'fetchBulk',
+      parameters: {
         index: index,
         ids: ids
       },
@@ -512,7 +512,7 @@ Backend.prototype.queryFetch = function(agent, index, query, options, callback) 
   var backend = this;
   backend._triggerQuery(agent, index, query, options, function(err, request) {
     if (err) return callback(err);
-    backend._query(agent, request, function(err, snapshots, extra) {
+    backend._query(agent, 'queryFetch', request, function(err, snapshots, extra) {
       if (err) return callback(err);
       backend.emit('timing', 'queryFetch', Date.now() - start, request);
       callback(null, snapshots, extra);
@@ -546,7 +546,7 @@ Backend.prototype.querySubscribe = function(agent, index, query, options, callba
         return;
       }
       // Issue query on db to get our initial results
-      backend._query(agent, request, function(err, snapshots, extra) {
+      backend._query(agent, 'querySubscribe', request, function(err, snapshots, extra) {
         if (err) {
           stream.destroy();
           return callback(err);
@@ -587,13 +587,13 @@ Backend.prototype._triggerQuery = function(agent, index, query, options, callbac
   });
 };
 
-Backend.prototype._query = function(agent, request, callback) {
+Backend.prototype._query = function(agent, method, request, callback) {
   var backend = this;
   request.db.query(request.collection, request.query, request.fields, request.options, function(err, snapshots, extra) {
     if (err) return callback(err);
     var requestContext = {
-      requestMethod: 'query',  // TODO: Should this distinguish between queryFetch and querySubscribe?
-      requestParams: {
+      method: method,
+      parameters: {
         index: request.index,
         query: request.query,
         options: request.options,
@@ -639,8 +639,8 @@ Backend.prototype.fetchSnapshot = function(agent, index, id, version, callback) 
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
     var requestContext = {
-      requestMethod: 'fetchSnapshot',
-      requestParams: {
+      method: 'fetchSnapshot',
+      parameters: {
         index: index,
         id: id,
         version: version,

--- a/test/client/snapshot-timestamp-request.js
+++ b/test/client/snapshot-timestamp-request.js
@@ -326,6 +326,8 @@ describe('SnapshotTimestampRequest', function () {
       it('triggers the middleware', function (done) {
         backend.use(backend.MIDDLEWARE_ACTIONS.readSnapshots,
           function (request) {
+            expect(request.method).to.eql(backend.READ_SNAPSHOTS_METHODS.fetchSnapshotByTimestamp);
+            expect(request.parameters).to.eql({index: 'books', id: 'time-machine', timestamp: day3});
             expect(request.snapshots[0]).to.eql(v3);
             expect(request.snapshotType).to.be(backend.SNAPSHOT_TYPES.byTimestamp);
             done();

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -199,8 +199,8 @@ describe('middleware', function() {
       var doneAfter = util.callAfter(1, done);
       backend.use('readSnapshots', function(request, next) {
         expect(request.snapshots).to.have.length(1);
-        expect(request.requestMethod).to.be.a('string');
-        expect(request.requestParams).to.be.ok;
+        expect(request.method).to.be.a('string');
+        expect(request.parameters).to.be.ok;
         expectFido(request);
         doneAfter();
         next();
@@ -212,8 +212,8 @@ describe('middleware', function() {
       var doneAfter = util.callAfter(1, done);
       backend.use('readSnapshots', function(request, next) {
         expect(request.snapshots).to.have.length(2);
-        expect(request.requestMethod).to.be.a('string');
-        expect(request.requestParams).to.be.ok;
+        expect(request.method).to.be.a('string');
+        expect(request.parameters).to.be.ok;
         expectFido(request);
         expectSpot(request);
         doneAfter();

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -199,6 +199,8 @@ describe('middleware', function() {
       var doneAfter = util.callAfter(1, done);
       backend.use('readSnapshots', function(request, next) {
         expect(request.snapshots).to.have.length(1);
+        expect(request.requestMethod).to.be.a('string');
+        expect(request.requestParams).to.be.ok;
         expectFido(request);
         doneAfter();
         next();
@@ -210,6 +212,8 @@ describe('middleware', function() {
       var doneAfter = util.callAfter(1, done);
       backend.use('readSnapshots', function(request, next) {
         expect(request.snapshots).to.have.length(2);
+        expect(request.requestMethod).to.be.a('string');
+        expect(request.requestParams).to.be.ok;
         expectFido(request);
         expectSpot(request);
         doneAfter();


### PR DESCRIPTION
When monitoring for unusual response sizes, it can be useful to record which client request was associated with the response. Unfortunately, ShareDB's current "readSnapshots" middleware, which is how you get info about snapshot responses, doesn't contain information about the associated request.

This PR adds a couple additional fields to the "readSnapshots" middleware's `request` param, `method` and `parameters`.

The "readSnapshots" middleware function now has a first parameter `request` like this:

```javascript
function(request, next) {
  let {
    collection,
    snapshots,
    method,  // Backend.prototype.READ_SNAPSHOTS_METHODS: 'fetch', 'query', etc.
    parameters,  // Plain JS object, shape varies depending on method
    snapshotType,  // Backend.prototype.SNAPSHOT_TYPES
    agent
  } = request;
}
```