### PR TITLE
Clear inflight op and debounce fetch

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -162,7 +162,12 @@ Agent.prototype.send = function(message) {
   if (this.closed) return;
 
   this.backend.emit('send', this, message);
-  this.stream.write(message);
+  try {
+    this.stream.write(message);
+  } catch (err) {
+    // Quietly drop replies if the stream was closed
+    console.error('Send message stream error', message, err);
+  }
 };
 
 Agent.prototype._sendOp = function(collection, id, op) {

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -383,7 +383,8 @@ Doc.prototype._resubscribe = function() {
 
 // Request the current document snapshot or ops that bring us up to date
 Doc.prototype.fetch = function(callback) {
-  if (this.connection.canSend) {
+  // If there is an inflightFetch, prevent to trigger another one
+  if (this.connection.canSend && !this.inflightFetch.length) {
     var isDuplicate = this.connection.sendFetch(this);
     pushActionCallback(this.inflightFetch, isDuplicate, callback);
     return;

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -842,8 +842,8 @@ Doc.prototype._opAcknowledged = function(message) {
     // have sent all the ops that have happened before acknowledging our op
     logger.warn('Invalid version from server. Expected: ' + this.version + ' Received: ' + message.v, message);
 
-    // Fetching should get us back to a working document state
-    return this.fetch();
+    // Rollback to clear the inflightOp and trigger a fetch from the server
+    return this._rollback();
   }
 
   // The op was committed successfully. Increment the version number


### PR DESCRIPTION
Proposition to solve the issue https://github.com/share/sharedb/issues/266. This PR fixes the locked state introduced by the persistent `inflightOp` which is never clean. It prevents to trigger multiple fetch requests to both prevent multiple treatment and offer a better experience for the clients subscribed to the `load` event.

### Workflow description of the fix:
1- A `message.v` is different from the current document's version and cannot be acknowledged.
2- Use the rollback method in order to both clean the `inflightOp` and `pendingOps`.
3- Trigger a fetch using the current version if the `inflightOp` could be revert or using `null` version if the document was hard rollbacked.
4- Put the fetch into the `inflightFetch`.
5- All messages received through the socket will trigger a fetch which will be debounced
6- The fetch comes back from the server and is handle. It triggers a `load` event which will allow the client to update his Quill's content .

### To do
- [ ] Be approved in principle
- [ ] Add tests