### PR TITLE
Support query subscriptions on projections with a filter not in the projection fields

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,6 +1,6 @@
 var hat = require('hat');
-var util = require('./util');
 var types = require('./types');
+var util = require('./util');
 var logger = require('./logger');
 
 /**
@@ -105,16 +105,7 @@ Agent.prototype._subscribeToStream = function(collection, id, stream) {
       logger.error('Doc subscription stream error', collection, id, data.error);
       return;
     }
-    if (agent._isOwnOp(collection, data)) return;
-
-    agent._sanitizeOp(collection, id, data, function(err) {
-      if (agent.closed) return;
-      if (err) {
-        logger.error('Doc subscription stream error', collection, id, err);
-        return;
-      }
-      agent._sendOp(collection, id, data);
-    });
+    agent._onOp(collection, id, data);
   });
   stream.on('end', function() {
     // The op stream is done sending, so release its reference
@@ -157,11 +148,43 @@ Agent.prototype._subscribeToQuery = function(emitter, queryId, collection, query
 
   emitter.onOp = function(op) {
     var id = op.d;
-    if (agent._isOwnOp(collection, op)) return;
-    agent._sendOp(collection, id, op);
+    agent._onOp(collection, id, op);
   };
 
   emitter._open();
+};
+
+Agent.prototype._onOp = function(collection, id, op) {
+  if (this._isOwnOp(collection, op)) return;
+
+  // Ops emitted here are coming directly from pubsub, which emits the same op
+  // object to listeners without making a copy. The pattern in middleware is to
+  // manipulate the passed in object, and projections are implemented the same
+  // way currently.
+  //
+  // Deep copying the op would be safest, but deep copies are very expensive,
+  // especially over arbitrary objects. This function makes a shallow copy of an
+  // op, and it requires that projections and any user middleware copy deep
+  // properties as needed when they modify the op.
+  //
+  // Polling of query subscriptions is determined by the same op objects. As a
+  // precaution against op middleware breaking query subscriptions, we delay
+  // before calling into projection and middleware code
+  var agent = this;
+  process.nextTick(function() {
+    var copy = shallowCopyOp(op);
+    if (!copy) {
+      logger.error('Op emitted from subscription failed to copy', collection, id, op);
+      return;
+    }
+    agent.backend.sanitizeOp(agent, collection, id, copy, function(err) {
+      if (err) {
+        logger.error('Error sanitizing op emitted from subscription', collection, id, copy, err);
+        return;
+      }
+      agent._sendOp(collection, id, copy);
+    });
+  });
 };
 
 Agent.prototype._isOwnOp = function(collection, op) {
@@ -169,22 +192,6 @@ Agent.prototype._isOwnOp = function(collection, op) {
   // these in, the submit reply will be sufficient and we can silently ignore
   // them in the streams for subscribed documents or queries
   return (this.clientId === op.src) && (collection === (op.i || op.c));
-};
-
-/**
- * Sanitizes an op in-place, including applying a projection if relevant.
- *
- * @param collectionName {string} - name of a collection or projection
- * @param id {string} - document id for the op
- * @param op {object} - op to sanitize in-place
- */
-Agent.prototype._sanitizeOp = function(collectionName, id, op, cb) {
-  var projection = this.backend.projections[collectionName];
-  var dbCollection = (projection) ? projection.target : collectionName;
-  this.backend._sanitizeOp(this, projection, dbCollection, id, op, function(err) {
-    if (err) return cb(err);
-    cb();
-  });
 };
 
 Agent.prototype.send = function(message) {
@@ -210,10 +217,15 @@ Agent.prototype._sendOp = function(collection, id, op) {
 
   this.send(message);
 };
-
 Agent.prototype._sendOps = function(collection, id, ops) {
   for (var i = 0; i < ops.length; i++) {
     this._sendOp(collection, id, ops[i]);
+  }
+};
+Agent.prototype._sendOpsBulk = function(collection, opsMap) {
+  for (var id in opsMap) {
+    var ops = opsMap[id];
+    this._sendOps(collection, id, ops);
   }
 };
 
@@ -340,7 +352,8 @@ Agent.prototype._handleMessage = function(request, callback) {
       case 'u':
         return this._unsubscribe(request.c, request.d, callback);
       case 'op':
-        var op = this._createOp(request);
+        // Normalize the properties submitted
+        var op = createClientOp(request, this.clientId);
         if (!op) return callback({code: 4000, message: 'Invalid op message'});
         return this._submit(request.c, request.d, op, callback);
       case 'nf':
@@ -517,10 +530,7 @@ Agent.prototype._fetchBulkOps = function(collection, versions, callback) {
   var agent = this;
   this.backend.getOpsBulk(this, collection, versions, null, function(err, opsMap) {
     if (err) return callback(err);
-    for (var id in opsMap) {
-      var ops = opsMap[id];
-      agent._sendOps(collection, id, ops);
-    }
+    agent._sendOpsBulk(collection, opsMap);
     callback();
   });
 };
@@ -529,8 +539,18 @@ Agent.prototype._subscribe = function(collection, id, version, callback) {
   // If the version is specified, catch the client up by sending all ops
   // since the specified version
   var agent = this;
-  this.backend.subscribe(this, collection, id, version, function(err, stream, snapshot) {
+  this.backend.subscribe(this, collection, id, version, function(err, stream, snapshot, ops) {
     if (err) return callback(err);
+    // If we're subscribing from a known version, send any ops committed since
+    // the requested version to bring the client's doc up to date
+    if (ops) {
+      agent._sendOps(collection, id, ops);
+    }
+    // In addition, ops may already be queued on the stream by pubsub.
+    // Subscribe is called before the ops or snapshot are fetched, so it is
+    // possible that some ops may be duplicates. Clients should ignore any
+    // duplicate ops they may receive. This will flush ops already queued and
+    // subscribe to ongoing ops from the stream
     agent._subscribeToStream(collection, id, stream);
     // Snapshot is returned only when subscribing from a null version.
     // Otherwise, ops will have been pushed into the stream
@@ -543,9 +563,13 @@ Agent.prototype._subscribe = function(collection, id, version, callback) {
 };
 
 Agent.prototype._subscribeBulk = function(collection, versions, callback) {
+  // See _subscribe() above. This function's logic should match but in bulk
   var agent = this;
-  this.backend.subscribeBulk(this, collection, versions, function(err, streams, snapshotMap) {
+  this.backend.subscribeBulk(this, collection, versions, function(err, streams, snapshotMap, opsMap) {
     if (err) return callback(err);
+    if (opsMap) {
+      agent._sendOpsBulk(collection, opsMap);
+    }
     for (var id in streams) {
       agent._subscribeToStream(collection, id, streams[id]);
     }
@@ -596,41 +620,6 @@ Agent.prototype._submit = function(collection, id, op, callback) {
   });
 };
 
-function CreateOp(src, seq, v, create) {
-  this.src = src;
-  this.seq = seq;
-  this.v = v;
-  this.create = create;
-  this.m = null;
-}
-function EditOp(src, seq, v, op) {
-  this.src = src;
-  this.seq = seq;
-  this.v = v;
-  this.op = op;
-  this.m = null;
-}
-function DeleteOp(src, seq, v, del) {
-  this.src = src;
-  this.seq = seq;
-  this.v = v;
-  this.del = del;
-  this.m = null;
-}
-// Normalize the properties submitted
-Agent.prototype._createOp = function(request) {
-  // src can be provided if it is not the same as the current agent,
-  // such as a resubmission after a reconnect, but it usually isn't needed
-  var src = request.src || this.clientId;
-  if (request.op) {
-    return new EditOp(src, request.seq, request.v, request.op);
-  } else if (request.create) {
-    return new CreateOp(src, request.seq, request.v, request.create);
-  } else if (request.del) {
-    return new DeleteOp(src, request.seq, request.v, request.del);
-  }
-};
-
 Agent.prototype._fetchSnapshot = function(collection, id, version, callback) {
   this.backend.fetchSnapshot(this, collection, id, version, callback);
 };
@@ -638,3 +627,50 @@ Agent.prototype._fetchSnapshot = function(collection, id, version, callback) {
 Agent.prototype._fetchSnapshotByTimestamp = function(collection, id, timestamp, callback) {
   this.backend.fetchSnapshotByTimestamp(this, collection, id, timestamp, callback);
 };
+
+
+function createClientOp(request, clientId) {
+  // src can be provided if it is not the same as the current agent,
+  // such as a resubmission after a reconnect, but it usually isn't needed
+  var src = request.src || clientId;
+  // c, d, and m arguments are intentionally undefined. These are set later
+  return (request.op) ? new EditOp(src, request.seq, request.v, request.op) :
+    (request.create) ? new CreateOp(src, request.seq, request.v, request.create) :
+      (request.del) ? new DeleteOp(src, request.seq, request.v, request.del) :
+        undefined;
+}
+
+function shallowCopyOp(op) {
+  return (op.op) ? new EditOp(op.src, op.seq, op.v, op.op, op.c, op.d, op.m) :
+    (op.create) ? new CreateOp(op.src, op.seq, op.v, op.create, op.c, op.d, op.m) :
+      (op.del) ? new DeleteOp(op.src, op.seq, op.v, op.del, op.c, op.d, op.m) :
+        undefined;
+}
+
+function CreateOp(src, seq, v, create, c, d, m) {
+  this.src = src;
+  this.seq = seq;
+  this.v = v;
+  this.create = create;
+  this.c = c;
+  this.d = d;
+  this.m = m;
+}
+function EditOp(src, seq, v, op, c, d, m) {
+  this.src = src;
+  this.seq = seq;
+  this.v = v;
+  this.op = op;
+  this.c = c;
+  this.d = d;
+  this.m = m;
+}
+function DeleteOp(src, seq, v, del, c, d, m) {
+  this.src = src;
+  this.seq = seq;
+  this.v = v;
+  this.del = del;
+  this.c = c;
+  this.d = d;
+  this.m = m;
+}

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -106,7 +106,15 @@ Agent.prototype._subscribeToStream = function(collection, id, stream) {
       return;
     }
     if (agent._isOwnOp(collection, data)) return;
-    agent._sendOp(collection, id, data);
+
+    agent._sanitizeOp(collection, id, data, function(err) {
+      if (agent.closed) return;
+      if (err) {
+        logger.error('Doc subscription stream error', collection, id, err);
+        return;
+      }
+      agent._sendOp(collection, id, data);
+    });
   });
   stream.on('end', function() {
     // The op stream is done sending, so release its reference
@@ -161,6 +169,22 @@ Agent.prototype._isOwnOp = function(collection, op) {
   // these in, the submit reply will be sufficient and we can silently ignore
   // them in the streams for subscribed documents or queries
   return (this.clientId === op.src) && (collection === (op.i || op.c));
+};
+
+/**
+ * Sanitizes an op in-place, including applying a projection if relevant.
+ *
+ * @param collectionName {string} - name of a collection or projection
+ * @param id {string} - document id for the op
+ * @param op {object} - op to sanitize in-place
+ */
+Agent.prototype._sanitizeOp = function(collectionName, id, op, cb) {
+  var projection = this.backend.projections[collectionName];
+  var dbCollection = (projection) ? projection.target : collectionName;
+  this.backend._sanitizeOp(this, projection, dbCollection, id, op, function(err) {
+    if (err) return cb(err);
+    cb();
+  });
 };
 
 Agent.prototype.send = function(message) {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -206,7 +206,7 @@ Backend.prototype.use = function(action, fn) {
     for (var i = 0; i < action.length; i++) {
       this.use(action[i], fn);
     }
-    return;
+    return this;
   }
   var fns = this.middleware[action] || (this.middleware[action] = []);
   fns.push(fn);

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -263,6 +263,12 @@ Backend.prototype.submit = function(agent, index, id, op, options, callback) {
   });
 };
 
+Backend.prototype.sanitizeOp = function(agent, index, id, op, callback) {
+  var projection = this.projections[index];
+  var collection = (projection) ? projection.target : index;
+  this._sanitizeOp(agent, projection, collection, id, op, callback);
+};
+
 Backend.prototype._sanitizeOp = function(agent, projection, collection, id, op, callback) {
   if (projection) {
     try {
@@ -317,6 +323,28 @@ Backend.prototype._getSnapshotsFromMap = function(ids, snapshotMap) {
   return snapshots;
 };
 
+Backend.prototype._getSanitizedOps = function(agent, projection, collection, id, from, to, opsOptions, callback) {
+  var backend = this;
+  backend.db.getOps(collection, id, from, to, opsOptions, function(err, ops) {
+    if (err) return callback(err);
+    backend._sanitizeOps(agent, projection, collection, id, ops, function(err) {
+      if (err) return callback(err);
+      callback(null, ops);
+    });
+  });
+};
+
+Backend.prototype._getSanitizedOpsBulk = function(agent, projection, collection, fromMap, toMap, opsOptions, callback) {
+  var backend = this;
+  backend.db.getOpsBulk(collection, fromMap, toMap, opsOptions, function(err, opsMap) {
+    if (err) return callback(err);
+    backend._sanitizeOpsBulk(agent, projection, collection, opsMap, function(err) {
+      if (err) return callback(err);
+      callback(null, opsMap);
+    });
+  });
+};
+
 // Non inclusive - gets ops from [from, to). Ie, all relevant ops. If to is
 // not defined (null or undefined) then it returns all ops.
 Backend.prototype.getOps = function(agent, index, id, from, to, options, callback) {
@@ -337,13 +365,10 @@ Backend.prototype.getOps = function(agent, index, id, from, to, options, callbac
     to: to
   };
   var opsOptions = options && options.opsOptions;
-  backend.db.getOps(collection, id, from, to, opsOptions, function(err, ops) {
+  backend._getSanitizedOps(agent, projection, collection, id, from, to, opsOptions, function(err, ops) {
     if (err) return callback(err);
-    backend._sanitizeOps(agent, projection, collection, id, ops, function(err) {
-      if (err) return callback(err);
-      backend.emit('timing', 'getOps', Date.now() - start, request);
-      callback(err, ops);
-    });
+    backend.emit('timing', 'getOps', Date.now() - start, request);
+    callback(null, ops);
   });
 };
 
@@ -364,13 +389,10 @@ Backend.prototype.getOpsBulk = function(agent, index, fromMap, toMap, options, c
     toMap: toMap
   };
   var opsOptions = options && options.opsOptions;
-  backend.db.getOpsBulk(collection, fromMap, toMap, opsOptions, function(err, opsMap) {
+  backend._getSanitizedOpsBulk(agent, projection, collection, fromMap, toMap, opsOptions, function(err, opsMap) {
     if (err) return callback(err);
-    backend._sanitizeOpsBulk(agent, projection, collection, opsMap, function(err) {
-      if (err) return callback(err);
-      backend.emit('timing', 'getOpsBulk', Date.now() - start, request);
-      callback(err, opsMap);
-    });
+    backend.emit('timing', 'getOpsBulk', Date.now() - start, request);
+    callback(null, opsMap);
   });
 };
 
@@ -471,21 +493,25 @@ Backend.prototype.subscribe = function(agent, index, id, version, options, callb
   };
   backend.pubsub.subscribe(channel, function(err, stream) {
     if (err) return callback(err);
-    stream.initProjection(backend, agent, projection);
     if (version == null) {
       // Subscribing from null means that the agent doesn't have a document
       // and needs to fetch it as well as subscribing
       backend.fetch(agent, index, id, function(err, snapshot) {
-        if (err) return callback(err);
+        if (err) {
+          stream.destroy();
+          return callback(err);
+        }
         backend.emit('timing', 'subscribe.snapshot', Date.now() - start, request);
         callback(null, stream, snapshot);
       });
     } else {
-      backend.db.getOps(collection, id, version, null, null, function(err, ops) {
-        if (err) return callback(err);
-        stream.pushOps(collection, id, ops);
+      backend._getSanitizedOps(agent, projection, collection, id, version, null, null, function(err, ops) {
+        if (err) {
+          stream.destroy();
+          return callback(err);
+        }
         backend.emit('timing', 'subscribe.ops', Date.now() - start, request);
-        callback(null, stream);
+        callback(null, stream, null, ops);
       });
     }
   });
@@ -509,7 +535,6 @@ Backend.prototype.subscribeBulk = function(agent, index, versions, callback) {
     var channel = backend.getDocChannel(collection, id);
     backend.pubsub.subscribe(channel, function(err, stream) {
       if (err) return eachCb(err);
-      stream.initProjection(backend, agent, projection);
       streams[id] = stream;
       eachCb();
     });
@@ -530,17 +555,13 @@ Backend.prototype.subscribeBulk = function(agent, index, versions, callback) {
       });
     } else {
       // If a versions map, get ops since requested versions
-      backend.db.getOpsBulk(collection, versions, null, null, function(err, opsMap) {
+      backend._getSanitizedOpsBulk(agent, projection, collection, versions, null, null, function(err, opsMap) {
         if (err) {
           destroyStreams(streams);
           return callback(err);
         }
-        for (var id in opsMap) {
-          var ops = opsMap[id];
-          streams[id].pushOps(collection, id, ops);
-        }
         backend.emit('timing', 'subscribeBulk.ops', Date.now() - start, request);
-        callback(null, streams);
+        callback(null, streams, null, opsMap);
       });
     }
   });
@@ -582,7 +603,6 @@ Backend.prototype.querySubscribe = function(agent, index, query, options, callba
     }
     backend.pubsub.subscribe(request.channel, function(err, stream) {
       if (err) return callback(err);
-      stream.initProjection(backend, agent, request.projection);
       if (options.ids) {
         var queryEmitter = new QueryEmitter(request, stream, options.ids);
         backend.emit('timing', 'querySubscribe.reconnect', Date.now() - start, request);

--- a/lib/op-stream.js
+++ b/lib/op-stream.js
@@ -22,6 +22,7 @@ OpStream.prototype._read = util.doNothing;
 OpStream.prototype.pushData = function(data) {
   // Ignore any messages after unsubscribe
   if (!this.open) return;
+  // This data gets consumed in Agent#_subscribeToStream
   this.push(data);
 };
 

--- a/lib/op-stream.js
+++ b/lib/op-stream.js
@@ -30,18 +30,10 @@ OpStream.prototype.initProjection = function(backend, agent, projection) {
   this.projection = projection;
 };
 
-OpStream.prototype.pushOp = function(collection, id, op) {
-  if (this.backend) {
-    var stream = this;
-    this.backend._sanitizeOp(this.agent, this.projection, collection, id, op, function(err) {
-      if (!stream.open) return;
-      stream.push(err ? {error: err} : op);
-    });
-  } else {
-    // Ignore any messages after unsubscribe
-    if (!this.open) return;
-    this.push(op);
-  }
+OpStream.prototype.pushOp = function(_collection, _id, op) {
+  // Ignore any messages after unsubscribe
+  if (!this.open) return;
+  this.push(op);
 };
 
 OpStream.prototype.pushOps = function(collection, id, ops) {

--- a/lib/op-stream.js
+++ b/lib/op-stream.js
@@ -5,12 +5,7 @@ var util = require('./util');
 // Stream of operations. Subscribe returns one of these
 function OpStream() {
   Readable.call(this, {objectMode: true});
-
   this.id = null;
-  this.backend = null;
-  this.agent = null;
-  this.projection = null;
-
   this.open = true;
 }
 module.exports = OpStream;
@@ -24,25 +19,14 @@ inherits(OpStream, Readable);
 // themselves.
 OpStream.prototype._read = util.doNothing;
 
-OpStream.prototype.initProjection = function(backend, agent, projection) {
-  this.backend = backend;
-  this.agent = agent;
-  this.projection = projection;
-};
-
-OpStream.prototype.pushOp = function(_collection, _id, op) {
+OpStream.prototype.pushData = function(data) {
   // Ignore any messages after unsubscribe
   if (!this.open) return;
-  this.push(op);
-};
-
-OpStream.prototype.pushOps = function(collection, id, ops) {
-  for (var i = 0; i < ops.length; i++) {
-    this.pushOp(collection, id, ops[i]);
-  }
+  this.push(data);
 };
 
 OpStream.prototype.destroy = function() {
+  // Only close stream once
   if (!this.open) return;
   this.open = false;
 

--- a/lib/pubsub/index.js
+++ b/lib/pubsub/index.js
@@ -90,8 +90,7 @@ PubSub.prototype._emit = function(channel, data) {
   var channelStreams = this.streams[channel];
   if (channelStreams) {
     for (var id in channelStreams) {
-      var copy = shallowCopy(data);
-      channelStreams[id].pushOp(copy.c, copy.d, copy);
+      channelStreams[id].pushData(data);
     }
   }
 };
@@ -129,11 +128,3 @@ PubSub.prototype._removeStream = function(channel, stream) {
 
   this._unsubscribe(channel, this._defaultCallback);
 };
-
-function shallowCopy(object) {
-  var out = {};
-  for (var key in object) {
-    out[key] = object[key];
-  }
-  return out;
-}

--- a/lib/query-emitter.js
+++ b/lib/query-emitter.js
@@ -63,7 +63,6 @@ QueryEmitter.prototype._emitTiming = function(action, start) {
 };
 
 QueryEmitter.prototype._update = function(op) {
-  var emitter = this;
   var id = op.d;
 
   // Check if the op's id matches the query before updating the query results
@@ -91,17 +90,11 @@ QueryEmitter.prototype._update = function(op) {
   // that removed the doc from the query to cause the client-side computed
   // list to update.
   if (this.ids.indexOf(id) !== -1) {
-    // Defer applying projection to the op until _after_ the skipPoll checks.
-    // It's possible for a query to filter on a field that's not in the projection. skipPoll checks
-    // to see if an op could possibly affect a query, so it should get passed the full op.
-    process.nextTick(function() {
-      emitter.agent._sanitizeOp(emitter.index, id, op, function(err) {
-        if (err) {
-          return emitter._defaultCallback(err);
-        }
-        emitter.onOp(op);
-      });
-    });
+    // Note that this op is not projected or sanitized yet. It's possible for a
+    // query to filter on a field that's not in the projection. skipPoll checks
+    // to see if an op could possibly affect a query, so it should get passed
+    // the full op. The onOp listener function must call backend.sanitizeOp()
+    this.onOp(op);
   }
 
   // Ignore if the database or user function says we don't need to poll

--- a/lib/query-emitter.js
+++ b/lib/query-emitter.js
@@ -63,6 +63,7 @@ QueryEmitter.prototype._emitTiming = function(action, start) {
 };
 
 QueryEmitter.prototype._update = function(op) {
+  var emitter = this;
   var id = op.d;
 
   // Check if the op's id matches the query before updating the query results
@@ -90,7 +91,17 @@ QueryEmitter.prototype._update = function(op) {
   // that removed the doc from the query to cause the client-side computed
   // list to update.
   if (this.ids.indexOf(id) !== -1) {
-    this.onOp(op);
+    // Defer applying projection to the op until _after_ the skipPoll checks.
+    // It's possible for a query to filter on a field that's not in the projection. skipPoll checks
+    // to see if an op could possibly affect a query, so it should get passed the full op.
+    process.nextTick(function() {
+      emitter.agent._sanitizeOp(emitter.index, id, op, function(err) {
+        if (err) {
+          return emitter._defaultCallback(err);
+        }
+        emitter.onOp(op);
+      });
+    });
   }
 
   // Ignore if the database or user function says we don't need to poll

--- a/test/BasicQueryableMemoryDB.js
+++ b/test/BasicQueryableMemoryDB.js
@@ -1,0 +1,65 @@
+var MemoryDB = require('../lib/db/memory');
+
+module.exports = BasicQueryableMemoryDB;
+
+// Extension of MemoryDB that supports query filters and sorts on simple
+// top-level properties, which is enough for the core ShareDB tests on
+// query subscription updating.
+function BasicQueryableMemoryDB() {
+  MemoryDB.apply(this, arguments);
+}
+BasicQueryableMemoryDB.prototype = Object.create(MemoryDB.prototype);
+BasicQueryableMemoryDB.prototype.constructor = BasicQueryableMemoryDB;
+
+BasicQueryableMemoryDB.prototype._querySync = function(snapshots, query) {
+  if (query.filter) {
+    snapshots = snapshots.filter(function(snapshot) {
+      for (var queryKey in query.filter) {
+        // This fake only supports simple property equality filters, so
+        // throw an error on Mongo-like filter properties with dots.
+        if (queryKey.includes('.')) {
+          throw new Error('Only simple property filters are supported, got:', queryKey);
+        }
+        if (snapshot.data[queryKey] !== query.filter[queryKey]) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }
+
+  if (query.sort) {
+    if (!Array.isArray(query.sort)) {
+      throw new Error('query.sort must be an array');
+    }
+    if (query.sort.length) {
+      snapshots.sort(snapshotComparator(query.sort));
+    }
+  }
+
+  return {snapshots: snapshots};
+};
+
+// sortProperties is an array whose items are each [propertyName, direction].
+function snapshotComparator(sortProperties) {
+  return function(snapshotA, snapshotB) {
+    for (var i = 0; i < sortProperties.length; i++) {
+      var sortProperty = sortProperties[i];
+      var sortKey = sortProperty[0];
+      var sortDirection = sortProperty[1];
+
+      var aPropVal = snapshotA.data[sortKey];
+      var bPropVal = snapshotB.data[sortKey];
+      if (aPropVal < bPropVal) {
+        return -1 * sortDirection;
+      } else if (aPropVal > bPropVal) {
+        return sortDirection;
+      } else if (aPropVal === bPropVal) {
+        continue;
+      } else {
+        throw new Error('Could not compare ' + aPropVal + ' and ' + bPropVal);
+      }
+    }
+    return 0;
+  };
+}

--- a/test/client/projections.js
+++ b/test/client/projections.js
@@ -1,7 +1,10 @@
 var expect = require('expect.js');
 var util = require('../util');
 
-module.exports = function() {
+module.exports = function(options) {
+  var getQuery = options.getQuery;
+  var matchAllQuery = getQuery({query: {}});
+
   describe('client projections', function() {
     beforeEach(function(done) {
       this.backend.addProjection('dogs_summary', 'dogs', {age: true, owner: true});
@@ -26,7 +29,7 @@ module.exports = function() {
     ['createFetchQuery', 'createSubscribeQuery'].forEach(function(method) {
       it('snapshot ' + method, function(done) {
         var connection2 = this.backend.connect();
-        connection2[method]('dogs_summary', {}, null, function(err, results) {
+        connection2[method]('dogs_summary', matchAllQuery, null, function(err, results) {
           if (err) return done(err);
           expect(results.length).eql(1);
           expect(results[0].data).eql({age: 3, owner: {name: 'jim'}});
@@ -139,7 +142,7 @@ module.exports = function() {
           if (err) return done(err);
           connection.get('dogs', 'fido').submitOp(op, function(err) {
             if (err) return done(err);
-            connection2.createFetchQuery('dogs_summary', {}, null, function(err) {
+            connection2.createFetchQuery('dogs_summary', matchAllQuery, null, function(err) {
               if (err) return done(err);
               expect(fido.data).eql(expected);
               expect(fido.version).eql(2);
@@ -156,7 +159,7 @@ module.exports = function() {
         var connection = this.connection;
         var connection2 = this.backend.connect();
         var fido = connection2.get('dogs_summary', 'fido');
-        connection2.createSubscribeQuery('dogs_summary', {}, null, function(err) {
+        connection2.createSubscribeQuery('dogs_summary', matchAllQuery, null, function(err) {
           if (err) return done(err);
           fido.on('op', function() {
             expect(fido.data).eql(expected);
@@ -194,7 +197,7 @@ module.exports = function() {
       function test(trigger, callback) {
         var connection = this.connection;
         var connection2 = this.backend.connect();
-        var query = connection2.createSubscribeQuery('dogs_summary', {}, null, function(err) {
+        var query = connection2.createSubscribeQuery('dogs_summary', matchAllQuery, null, function(err) {
           if (err) return callback(err);
           query.on('insert', function() {
             callback(null, query.results);
@@ -211,7 +214,7 @@ module.exports = function() {
         var connection2 = this.backend.connect();
         trigger(connection, function(err) {
           if (err) return callback(err);
-          connection2.createFetchQuery('dogs_summary', {}, null, callback);
+          connection2.createFetchQuery('dogs_summary', matchAllQuery, null, callback);
         });
       }
       queryUpdateTests(test);

--- a/test/db-memory.js
+++ b/test/db-memory.js
@@ -1,6 +1,6 @@
 var expect = require('expect.js');
 var DB = require('../lib/db');
-var MemoryDB = require('../lib/db/memory');
+var BasicQueryableMemoryDB = require('./BasicQueryableMemoryDB');
 
 describe('DB base class', function() {
   it('can call db.close() without callback', function() {
@@ -53,69 +53,6 @@ describe('DB base class', function() {
     });
   });
 });
-
-
-// Extension of MemoryDB that supports query filters and sorts on simple
-// top-level properties, which is enough for the core ShareDB tests on
-// query subscription updating.
-function BasicQueryableMemoryDB() {
-  MemoryDB.apply(this, arguments);
-}
-BasicQueryableMemoryDB.prototype = Object.create(MemoryDB.prototype);
-BasicQueryableMemoryDB.prototype.constructor = BasicQueryableMemoryDB;
-
-BasicQueryableMemoryDB.prototype._querySync = function(snapshots, query) {
-  if (query.filter) {
-    snapshots = snapshots.filter(function(snapshot) {
-      for (var queryKey in query.filter) {
-        // This fake only supports simple property equality filters, so
-        // throw an error on Mongo-like filter properties with dots.
-        if (queryKey.includes('.')) {
-          throw new Error('Only simple property filters are supported, got:', queryKey);
-        }
-        if (snapshot.data[queryKey] !== query.filter[queryKey]) {
-          return false;
-        }
-      }
-      return true;
-    });
-  }
-
-  if (query.sort) {
-    if (!Array.isArray(query.sort)) {
-      throw new Error('query.sort must be an array');
-    }
-    if (query.sort.length) {
-      snapshots.sort(snapshotComparator(query.sort));
-    }
-  }
-
-  return {snapshots: snapshots};
-};
-
-// sortProperties is an array whose items are each [propertyName, direction].
-function snapshotComparator(sortProperties) {
-  return function(snapshotA, snapshotB) {
-    for (var i = 0; i < sortProperties.length; i++) {
-      var sortProperty = sortProperties[i];
-      var sortKey = sortProperty[0];
-      var sortDirection = sortProperty[1];
-
-      var aPropVal = snapshotA.data[sortKey];
-      var bPropVal = snapshotB.data[sortKey];
-      if (aPropVal < bPropVal) {
-        return -1 * sortDirection;
-      } else if (aPropVal > bPropVal) {
-        return sortDirection;
-      } else if (aPropVal === bPropVal) {
-        continue;
-      } else {
-        throw new Error('Could not compare ' + aPropVal + ' and ' + bPropVal);
-      }
-    }
-    return 0;
-  };
-}
 
 // Run all the DB-based tests against the BasicQueryableMemoryDB.
 require('./db')({

--- a/test/db.js
+++ b/test/db.js
@@ -36,7 +36,7 @@ module.exports = function(options) {
       });
     });
 
-    require('./client/projections')();
+    require('./client/projections')({getQuery: getQuery});
     require('./client/query-subscribe')({getQuery: getQuery});
     require('./client/query')({getQuery: getQuery});
     require('./client/submit')();

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -24,6 +24,11 @@ describe('middleware', function() {
       var response = this.backend.use('submit', function() {});
       expect(response).equal(this.backend);
     });
+
+    it('accepts an array of action names', function() {
+      var response = this.backend.use(['submit', 'connect'], function() {});
+      expect(response).equal(this.backend);
+    });
   });
 
   describe('connect', function() {


### PR DESCRIPTION
Prior to this PR, if you issue a query subscription on a projection, with a filter field that's not in the projection fields, then an op to change that filter field will not trigger the query to update.

This is because the op projection (`_sanitizeOp`) was happening prior to the `skipPoll` checks, which are what determine if an op could affect a query. A projected op would appear like it doesn't affect the query.

The fix is to defer applying projections to query ops until after the `skipPoll` checks.

I couldn't write a unit test in this repo, since the MemoryDB's query implementation always returns all docs in the collection, regardless of query filters. See below for the test I'll be adding to sharedb-mongo to cover this case.

----

Test I'll be adding to sharedb-mongo, which fails prior to this change and succeeds after this change:

```js
  describe('projection query subscribe', function() {
    var ShareDB = require('sharedb');

    var backend;
    beforeEach(function() {
      backend = new ShareDB({db: this.db});
    });

    it('query subscribe on projection will update based on fields not in projection', function(done) {
      backend.addProjection('notes_text', 'notes', {text: true});
      var connection1 = backend.connect();
      var connection2 = backend.connect();
      // Create doc and a query that doesn't match the doc.
      var doc1 = connection1.get('notes', 'doc1');
      doc1.create({color: 'blue', text: 'Hello', location: 'Work'}, null, null, function(err) {
        if (err) return done(err);
        var query = connection2.createSubscribeQuery('notes_text', {color: 'green'}, null, function(err, results) {
          if (err) return done(err);
          expect(results).to.have.length(0);

          // Submit an op on a field not in the projection, where the op should cause the doc to be
          // included in the query results.
          doc1.submitOp({p: ['color'], od: 'blue', oi: 'green'}, null, function(err) {
            if (err) return done(err);
            setTimeout(function() {
              expect(query.results).to.have.length(1);
              expect(query.results[0].id).to.equal('doc1');
              expect(query.results[0].data).to.eql({text: 'Hello'});
              done();
            }, 10);
          });
        });
      });
    });
  });
});
```