### PR TITLE
Add new "reply" middleware action

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -209,12 +209,7 @@ Agent.prototype._reply = function(request, err, message) {
   var backend = agent.backend;
   if (err) {
     request.error = getReplyErrorObject(err);
-    var middlewareContext = {request: request, reply: request};
-    backend.trigger(backend.MIDDLEWARE_ACTIONS.reply, agent, middlewareContext, function(_err) {
-      // If we were already going to send back an error, and the reply middleware runs into
-      // another error (`_err`), just send back the original error.
-      agent.send(middlewareContext.reply);
-    });
+    agent.send(request);
     return;
   }
   if (!message) message = {};

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -202,7 +202,7 @@ function getReplyErrorObject(err) {
       message: err.message
     };
   }
-};
+}
 
 Agent.prototype._reply = function(request, err, message) {
   var agent = this;

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -187,23 +187,34 @@ Agent.prototype._sendOps = function(collection, id, ops) {
   }
 };
 
-Agent.prototype._reply = function(request, err, message) {
-  if (err) {
-    if (typeof err === 'string') {
-      request.error = {
-        code: 4001,
-        message: err
-      };
-    } else {
-      if (err.stack) {
-        logger.warn(err.stack);
-      }
-      request.error = {
-        code: err.code,
-        message: err.message
-      };
+function getReplyErrorObject(err) {
+  if (typeof err === 'string') {
+    return {
+      code: 4001,
+      message: err
+    };
+  } else {
+    if (err.stack) {
+      logger.warn(err.stack);
     }
-    this.send(request);
+    return {
+      code: err.code,
+      message: err.message
+    };
+  }
+};
+
+Agent.prototype._reply = function(request, err, message) {
+  var agent = this;
+  var backend = agent.backend;
+  if (err) {
+    request.error = getReplyErrorObject(err);
+    var middlewareContext = {request: request, reply: request};
+    backend.trigger(backend.MIDDLEWARE_ACTIONS.reply, agent, middlewareContext, function(_err) {
+      // If we were already going to send back an error, and the reply middleware runs into
+      // another error (`_err`), just send back the original error.
+      agent.send(middlewareContext.reply);
+    });
     return;
   }
   if (!message) message = {};
@@ -217,7 +228,15 @@ Agent.prototype._reply = function(request, err, message) {
     if (request.b && !message.data) message.b = request.b;
   }
 
-  this.send(message);
+  var middlewareContext = {request: request, reply: message};
+  backend.trigger(backend.MIDDLEWARE_ACTIONS.reply, agent, middlewareContext, function(err) {
+    if (err) {
+      request.error = getReplyErrorObject(err);
+      agent.send(request);
+    } else {
+      agent.send(middlewareContext.reply);
+    }
+  });
 };
 
 // Start processing events from the stream

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -69,10 +69,16 @@ Backend.prototype.MIDDLEWARE_ACTIONS = {
   op: 'op',
   // A query is about to be sent to the database
   query: 'query',
-  // Received a message from a client
-  receive: 'receive',
   // Snapshot(s) were received from the database and are about to be returned to a client
   readSnapshots: 'readSnapshots',
+  // Received a message from a client
+  receive: 'receive',
+  // About to reply to a client message.
+  // WARNING: This gets passed a direct reference to the reply object, so
+  // be cautious with it. While modifications to the reply message are possible
+  // by design, changing existing reply properties can cause weird bugs, since
+  // the rest of ShareDB would be unaware of those changes.
+  reply: 'reply',
   // An operation is about to be submitted to the database
   submit: 'submit'
 };

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -73,7 +73,7 @@ Backend.prototype.MIDDLEWARE_ACTIONS = {
   readSnapshots: 'readSnapshots',
   // Received a message from a client
   receive: 'receive',
-  // About to reply to a client message.
+  // About to send a non-error reply to a client message.
   // WARNING: This gets passed a direct reference to the reply object, so
   // be cautious with it. While modifications to the reply message are possible
   // by design, changing existing reply properties can cause weird bugs, since

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -264,7 +264,6 @@ describe('middleware', function() {
         }
         // Directly invoke backend DB method to delete doc, so that
         // client `doc` is unaware of the change.
-        debugger;
         backend.db.commit('dogs', 'fido', {v: 1, del: true}, {v: 2, data: null}, null, function(err) {
           if (err) {
             return done(err);
@@ -284,7 +283,7 @@ describe('middleware', function() {
             // Expect that there was an error.
             expect(err).to.have.property('code', 4017);  // "Document was deleted"
             done();
-          })
+          });
         });
       });
     });

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -254,6 +254,19 @@ describe('middleware', function() {
       });
     });
 
+    it('can produce errors that get sent back to client', function(done) {
+      var errorMessage = 'This is an error from reply middleware';
+      this.backend.use('reply', function(_replyContext, next) {
+        next(errorMessage);
+      });
+      var connection = this.backend.connect();
+      var doc = connection.get('dogs', 'fido');
+      doc.fetch(function(err) {
+        expect(err).to.have.property('message', errorMessage);
+        done();
+      });
+    });
+
     it('can make raw additions to query reply extra', function(done) {
       var snapshot = this.snapshot;
       this.backend.use('reply', function(replyContext, next) {

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -254,40 +254,6 @@ describe('middleware', function() {
       });
     });
 
-    it('triggers on errors', function(done) {
-      var backend = this.backend;
-      var connection = this.backend.connect();
-      var doc = connection.get('dogs', 'fido');
-      doc.fetch(function(err) {
-        if (err) {
-          return done(err);
-        }
-        // Directly invoke backend DB method to delete doc, so that
-        // client `doc` is unaware of the change.
-        backend.db.commit('dogs', 'fido', {v: 1, del: true}, {v: 2, data: null}, null, function(err) {
-          if (err) {
-            return done(err);
-          }
-          // Submitting op on deleted doc should result in an error.
-          var newOp = {p: ['age'], na: 1};
-          backend.use('reply', function(replyContext, next) {
-            var reply = replyContext.reply;
-            expect(reply.a).to.eql('op');
-            expect(reply.c).to.eql('dogs');
-            expect(reply.d).to.eql('fido');
-            expect(reply.op).to.eql([newOp]);
-            expect(reply.error).to.have.property('code', 4017);  // "Document was deleted"
-            next();
-          });
-          doc.submitOp(newOp, function(err) {
-            // Expect that there was an error.
-            expect(err).to.have.property('code', 4017);  // "Document was deleted"
-            done();
-          });
-        });
-      });
-    });
-
     it('can make raw additions to query reply extra', function(done) {
       var snapshot = this.snapshot;
       this.backend.use('reply', function(replyContext, next) {


### PR DESCRIPTION
The "reply" middleware is called just before the backend is about to send a non-error reply to a client.

It's the flip side of the existing "receive" middleware action.

The middleware function gets a context with these properties:
- request
- reply
- action (always `'reply'` for this middleware)
- agent
- backend