### PR TITLE
Rename `afterSubmit` middleware hook to `afterWrite`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Register a new middleware.
     before being committed to the database
   * `'commit'`: An operation was applied to a snapshot; The operation
     and new snapshot are about to be written to the database.
-  * `'afterSubmit'`: An operation was successfully submitted to
+  * `'afterWrite'`: An operation was successfully written to
     the database.
   * `'receive'`: Received a message from a client
   * `'reply'`: About to send a non-error reply to a client message
@@ -321,7 +321,7 @@ Populate the fields on `doc` with a snapshot of the document from the server.
 Populate the fields on `doc` with a snapshot of the document from the server, and
 fire events on subsequent changes.
 
-`doc.unsubscribe(function (err) {...})`	
+`doc.unsubscribe(function (err) {...})`
 Stop listening for document updates. The document data at the time of unsubscribing remains in memory, but no longer stays up-to-date. Resubscribe with `doc.subscribe`.
 
 `doc.ingestSnapshot(snapshot, callback)`

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -18,9 +18,9 @@ var warnDeprecatedAfterSubmit = true;
 var DOC_ACTION_DEPRECATION_WARNING = 'DEPRECATED: "doc" middleware action. Use "readSnapshots" instead. ' +
   'Pass `disableDocAction: true` option to ShareDB to disable the "doc" action and this warning.';
 
-var AFFTER_SUBMIT_ACTION_DEPRECATION_WARNING = 'DEPRECATED: "after submit" middleware action. ' +
-  'Use "afterSubmit" instead. Pass `disableSpaceDelimitedActions: true` option to ShareDB to ' +
-  'disable the "after submit" action and this warning.';
+var AFTER_SUBMIT_ACTION_DEPRECATION_WARNING = 'DEPRECATED: "after submit" and "afterSubmit" middleware actions. ' +
+  'Use "afterWrite" instead. Pass `disableSpaceDelimitedActions: true` option to ShareDB to ' +
+  'disable the "after submit" and "afterSubmit" actions and this warning.';
 
 function Backend(options) {
   if (!(this instanceof Backend)) return new Backend(options);
@@ -59,10 +59,12 @@ module.exports = Backend;
 emitter.mixin(Backend);
 
 Backend.prototype.MIDDLEWARE_ACTIONS = {
-  // An operation was successfully submitted to the database.
+  // DEPRECATED: Synonym for 'afterWrite'
   afterSubmit: 'afterSubmit',
-  // DEPRECATED: Synonym for 'afterSubmit'
+  // DEPRECATED: Synonym for 'afterWrite'
   'after submit': 'after submit',
+  // An operation was successfully written to the database.
+  afterWrite: 'afterWrite',
   // An operation is about to be applied to a snapshot before being committed to the database
   apply: 'apply',
   // An operation was applied to a snapshot; The operation and new snapshot are about to be written to the database.
@@ -114,16 +116,19 @@ Backend.prototype._shimDocAction = function() {
 };
 
 // Shim for backwards compatibility with deprecated middleware action name.
-// The action 'after submit' is now 'afterSubmit'.
+// The actions 'after submit' and 'afterSubmit' are now 'afterWrite'.
 Backend.prototype._shimAfterSubmit = function() {
   if (warnDeprecatedAfterSubmit) {
     warnDeprecatedAfterSubmit = false;
-    console.warn(AFFTER_SUBMIT_ACTION_DEPRECATION_WARNING);
+    console.warn(AFTER_SUBMIT_ACTION_DEPRECATION_WARNING);
   }
 
   var backend = this;
-  this.use(backend.MIDDLEWARE_ACTIONS.afterSubmit, function(request, callback) {
+  this.use(backend.MIDDLEWARE_ACTIONS.afterWrite, function(request, callback) {
     backend.trigger(backend.MIDDLEWARE_ACTIONS['after submit'], request.agent, request, callback);
+  });
+  this.use(backend.MIDDLEWARE_ACTIONS.afterWrite, function(request, callback) {
+    backend.trigger(backend.MIDDLEWARE_ACTIONS['afterSubmit'], request.agent, request, callback);
   });
 };
 
@@ -251,7 +256,7 @@ Backend.prototype.submit = function(agent, index, id, op, options, callback) {
     if (err) return callback(err);
     request.submit(function(err) {
       if (err) return callback(err);
-      backend.trigger(backend.MIDDLEWARE_ACTIONS.afterSubmit, agent, request, function(err) {
+      backend.trigger(backend.MIDDLEWARE_ACTIONS.afterWrite, agent, request, function(err) {
         if (err) return callback(err);
         backend._sanitizeOps(agent, request.projection, request.collection, id, request.ops, function(err) {
           if (err) return callback(err);

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -283,8 +283,8 @@ describe('middleware', function() {
   });
 
   describe('submit lifecycle', function() {
-    // DEPRECATED: 'after submit' is a synonym for 'afterSubmit'
-    ['submit', 'apply', 'commit', 'afterSubmit', 'after submit'].forEach(function(action) {
+    // DEPRECATED: 'after submit' and 'afterSubmit' are synonyms for 'afterWrite'
+    ['submit', 'apply', 'commit', 'afterWrite', 'afterSubmit', 'after submit'].forEach(function(action) {
       it(action + ' gets options passed to backend.submit', function(done) {
         var doneAfter = util.callAfter(1, done);
         this.backend.use(action, function(request, next) {


### PR DESCRIPTION
Fixes https://github.com/share/sharedb/issues/313

`afterSubmit` is a potentially confusing middleware hook, as it might
suggest that it takes place after an op has been submitted, but _before_
it has been processed and committed.

This change renames the hook to the slightly clearer `afterWrite` hook,
which conveys that the op has actually been written.