### PR TITLE
Making textarea example more clear by assigning the textarea value to the property of a document, rather than directly to the document.

### DIFF
--- a/examples/textarea/client.js
+++ b/examples/textarea/client.js
@@ -31,6 +31,6 @@ var doc = connection.get('examples', 'textarea');
 doc.subscribe(function(err) {
   if (err) throw err;
   
-  var binding = new StringBinding(element, doc);
+  var binding = new StringBinding(element, doc, ['content']);
   binding.setup();
 });

--- a/examples/textarea/server.js
+++ b/examples/textarea/server.js
@@ -14,7 +14,7 @@ function createDoc(callback) {
   doc.fetch(function(err) {
     if (err) throw err;
     if (doc.type === null) {
-      doc.create('', callback);
+      doc.create({ content: '' }, callback);
       return;
     }
     callback();


### PR DESCRIPTION
This textarea example was initially confusing for me as I could not understand initially how to assign the textarea value to the property within the document without reading documentation multiple times to provide the path. 

This pull request hopes to address that: By making it more clear to access the property of the document and assigning the value within the HTML textarea to that property of the document instead of assigning it as the raw data value for the document.

This makes it a bit more intuitive for those getting started with using sharedb for co-editing components within their web applications to see how one can use the textarea as an element of choice. 