### PR TITLE
In Doc._clearInflightOp, clear inflightOp before calling callbacks

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -920,9 +920,12 @@ Doc.prototype._hardRollback = function(err) {
 };
 
 Doc.prototype._clearInflightOp = function(err) {
-  var called = callEach(this.inflightOp.callbacks, err);
+  var inflightOp = this.inflightOp;
 
   this.inflightOp = null;
+
+  var called = callEach(inflightOp.callbacks, err);
+
   this.flush();
   this._emitNothingPending();
 


### PR DESCRIPTION
This fixes a double-callback issue for chained op submissions, where if the second op is invalid, the first op's callback gets called twice:
https://github.com/share/sharedb/issues/272

`Doc._hardRollback` [already does takes a similar approach](https://github.com/share/sharedb/blob/v1.0.0-beta.18/lib/client/doc.js#L896-L904) of clearing local Doc state prior to calling callbacks, and Nate expressed his agreement with this fix today at the PR review meeting.

Thanks to @nickasd and @alecgibson for developing the test case that reproduces the issue!