### PR TITLE
Update rest of examples to @teamwork/websocket-json-stream

### DIFF
--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "express": "^4.14.0",
     "sharedb": "^1.0.0-beta",
-    "websocket-json-stream": "^0.0.1",
+    "@teamwork/websocket-json-stream": "^2.0.0",
     "ws": "^1.1.0"
   },
   "devDependencies": {

--- a/examples/counter/server.js
+++ b/examples/counter/server.js
@@ -2,7 +2,7 @@ var http = require('http');
 var express = require('express');
 var ShareDB = require('sharedb');
 var WebSocket = require('ws');
-var WebSocketJSONStream = require('websocket-json-stream');
+var WebSocketJSONStream = require('@teamwork/websocket-json-stream');
 
 var backend = new ShareDB();
 createDoc(startServer);

--- a/examples/leaderboard/package.json
+++ b/examples/leaderboard/package.json
@@ -24,7 +24,7 @@
     "sharedb-mingo-memory": "^1.0.0-beta",
     "through2": "^2.0.1",
     "underscore": "^1.8.3",
-    "websocket-json-stream": "^0.0.3",
+    "@teamwork/websocket-json-stream": "^2.0.0",
     "ws": "^1.1.0"
   },
   "devDependencies": {

--- a/examples/leaderboard/server/index.js
+++ b/examples/leaderboard/server/index.js
@@ -3,7 +3,7 @@ var ShareDB = require("sharedb");
 var connect = require("connect");
 var serveStatic = require('serve-static');
 var ShareDBMingoMemory = require('sharedb-mingo-memory');
-var WebSocketJSONStream = require('websocket-json-stream');
+var WebSocketJSONStream = require('@teamwork/websocket-json-stream');
 var WebSocket = require('ws');
 var util = require('util');
 

--- a/examples/rich-text/package.json
+++ b/examples/rich-text/package.json
@@ -18,7 +18,7 @@
     "quill": "^1.0.0-beta.11",
     "rich-text": "^3.0.1",
     "sharedb": "^1.0.0-beta",
-    "websocket-json-stream": "^0.0.1",
+    "@teamwork/websocket-json-stream": "^2.0.0",
     "ws": "^1.1.0"
   },
   "devDependencies": {

--- a/examples/rich-text/server.js
+++ b/examples/rich-text/server.js
@@ -3,7 +3,7 @@ var express = require('express');
 var ShareDB = require('sharedb');
 var richText = require('rich-text');
 var WebSocket = require('ws');
-var WebSocketJSONStream = require('websocket-json-stream');
+var WebSocketJSONStream = require('@teamwork/websocket-json-stream');
 
 ShareDB.types.register(richText.type);
 var backend = new ShareDB();


### PR DESCRIPTION
This finishes up the work started to update the README (https://github.com/share/sharedb/pull/276) and the textarea example (https://github.com/share/sharedb/pull/281).

`@teamwork/websocket-json-stream` is more actively maintained. See https://github.com/share/sharedb/issues/275 for the discussion around switching.