### PR TITLE
Use @teamwork/websocket-json-stream in textarea example

### DIFF
--- a/examples/textarea/package.json
+++ b/examples/textarea/package.json
@@ -18,7 +18,7 @@
     "reconnecting-websocket": "^3.0.3",
     "sharedb": "^1.0.0-beta",
     "sharedb-string-binding": "^1.0.0",
-    "websocket-json-stream": "^0.0.1",
+    "@teamwork/websocket-json-stream": "^2.0.0",
     "ws": "^1.1.0"
   },
   "devDependencies": {

--- a/examples/textarea/server.js
+++ b/examples/textarea/server.js
@@ -2,7 +2,7 @@ var http = require('http');
 var express = require('express');
 var ShareDB = require('sharedb');
 var WebSocket = require('ws');
-var WebSocketJSONStream = require('websocket-json-stream');
+var WebSocketJSONStream = require('@teamwork/websocket-json-stream');
 
 var backend = new ShareDB();
 createDoc(startServer);


### PR DESCRIPTION
Closes  #280

Since the [example in README.md uses @teamwork/websocket-json-stream](https://github.com/share/sharedb/pull/276/files), I thought it would make sense to also have the code examples use it.

There is a slight issue at the moment with this change, I'm not sure why. It's documented here [Teamwork/websocket-json-stream: Error with ShareDB Usage](https://github.com/Teamwork/websocket-json-stream/issues/3).

If we proress here, I'd like to also propose updating the other examples in the same way, then once they work, update all their dependencies generally, which are getting out of date.

Related to discussion here https://github.com/share/sharedb/issues/275