### PR TITLE
Downgrade middleware stack dump from `warn` to `info`

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -201,7 +201,7 @@ function getReplyErrorObject(err) {
     };
   } else {
     if (err.stack) {
-      logger.warn(err.stack);
+      logger.info(err.stack);
     }
     return {
       code: err.code,


### PR DESCRIPTION
Fixes https://github.com/share/sharedb/issues/315

At the moment, if middleware ever returns an `Error` object, its stack
trace will get dumped into `logger.warn`. This can be quite noisy,
especially if those errors are part of normal control flow (eg
authentication).

This behaviour can currently be avoided by passing just a `string` to
the middleware callback (rather than an `Error` object). However, this
is not the "standard" behaviour for callbacks, which will typically be
called with an actual `Error` object, rather than a `string` (eg Node's
[`fs` module][1]).

This change downgrades the logging from `warn` (surprising, but non-
critical) to `info` (unsurprising), so that the information is still
available to those who want it, but doesn't get the same sort of
importance assigned to it as other things we `warn` about, such as:

  - [stream errors][2]
  - [`Agent` close errors][3]
  - [bad messages][4]
  - [bad acks][5]

If consumers want more information about the errors that they are
themselves returning, they can naturally add their own logging logic,
too.

[1]: https://nodejs.org/api/fs.html
[2]: https://github.com/share/sharedb/blob/4f81761723ff14f03217e7a1581f7e81a081e3bd/lib/stream-socket.js#L40
[3]: https://github.com/share/sharedb/blob/985146528a9f63c2ba2d91f99fada7dedf62138a/lib/agent.js#L51
[4]: https://github.com/share/sharedb/blob/985146528a9f63c2ba2d91f99fada7dedf62138a/lib/client/connection.js#L121
[5]: https://github.com/share/sharedb/blob/985146528a9f63c2ba2d91f99fada7dedf62138a/lib/client/doc.js#L849