### PR TITLE
Revert "For readSnapshots middleware, add method and parameter properties to first parameter"

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -77,24 +77,6 @@ Backend.prototype.MIDDLEWARE_ACTIONS = {
   submit: 'submit'
 };
 
-// Context provided to readSnapshots middleware
-function ReadSnapshotsContext(method, parameters, snapshotType) {
-  this.method = method;
-  this.parameters = parameters;
-  this.snapshotType = snapshotType;
-  this.collection = null;  // Set during _sanitizeSnapshots
-  this.snapshots = null;  // Set during _sanitizeSnapshots
-}
-
-Backend.prototype.READ_SNAPSHOTS_METHODS = {
-  fetch: 'fetch',
-  fetchBulk: 'fetchBulk',
-  fetchSnapshot: 'fetchSnapshot',
-  fetchSnapshotByTimestamp: 'fetchSnapshotByTimestamp',
-  queryFetch: 'queryFetch',
-  querySubscribe: 'querySubscribe'
-};
-
 Backend.prototype.SNAPSHOT_TYPES = {
   // The current snapshot is being fetched (eg through backend.fetch)
   current: 'current',
@@ -292,7 +274,7 @@ Backend.prototype._sanitizeOpsBulk = function(agent, projection, collection, ops
   }, callback);
 };
 
-Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, requestContext, callback) {
+Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, snapshots, snapshotType, callback) {
   if (projection) {
     try {
       projections.projectSnapshots(projection.fields, snapshots);
@@ -301,10 +283,13 @@ Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, s
     }
   }
 
-  requestContext.collection = collection;
-  requestContext.snapshots = snapshots;
+  var request = {
+    collection: collection,
+    snapshots: snapshots,
+    snapshotType: snapshotType
+  };
 
-  this.trigger(this.MIDDLEWARE_ACTIONS.readSnapshots, agent, requestContext, callback);
+  this.trigger(this.MIDDLEWARE_ACTIONS.readSnapshots, agent, request, callback);
 };
 
 Backend.prototype._getSnapshotProjection = function(db, projection) {
@@ -383,15 +368,7 @@ Backend.prototype.fetch = function(agent, index, id, callback) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
-    var requestContext = new ReadSnapshotsContext(
-      backend.READ_SNAPSHOTS_METHODS.fetch,
-      {
-        index: index,
-        id: id
-      },
-      backend.SNAPSHOT_TYPES.current
-    );
-    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, requestContext, function(err) {
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, backend.SNAPSHOT_TYPES.current, function(err) {
       if (err) return callback(err);
       backend.emit('timing', 'fetch', Date.now() - start, request);
       callback(null, snapshot);
@@ -415,15 +392,7 @@ Backend.prototype.fetchBulk = function(agent, index, ids, callback) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = backend._getSnapshotsFromMap(ids, snapshotMap);
-    var requestContext =  new ReadSnapshotsContext(
-      backend.READ_SNAPSHOTS_METHODS.fetchBulk,
-      {
-        index: index,
-        ids: ids
-      },
-      backend.SNAPSHOT_TYPES.current
-    );
-    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, requestContext, function(err) {
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, backend.SNAPSHOT_TYPES.current, function(err) {
       if (err) return callback(err);
       backend.emit('timing', 'fetchBulk', Date.now() - start, request);
       callback(null, snapshotMap);
@@ -532,7 +501,7 @@ Backend.prototype.queryFetch = function(agent, index, query, options, callback) 
   var backend = this;
   backend._triggerQuery(agent, index, query, options, function(err, request) {
     if (err) return callback(err);
-    backend._query(agent, backend.READ_SNAPSHOTS_METHODS.queryFetch, request, function(err, snapshots, extra) {
+    backend._query(agent, request, function(err, snapshots, extra) {
       if (err) return callback(err);
       backend.emit('timing', 'queryFetch', Date.now() - start, request);
       callback(null, snapshots, extra);
@@ -566,7 +535,7 @@ Backend.prototype.querySubscribe = function(agent, index, query, options, callba
         return;
       }
       // Issue query on db to get our initial results
-      backend._query(agent, backend.READ_SNAPSHOTS_METHODS.querySubscribe, request, function(err, snapshots, extra) {
+      backend._query(agent, request, function(err, snapshots, extra) {
         if (err) {
           stream.destroy();
           return callback(err);
@@ -607,20 +576,11 @@ Backend.prototype._triggerQuery = function(agent, index, query, options, callbac
   });
 };
 
-Backend.prototype._query = function(agent, method, request, callback) {
+Backend.prototype._query = function(agent, request, callback) {
   var backend = this;
   request.db.query(request.collection, request.query, request.fields, request.options, function(err, snapshots, extra) {
     if (err) return callback(err);
-    var requestContext =  new ReadSnapshotsContext(
-      method,
-      {
-        index: request.index,
-        query: request.query,
-        options: request.options,
-      },
-      backend.SNAPSHOT_TYPES.current
-    );
-    backend._sanitizeSnapshots(agent, request.snapshotProjection, request.collection, snapshots, requestContext, function(err) {
+    backend._sanitizeSnapshots(agent, request.snapshotProjection, request.collection, snapshots, backend.SNAPSHOT_TYPES.current, function(err) {
       callback(err, snapshots, extra);
     });
   });
@@ -658,16 +618,8 @@ Backend.prototype.fetchSnapshot = function(agent, index, id, version, callback) 
     if (error) return callback(error);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
-    var requestContext = new ReadSnapshotsContext(
-      backend.READ_SNAPSHOTS_METHODS.fetchSnapshot,
-      {
-        index: index,
-        id: id,
-        version: version,
-      },
-      backend.SNAPSHOT_TYPES.byVersion
-    );
-    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, requestContext, function (error) {
+    var snapshotType = backend.SNAPSHOT_TYPES.byVersion;
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, snapshotType, function (error) {
       if (error) return callback(error);
       backend.emit('timing', 'fetchSnapshot', Date.now() - start, request);
       callback(null, snapshot);
@@ -719,16 +671,8 @@ Backend.prototype.fetchSnapshotByTimestamp = function (agent, index, id, timesta
     if (error) return callback(error);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
     var snapshots = [snapshot];
-    var requestContext = new ReadSnapshotsContext(
-      backend.READ_SNAPSHOTS_METHODS.fetchSnapshotByTimestamp,
-      {
-        index: index,
-        id: id,
-        timestamp: timestamp,
-      },
-      backend.SNAPSHOT_TYPES.byTimestamp
-    );
-    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, requestContext, function (error) {
+    var snapshotType = backend.SNAPSHOT_TYPES.byTimestamp;
+    backend._sanitizeSnapshots(agent, snapshotProjection, collection, snapshots, snapshotType, function (error) {
       if (error) return callback(error);
       backend.emit('timing', 'fetchSnapshot', Date.now() - start, request);
       callback(null, snapshot);

--- a/test/client/snapshot-timestamp-request.js
+++ b/test/client/snapshot-timestamp-request.js
@@ -326,8 +326,6 @@ describe('SnapshotTimestampRequest', function () {
       it('triggers the middleware', function (done) {
         backend.use(backend.MIDDLEWARE_ACTIONS.readSnapshots,
           function (request) {
-            expect(request.method).to.eql(backend.READ_SNAPSHOTS_METHODS.fetchSnapshotByTimestamp);
-            expect(request.parameters).to.eql({index: 'books', id: 'time-machine', timestamp: day3});
             expect(request.snapshots[0]).to.eql(v3);
             expect(request.snapshotType).to.be(backend.SNAPSHOT_TYPES.byTimestamp);
             done();

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -199,8 +199,6 @@ describe('middleware', function() {
       var doneAfter = util.callAfter(1, done);
       backend.use('readSnapshots', function(request, next) {
         expect(request.snapshots).to.have.length(1);
-        expect(request.method).to.be.a('string');
-        expect(request.parameters).to.be.ok;
         expectFido(request);
         doneAfter();
         next();
@@ -212,8 +210,6 @@ describe('middleware', function() {
       var doneAfter = util.callAfter(1, done);
       backend.use('readSnapshots', function(request, next) {
         expect(request.snapshots).to.have.length(2);
-        expect(request.method).to.be.a('string');
-        expect(request.parameters).to.be.ok;
         expectFido(request);
         expectSpot(request);
         doneAfter();


### PR DESCRIPTION
Reverts share/sharedb#263, as it causes issues with `'readSnapshots'` middleware for `queryPoll()` calls. The "bad" version has already been unpublished from NPM.

See https://github.com/share/sharedb/issues/269 for details.