### PR TITLE
Update dependencies & node versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - "12"
   - "10"
   - "8"
-  - "6"
 script: "npm run lint && npm run test-cover"
 # Send coverage data to Coveralls
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/lib/client/connection.js
+++ b/lib/client/connection.js
@@ -293,8 +293,15 @@ Connection.prototype._setState = function(newState, reason) {
   // 'connecting' from anywhere other than 'disconnected' and getting to
   // 'connected' from anywhere other than 'connecting'.
   if (
-    (newState === 'connecting' && this.state !== 'disconnected' && this.state !== 'stopped' && this.state !== 'closed')
-      || (newState === 'connected' && this.state !== 'connecting')
+    (
+      newState === 'connecting' &&
+      this.state !== 'disconnected' &&
+      this.state !== 'stopped' &&
+      this.state !== 'closed'
+    ) || (
+      newState === 'connected' &&
+      this.state !== 'connecting'
+    )
   ) {
     var err = new ShareDBError(5007, 'Cannot transition directly from ' + this.state + ' to ' + newState);
     return this.emit('error', err);
@@ -303,7 +310,13 @@ Connection.prototype._setState = function(newState, reason) {
   this.state = newState;
   this.canSend = (newState === 'connected');
 
-  if (newState === 'disconnected' || newState === 'stopped' || newState === 'closed') this._reset();
+  if (
+    newState === 'disconnected' ||
+    newState === 'stopped' ||
+    newState === 'closed'
+  ) {
+    this._reset();
+  }
 
   // Group subscribes together to help server make more efficient calls
   this.startBulk();

--- a/lib/query-emitter.js
+++ b/lib/query-emitter.js
@@ -1,5 +1,5 @@
 var arraydiff = require('arraydiff');
-var deepEquals = require('deep-is');
+var deepEqual = require('fast-deep-equal');
 var ShareDBError = require('./error');
 var util = require('./util');
 
@@ -173,7 +173,7 @@ QueryEmitter.prototype.queryPoll = function(callback) {
     emitter._emitTiming('queryEmitter.poll', start);
 
     // Be nice to not have to do this in such a brute force way
-    if (!deepEquals(emitter.extra, extra)) {
+    if (!deepEqual(emitter.extra, extra)) {
       emitter.extra = extra;
       emitter.onExtra(extra);
     }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "arraydiff": "^0.1.1",
     "async": "^3.1.0",
-    "deep-is": "^0.1.3",
+    "fast-deep-equal": "^2.0.1",
     "hat": "0.0.3",
     "make-error": "^1.1.1",
     "ot-json0": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "arraydiff": "^0.1.1",
-    "async": "^3.1.0",
+    "async": "^1.4.2",
     "fast-deep-equal": "^2.0.1",
     "hat": "0.0.3",
     "make-error": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -12,18 +12,18 @@
     "ot-json0": "^1.0.1"
   },
   "devDependencies": {
-    "coveralls": "^2.11.8",
-    "eslint": "^5.16.0",
-    "eslint-config-google": "^0.13.0",
-    "expect.js": "^0.3.1",
-    "istanbul": "^0.4.2",
-    "lolex": "^3.0.0",
-    "mocha": "^5.2.0",
-    "sinon": "^6.1.5"
+    "chai": "^4.2.0",
+    "coveralls": "^3.0.7",
+    "eslint": "^6.5.1",
+    "eslint-config-google": "^0.14.0",
+    "lolex": "^5.1.1",
+    "mocha": "^6.2.2",
+    "nyc": "^14.1.1",
+    "sinon": "^7.5.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha && npm run lint",
-    "test-cover": "node_modules/istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha",
+    "test-cover": "node_modules/nyc/bin/nyc.js --temp-dir=coverage -r text -r lcov node_modules/mocha/bin/_mocha && npm run lint",
     "lint": "./node_modules/.bin/eslint --ignore-path .gitignore '**/*.js'",
     "lint:fix": "npm run lint -- --fix"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "arraydiff": "^0.1.1",
-    "async": "^1.4.2",
+    "async": "^3.1.0",
     "deep-is": "^0.1.3",
     "hat": "0.0.3",
     "make-error": "^1.1.1",

--- a/test/backend.js
+++ b/test/backend.js
@@ -1,5 +1,5 @@
 var Backend = require('../lib/backend');
-var expect = require('expect.js');
+var expect = require('chai').expect;
 
 describe('Backend', function() {
   var backend;
@@ -39,8 +39,8 @@ describe('Backend', function() {
         backend.getOps(null, 'books', '1984', 0, null, options, function(error, ops) {
           if (error) return done(error);
           expect(ops).to.have.length(2);
-          expect(ops[0].m).to.be.ok();
-          expect(ops[1].m).to.be.ok();
+          expect(ops[0].m).to.be.ok;
+          expect(ops[1].m).to.be.ok;
           done();
         });
       });
@@ -64,7 +64,7 @@ describe('Backend', function() {
         };
         backend.fetch(null, 'books', '1984', options, function(error, doc) {
           if (error) return done(error);
-          expect(doc.m).to.be.ok();
+          expect(doc.m).to.be.ok;
           done();
         });
       });
@@ -74,7 +74,7 @@ describe('Backend', function() {
       it('subscribes to the document', function(done) {
         backend.subscribe(null, 'books', '1984', null, function(error, stream, snapshot) {
           if (error) return done(error);
-          expect(stream.open).to.be(true);
+          expect(stream.open).to.equal(true);
           expect(snapshot.data).to.eql({
             title: '1984',
             author: 'George Orwell'
@@ -95,7 +95,7 @@ describe('Backend', function() {
           opsOptions: {metadata: true}
         };
         backend.subscribe(null, 'books', '1984', null, options, function(error) {
-          expect(error.code).to.be(4025);
+          expect(error.code).to.equal(4025);
           done();
         });
       });

--- a/test/client/connection.js
+++ b/test/client/connection.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var Backend = require('../../lib/backend');
 var Connection = require('../../lib/client/connection');
 
@@ -69,7 +69,7 @@ describe('client connection', function() {
         expect(originalStream).to.have.property('open', false);
         var newStream = agent.subscribedDocs[collection][docId];
         expect(newStream).to.have.property('open', true);
-        expect(newStream).to.not.be(originalStream);
+        expect(newStream).to.not.equal(originalStream);
         connection.close();
         done();
       });

--- a/test/client/doc.js
+++ b/test/client/doc.js
@@ -1,5 +1,5 @@
 var Backend = require('../../lib/backend');
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var util = require('../util');
 
 describe('Doc', function() {
@@ -229,7 +229,7 @@ describe('Doc', function() {
     it('succeeds with valid op', function(done) {
       var doc = this.doc;
       doc.create({name: 'Scooby Doo'}, function(error) {
-        expect(error).to.not.be.ok();
+        expect(error).to.not.be.ok;
         // Build valid op that deletes a substring at index 0 of name.
         var textOpComponents = [{p: 0, d: 'Scooby '}];
         var op = [{p: ['name'], t: 'text0', o: textOpComponents}];
@@ -244,12 +244,12 @@ describe('Doc', function() {
     it('fails with invalid op', function(done) {
       var doc = this.doc;
       doc.create({name: 'Scooby Doo'}, function(error) {
-        expect(error).to.not.be.ok();
+        expect(error).to.not.be.ok;
         // Build op that tries to delete an invalid substring at index 0 of name.
         var textOpComponents = [{p: 0, d: 'invalid'}];
         var op = [{p: ['name'], t: 'text0', o: textOpComponents}];
         doc.submitOp(op, function(error) {
-          expect(error).to.be.ok();
+          expect(error).to.be.ok;
           done();
         });
       });
@@ -286,7 +286,7 @@ describe('Doc', function() {
       util.callInSeries([
         function(next) {
           doc.submitOp(invalidOp, function(error) {
-            expect(error).to.be.ok();
+            expect(error).to.be.ok;
             next();
           });
         },

--- a/test/client/doc.js
+++ b/test/client/doc.js
@@ -229,7 +229,7 @@ describe('Doc', function() {
     it('succeeds with valid op', function(done) {
       var doc = this.doc;
       doc.create({name: 'Scooby Doo'}, function(error) {
-        expect(error).to.not.be.ok;
+        expect(error).to.not.exist;
         // Build valid op that deletes a substring at index 0 of name.
         var textOpComponents = [{p: 0, d: 'Scooby '}];
         var op = [{p: ['name'], t: 'text0', o: textOpComponents}];
@@ -244,12 +244,12 @@ describe('Doc', function() {
     it('fails with invalid op', function(done) {
       var doc = this.doc;
       doc.create({name: 'Scooby Doo'}, function(error) {
-        expect(error).to.not.be.ok;
+        expect(error).to.not.exist;
         // Build op that tries to delete an invalid substring at index 0 of name.
         var textOpComponents = [{p: 0, d: 'invalid'}];
         var op = [{p: ['name'], t: 'text0', o: textOpComponents}];
         doc.submitOp(op, function(error) {
-          expect(error).to.be.ok;
+          expect(error).instanceOf(Error);
           done();
         });
       });
@@ -286,7 +286,7 @@ describe('Doc', function() {
       util.callInSeries([
         function(next) {
           doc.submitOp(invalidOp, function(error) {
-            expect(error).to.be.ok;
+            expect(error).instanceOf(Error);
             next();
           });
         },

--- a/test/client/pending.js
+++ b/test/client/pending.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var Backend = require('../../lib/backend');
 
 describe('client connection', function() {

--- a/test/client/projections.js
+++ b/test/client/projections.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var util = require('../util');
 
 module.exports = function() {
@@ -240,7 +240,7 @@ module.exports = function() {
         projected.fetch(function(err) {
           if (err) return done(err);
           projected.submitOp(op, function(err) {
-            expect(err).ok();
+            expect(err).ok;
             doc.fetch(function(err) {
               if (err) return done(err);
               expect(doc.data).eql({age: 3, color: 'gold', owner: {name: 'jim'}, litter: {count: 4}});
@@ -318,7 +318,7 @@ module.exports = function() {
         var projected = this.backend.connect().get('dogs_summary', 'spot');
         var data = {age: 5, foo: 'bar'};
         projected.create(data, function(err) {
-          expect(err).ok();
+          expect(err).ok;
           doc.fetch(function(err) {
             if (err) return done(err);
             expect(doc.data).eql(undefined);

--- a/test/client/projections.js
+++ b/test/client/projections.js
@@ -267,7 +267,7 @@ module.exports = function(options) {
         projected.fetch(function(err) {
           if (err) return done(err);
           projected.submitOp(op, function(err) {
-            expect(err).ok;
+            expect(err).instanceOf(Error);
             doc.fetch(function(err) {
               if (err) return done(err);
               expect(doc.data).eql({age: 3, color: 'gold', owner: {name: 'jim'}, litter: {count: 4}});
@@ -345,7 +345,7 @@ module.exports = function(options) {
         var projected = this.backend.connect().get('dogs_summary', 'spot');
         var data = {age: 5, foo: 'bar'};
         projected.create(data, function(err) {
-          expect(err).ok;
+          expect(err).instanceOf(Error);
           doc.fetch(function(err) {
             if (err) return done(err);
             expect(doc.data).eql(undefined);

--- a/test/client/query-subscribe.js
+++ b/test/client/query-subscribe.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var async = require('async');
 var util = require('../util');
 

--- a/test/client/query.js
+++ b/test/client/query.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var async = require('async');
 var util = require('../util');
 

--- a/test/client/snapshot-timestamp-request.js
+++ b/test/client/snapshot-timestamp-request.js
@@ -1,5 +1,5 @@
 var Backend = require('../../lib/backend');
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var util = require('../util');
 var lolex = require('lolex');
 var MemoryDb = require('../../lib/db/memory');
@@ -183,7 +183,7 @@ describe('SnapshotTimestampRequest', function() {
         backend.connect().fetchSnapshotByTimestamp('books', 'time-machine', undefined, function() {});
       };
 
-      expect(fetch).to.throwError();
+      expect(fetch).to.throw(Error);
     });
 
     it('throws without a callback', function() {
@@ -191,7 +191,7 @@ describe('SnapshotTimestampRequest', function() {
         backend.connect().fetchSnapshotByTimestamp('books', 'time-machine');
       };
 
-      expect(fetch).to.throwError();
+      expect(fetch).to.throw(Error);
     });
 
     it('throws if the timestamp is -1', function() {
@@ -199,7 +199,7 @@ describe('SnapshotTimestampRequest', function() {
         backend.connect().fetchSnapshotByTimestamp('books', 'time-machine', -1, function() { });
       };
 
-      expect(fetch).to.throwError();
+      expect(fetch).to.throw(Error);
     });
 
     it('errors if the timestamp is a string', function() {
@@ -207,7 +207,7 @@ describe('SnapshotTimestampRequest', function() {
         backend.connect().fetchSnapshotByTimestamp('books', 'time-machine', 'foo', function() { });
       };
 
-      expect(fetch).to.throwError();
+      expect(fetch).to.throw(Error);
     });
 
     it('returns an empty snapshot if trying to fetch a non-existent document', function(done) {
@@ -229,11 +229,11 @@ describe('SnapshotTimestampRequest', function() {
 
       connection.fetchSnapshotByTimestamp('books', 'time-machine', null, function(error) {
         if (error) return done(error);
-        expect(connection.hasPending()).to.be(false);
+        expect(connection.hasPending()).to.equal(false);
         done();
       });
 
-      expect(connection.hasPending()).to.be(true);
+      expect(connection.hasPending()).to.equal(true);
     });
 
     it('deletes the request from the connection', function(done) {
@@ -269,7 +269,7 @@ describe('SnapshotTimestampRequest', function() {
       });
 
       connection.whenNothingPending(function() {
-        expect(snapshotFetched).to.be(true);
+        expect(snapshotFetched).to.equal(true);
         done();
       });
     });
@@ -328,7 +328,7 @@ describe('SnapshotTimestampRequest', function() {
         backend.use(backend.MIDDLEWARE_ACTIONS.readSnapshots,
           function(request) {
             expect(request.snapshots[0]).to.eql(v3);
-            expect(request.snapshotType).to.be(backend.SNAPSHOT_TYPES.byTimestamp);
+            expect(request.snapshotType).to.equal(backend.SNAPSHOT_TYPES.byTimestamp);
             done();
           }
         );
@@ -346,7 +346,7 @@ describe('SnapshotTimestampRequest', function() {
 
         backend.connect().fetchSnapshotByTimestamp('books', 'time-machine', function(error, snapshot) {
           if (error) return done(error);
-          expect(snapshot.data.title).to.be('Alice in Wonderland');
+          expect(snapshot.data.title).to.equal('Alice in Wonderland');
           done();
         });
       });
@@ -359,7 +359,7 @@ describe('SnapshotTimestampRequest', function() {
         ];
 
         backend.connect().fetchSnapshotByTimestamp('books', 'time-machine', day1, function(error) {
-          expect(error.message).to.be('foo');
+          expect(error.message).to.equal('foo');
           done();
         });
       });
@@ -374,8 +374,8 @@ describe('SnapshotTimestampRequest', function() {
         backend.connect().fetchSnapshotByTimestamp('bookTitles', 'time-machine', day2, function(error, snapshot) {
           if (error) return done(error);
 
-          expect(snapshot.data.title).to.be('The Time Machine');
-          expect(snapshot.data.author).to.be(undefined);
+          expect(snapshot.data.title).to.equal('The Time Machine');
+          expect(snapshot.data.author).to.equal(undefined);
           done();
         });
       });
@@ -441,11 +441,11 @@ describe('SnapshotTimestampRequest', function() {
           .fetchSnapshotByTimestamp('books', 'mocking-bird', halfwayBetweenDays3and4, function(error, snapshot) {
             if (error) return done(error);
 
-            expect(milestoneDb.getMilestoneSnapshotAtOrBeforeTime.calledOnce).to.be(true);
-            expect(milestoneDb.getMilestoneSnapshotAtOrAfterTime.calledOnce).to.be(true);
-            expect(db.getOps.calledWith('books', 'mocking-bird', 2, 4)).to.be(true);
+            expect(milestoneDb.getMilestoneSnapshotAtOrBeforeTime.calledOnce).to.equal(true);
+            expect(milestoneDb.getMilestoneSnapshotAtOrAfterTime.calledOnce).to.equal(true);
+            expect(db.getOps.calledWith('books', 'mocking-bird', 2, 4)).to.equal(true);
 
-            expect(snapshot.v).to.be(3);
+            expect(snapshot.v).to.equal(3);
             expect(snapshot.data).to.eql({title: 'To Kill a Mocking Bird', author: 'Harper Lee'});
             done();
           });
@@ -459,10 +459,10 @@ describe('SnapshotTimestampRequest', function() {
           .fetchSnapshotByTimestamp('books', 'mocking-bird', day2, function(error, snapshot) {
             if (error) return done(error);
 
-            expect(milestoneDb.getMilestoneSnapshotAtOrBeforeTime.calledOnce).to.be(true);
-            expect(milestoneDb.getMilestoneSnapshotAtOrAfterTime.calledOnce).to.be(true);
+            expect(milestoneDb.getMilestoneSnapshotAtOrBeforeTime.calledOnce).to.equal(true);
+            expect(milestoneDb.getMilestoneSnapshotAtOrAfterTime.calledOnce).to.equal(true);
 
-            expect(snapshot.v).to.be(2);
+            expect(snapshot.v).to.equal(2);
             expect(snapshot.data).to.eql({title: 'To Kill a Mocking Bird', author: 'Harper Lea'});
             done();
           });
@@ -477,11 +477,11 @@ describe('SnapshotTimestampRequest', function() {
           .fetchSnapshotByTimestamp('books', 'mocking-bird', day1, function(error, snapshot) {
             if (error) return done(error);
 
-            expect(milestoneDb.getMilestoneSnapshotAtOrBeforeTime.calledOnce).to.be(true);
-            expect(milestoneDb.getMilestoneSnapshotAtOrAfterTime.calledOnce).to.be(true);
-            expect(db.getOps.calledWith('books', 'mocking-bird', 0, 2)).to.be(true);
+            expect(milestoneDb.getMilestoneSnapshotAtOrBeforeTime.calledOnce).to.equal(true);
+            expect(milestoneDb.getMilestoneSnapshotAtOrAfterTime.calledOnce).to.equal(true);
+            expect(db.getOps.calledWith('books', 'mocking-bird', 0, 2)).to.equal(true);
 
-            expect(snapshot.v).to.be(1);
+            expect(snapshot.v).to.equal(1);
             expect(snapshot.data).to.eql({title: 'To Kill a Mocking Bird'});
             done();
           });
@@ -496,11 +496,11 @@ describe('SnapshotTimestampRequest', function() {
           .fetchSnapshotByTimestamp('books', 'mocking-bird', day5, function(error, snapshot) {
             if (error) return done(error);
 
-            expect(milestoneDb.getMilestoneSnapshotAtOrBeforeTime.calledOnce).to.be(true);
-            expect(milestoneDb.getMilestoneSnapshotAtOrAfterTime.calledOnce).to.be(true);
-            expect(db.getOps.calledWith('books', 'mocking-bird', 4, null)).to.be(true);
+            expect(milestoneDb.getMilestoneSnapshotAtOrBeforeTime.calledOnce).to.equal(true);
+            expect(milestoneDb.getMilestoneSnapshotAtOrAfterTime.calledOnce).to.equal(true);
+            expect(db.getOps.calledWith('books', 'mocking-bird', 4, null)).to.equal(true);
 
-            expect(snapshot.v).to.be(5);
+            expect(snapshot.v).to.equal(5);
             expect(snapshot.data).to.eql({
               title: 'To Kill a Mocking Bird',
               author: 'Harper Lee',

--- a/test/client/snapshot-version-request.js
+++ b/test/client/snapshot-version-request.js
@@ -1,5 +1,5 @@
 var Backend = require('../../lib/backend');
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var MemoryDb = require('../../lib/db/memory');
 var MemoryMilestoneDb = require('../../lib/milestone-db/memory');
 var sinon = require('sinon');
@@ -105,7 +105,7 @@ describe('SnapshotVersionRequest', function() {
         backend.connect().fetchSnapshot('books', 'don-quixote', undefined, function() {});
       };
 
-      expect(fetch).to.throwError();
+      expect(fetch).to.throw(Error);
     });
 
     it('fetches the latest version when the optional version is not provided', function(done) {
@@ -121,7 +121,7 @@ describe('SnapshotVersionRequest', function() {
         backend.connect().fetchSnapshot('books', 'don-quixote');
       };
 
-      expect(fetch).to.throwError();
+      expect(fetch).to.throw(Error);
     });
 
     it('throws if the version is -1', function() {
@@ -129,7 +129,7 @@ describe('SnapshotVersionRequest', function() {
         backend.connect().fetchSnapshot('books', 'don-quixote', -1, function() {});
       };
 
-      expect(fetch).to.throwError();
+      expect(fetch).to.throw(Error);
     });
 
     it('errors if the version is a string', function() {
@@ -137,13 +137,13 @@ describe('SnapshotVersionRequest', function() {
         backend.connect().fetchSnapshot('books', 'don-quixote', 'foo', function() { });
       };
 
-      expect(fetch).to.throwError();
+      expect(fetch).to.throw(Error);
     });
 
     it('errors if asking for a version that does not exist', function(done) {
       backend.connect().fetchSnapshot('books', 'don-quixote', 4, function(error, snapshot) {
-        expect(error.code).to.be(4024);
-        expect(snapshot).to.be(undefined);
+        expect(error.code).to.equal(4024);
+        expect(snapshot).to.equal(undefined);
         done();
       });
     });
@@ -167,11 +167,11 @@ describe('SnapshotVersionRequest', function() {
 
       connection.fetchSnapshot('books', 'don-quixote', null, function(error) {
         if (error) return done(error);
-        expect(connection.hasPending()).to.be(false);
+        expect(connection.hasPending()).to.equal(false);
         done();
       });
 
-      expect(connection.hasPending()).to.be(true);
+      expect(connection.hasPending()).to.equal(true);
     });
 
     it('deletes the request from the connection', function(done) {
@@ -207,7 +207,7 @@ describe('SnapshotVersionRequest', function() {
       });
 
       connection.whenNothingPending(function() {
-        expect(snapshotFetched).to.be(true);
+        expect(snapshotFetched).to.equal(true);
         done();
       });
     });
@@ -266,7 +266,7 @@ describe('SnapshotVersionRequest', function() {
         backend.use(backend.MIDDLEWARE_ACTIONS.readSnapshots,
           function(request) {
             expect(request.snapshots[0]).to.eql(v3);
-            expect(request.snapshotType).to.be(backend.SNAPSHOT_TYPES.byVersion);
+            expect(request.snapshotType).to.equal(backend.SNAPSHOT_TYPES.byVersion);
             done();
           }
         );
@@ -284,7 +284,7 @@ describe('SnapshotVersionRequest', function() {
 
         backend.connect().fetchSnapshot('books', 'don-quixote', function(error, snapshot) {
           if (error) return done(error);
-          expect(snapshot.data.title).to.be('Alice in Wonderland');
+          expect(snapshot.data.title).to.equal('Alice in Wonderland');
           done();
         });
       });
@@ -297,7 +297,7 @@ describe('SnapshotVersionRequest', function() {
         ];
 
         backend.connect().fetchSnapshot('books', 'don-quixote', 0, function(error) {
-          expect(error.message).to.be('foo');
+          expect(error.message).to.equal('foo');
           done();
         });
       });
@@ -312,8 +312,8 @@ describe('SnapshotVersionRequest', function() {
         backend.connect().fetchSnapshot('bookTitles', 'don-quixote', 2, function(error, snapshot) {
           if (error) return done(error);
 
-          expect(snapshot.data.title).to.be('Don Quixote');
-          expect(snapshot.data.author).to.be(undefined);
+          expect(snapshot.data.title).to.equal('Don Quixote');
+          expect(snapshot.data.author).to.equal(undefined);
           done();
         });
       });
@@ -435,9 +435,9 @@ describe('SnapshotVersionRequest', function() {
           backendWithMilestones.connect().fetchSnapshot('books', 'mocking-bird', 3, next);
         },
         function(snapshot, next) {
-          expect(milestoneDb.getMilestoneSnapshot.calledOnce).to.be(true);
-          expect(db.getOps.calledWith('books', 'mocking-bird', 2, 3)).to.be(true);
-          expect(snapshot.v).to.be(3);
+          expect(milestoneDb.getMilestoneSnapshot.calledOnce).to.equal(true);
+          expect(db.getOps.calledWith('books', 'mocking-bird', 2, 3)).to.equal(true);
+          expect(snapshot.v).to.equal(3);
           expect(snapshot.data).to.eql({title: 'To Kill a Mocking Bird', author: 'Harper Lee'});
           next();
         },

--- a/test/client/submit.js
+++ b/test/client/submit.js
@@ -1,5 +1,5 @@
 var async = require('async');
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var types = require('../../lib/types');
 var deserializedType = require('./deserialized-type');
 var numberType = require('./number-type');
@@ -96,7 +96,7 @@ module.exports = function() {
         if (err) return done(err);
         doc.version++;
         doc.submitOp({p: ['age'], na: 2}, function(err) {
-          expect(err).ok();
+          expect(err).ok;
           done();
         });
       });
@@ -105,7 +105,7 @@ module.exports = function() {
     it('cannot submit op on an uncreated doc', function(done) {
       var doc = this.backend.connect().get('dogs', 'fido');
       doc.submitOp({p: ['age'], na: 2}, function(err) {
-        expect(err).ok();
+        expect(err).ok;
         done();
       });
     });
@@ -113,7 +113,7 @@ module.exports = function() {
     it('cannot delete an uncreated doc', function(done) {
       var doc = this.backend.connect().get('dogs', 'fido');
       doc.del(function(err) {
-        expect(err).ok();
+        expect(err).ok;
         done();
       });
     });
@@ -207,7 +207,7 @@ module.exports = function() {
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc.create({age: 4}, function(err) {
-          expect(err).ok();
+          expect(err).ok;
           expect(doc.version).equal(1);
           expect(doc.data).eql({age: 3});
           done();
@@ -221,7 +221,7 @@ module.exports = function() {
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.create({age: 4}, function(err) {
-          expect(err).ok();
+          expect(err).ok;
           expect(doc2.version).equal(1);
           expect(doc2.data).eql({age: 3});
           done();
@@ -262,7 +262,7 @@ module.exports = function() {
           doc.submitOp({p: ['age'], na: 1}, function(err) {
             if (err) return done(err);
             doc2.submitOp({p: ['age'], na: 2}, function(err) {
-              expect(err).ok();
+              expect(err).ok;
               done();
             });
           });
@@ -287,7 +287,7 @@ module.exports = function() {
           doc.submitOp({p: ['age'], na: 1}, function(err) {
             if (err) return done(err);
             doc2.submitOp({p: ['age'], na: 2}, function(err) {
-              expect(err).ok();
+              expect(err).ok;
               done();
             });
           });
@@ -432,7 +432,7 @@ module.exports = function() {
           expect(doc.version).eql(1);
           expect(doc.data).eql({age: 3});
         } else {
-          expect(err).ok();
+          expect(err).ok;
           expect(doc.version).eql(1);
           expect(doc.data).eql({age: 5});
           done();
@@ -445,7 +445,7 @@ module.exports = function() {
           expect(doc2.version).eql(1);
           expect(doc2.data).eql({age: 5});
         } else {
-          expect(err).ok();
+          expect(err).ok;
           expect(doc2.version).eql(1);
           expect(doc2.data).eql({age: 3});
           done();
@@ -537,15 +537,15 @@ module.exports = function() {
               docCallback();
             }
           });
-          doc.submitOp({p: ['age'], na: 2}, function(error) {
-            if (error) return done(error);
+          doc.submitOp({p: ['age'], na: 2}, function(err) {
+            if (err) return done(err);
             // When we know the first op has been committed, we try to commit the second op, which will
             // fail because it's working on an out-of-date snapshot. It will retry, but exceed the
             // maxSubmitRetries limit of 0
             doc2Callback();
           });
-          doc2.submitOp({p: ['age'], na: 7}, function(error) {
-            expect(error).ok();
+          doc2.submitOp({p: ['age'], na: 7}, function(err) {
+            expect(err).ok;
             done();
           });
         });
@@ -616,7 +616,7 @@ module.exports = function() {
           doc2.del(function(err) {
             if (err) return done(err);
             doc.submitOp({p: ['age'], na: 1}, function(err) {
-              expect(err).ok();
+              expect(err).ok;
               expect(doc.version).equal(1);
               expect(doc.data).eql({age: 3});
               done();
@@ -1070,7 +1070,7 @@ module.exports = function() {
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc._submit({}, null, function(err) {
-          expect(err).ok();
+          expect(err).ok;
           done();
         });
       });
@@ -1094,8 +1094,9 @@ module.exports = function() {
         var doc = this.backend.connect().get('dogs', 'fido');
         doc.create([3], deserializedType.type.uri, function(err) {
           if (err) return done(err);
-          expect(doc.data).a(deserializedType.Node);
-          expect(doc.data).eql({value: 3, next: null});
+          expect(doc.data).instanceOf(deserializedType.Node);
+          expect(doc.data.value).equal(3);
+          expect(doc.data.next).equal(null);
           done();
         });
       });
@@ -1120,8 +1121,9 @@ module.exports = function() {
           if (err) return done(err);
           doc2.fetch(function(err) {
             if (err) return done(err);
-            expect(doc2.data).a(deserializedType.Node);
-            expect(doc2.data).eql({value: 3, next: null});
+            expect(doc2.data).instanceOf(deserializedType.Node);
+            expect(doc2.data.value).equal(3);
+            expect(doc2.data.next).equal(null);
             done();
           });
         });
@@ -1133,7 +1135,9 @@ module.exports = function() {
           if (err) return done(err);
           doc.submitOp({insert: 0, value: 2}, function(err) {
             if (err) return done(err);
-            expect(doc.data).eql({value: 2, next: {value: 3, next: null}});
+            expect(doc.data.value).eql(2);
+            expect(doc.data.next.value).equal(3);
+            expect(doc.data.next.next).equal(null);
             done();
           });
         });
@@ -1150,7 +1154,10 @@ module.exports = function() {
               if (err) return done(err);
               doc2.submitOp({insert: 1, value: 4}, function(err) {
                 if (err) return done(err);
-                expect(doc2.data).eql({value: 2, next: {value: 3, next: {value: 4, next: null}}});
+                expect(doc2.data.value).equal(2);
+                expect(doc2.data.next.value).equal(3);
+                expect(doc2.data.next.next.value).equal(4);
+                expect(doc2.data.next.next.next).equal(null);
                 done();
               });
             });
@@ -1164,8 +1171,9 @@ module.exports = function() {
         var doc = this.backend.connect().get('dogs', 'fido');
         doc.create([3], deserializedType.type2.uri, function(err) {
           if (err) return done(err);
-          expect(doc.data).a(deserializedType.Node);
-          expect(doc.data).eql({value: 3, next: null});
+          expect(doc.data).instanceOf(deserializedType.Node);
+          expect(doc.data.value).equal(3);
+          expect(doc.data.next).equal(null);
           done();
         });
       });
@@ -1174,8 +1182,9 @@ module.exports = function() {
         var doc = this.backend.connect().get('dogs', 'fido');
         doc.create(new deserializedType.Node(3), deserializedType.type2.uri, function(err) {
           if (err) return done(err);
-          expect(doc.data).a(deserializedType.Node);
-          expect(doc.data).eql({value: 3, next: null});
+          expect(doc.data).instanceOf(deserializedType.Node);
+          expect(doc.data.value).equal(3);
+          expect(doc.data.next).equal(null);
           done();
         });
       });

--- a/test/client/submit.js
+++ b/test/client/submit.js
@@ -96,7 +96,7 @@ module.exports = function() {
         if (err) return done(err);
         doc.version++;
         doc.submitOp({p: ['age'], na: 2}, function(err) {
-          expect(err).ok;
+          expect(err).instanceOf(Error);
           done();
         });
       });
@@ -105,7 +105,7 @@ module.exports = function() {
     it('cannot submit op on an uncreated doc', function(done) {
       var doc = this.backend.connect().get('dogs', 'fido');
       doc.submitOp({p: ['age'], na: 2}, function(err) {
-        expect(err).ok;
+        expect(err).instanceOf(Error);
         done();
       });
     });
@@ -113,7 +113,7 @@ module.exports = function() {
     it('cannot delete an uncreated doc', function(done) {
       var doc = this.backend.connect().get('dogs', 'fido');
       doc.del(function(err) {
-        expect(err).ok;
+        expect(err).instanceOf(Error);
         done();
       });
     });
@@ -207,7 +207,7 @@ module.exports = function() {
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc.create({age: 4}, function(err) {
-          expect(err).ok;
+          expect(err).instanceOf(Error);
           expect(doc.version).equal(1);
           expect(doc.data).eql({age: 3});
           done();
@@ -221,7 +221,7 @@ module.exports = function() {
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.create({age: 4}, function(err) {
-          expect(err).ok;
+          expect(err).instanceOf(Error);
           expect(doc2.version).equal(1);
           expect(doc2.data).eql({age: 3});
           done();
@@ -262,7 +262,7 @@ module.exports = function() {
           doc.submitOp({p: ['age'], na: 1}, function(err) {
             if (err) return done(err);
             doc2.submitOp({p: ['age'], na: 2}, function(err) {
-              expect(err).ok;
+              expect(err).instanceOf(Error);
               done();
             });
           });
@@ -287,7 +287,7 @@ module.exports = function() {
           doc.submitOp({p: ['age'], na: 1}, function(err) {
             if (err) return done(err);
             doc2.submitOp({p: ['age'], na: 2}, function(err) {
-              expect(err).ok;
+              expect(err).instanceOf(Error);
               done();
             });
           });
@@ -432,7 +432,7 @@ module.exports = function() {
           expect(doc.version).eql(1);
           expect(doc.data).eql({age: 3});
         } else {
-          expect(err).ok;
+          expect(err).instanceOf(Error);
           expect(doc.version).eql(1);
           expect(doc.data).eql({age: 5});
           done();
@@ -445,7 +445,7 @@ module.exports = function() {
           expect(doc2.version).eql(1);
           expect(doc2.data).eql({age: 5});
         } else {
-          expect(err).ok;
+          expect(err).instanceOf(Error);
           expect(doc2.version).eql(1);
           expect(doc2.data).eql({age: 3});
           done();
@@ -545,7 +545,7 @@ module.exports = function() {
             doc2Callback();
           });
           doc2.submitOp({p: ['age'], na: 7}, function(err) {
-            expect(err).ok;
+            expect(err).instanceOf(Error);
             done();
           });
         });
@@ -616,7 +616,7 @@ module.exports = function() {
           doc2.del(function(err) {
             if (err) return done(err);
             doc.submitOp({p: ['age'], na: 1}, function(err) {
-              expect(err).ok;
+              expect(err).instanceOf(Error);
               expect(doc.version).equal(1);
               expect(doc.data).eql({age: 3});
               done();
@@ -1070,7 +1070,7 @@ module.exports = function() {
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc._submit({}, null, function(err) {
-          expect(err).ok;
+          expect(err).instanceOf(Error);
           done();
         });
       });

--- a/test/client/subscribe.js
+++ b/test/client/subscribe.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var async = require('async');
 
 module.exports = function() {
@@ -339,7 +339,7 @@ module.exports = function() {
           doc.pause();
           var calls = 0;
           doc.create({age: 3}, function(err) {
-            expect(err).ok();
+            expect(err).ok;
             calls++;
           });
           doc[method](function(err) {

--- a/test/client/subscribe.js
+++ b/test/client/subscribe.js
@@ -339,7 +339,7 @@ module.exports = function() {
           doc.pause();
           var calls = 0;
           doc.create({age: 3}, function(err) {
-            expect(err).ok;
+            expect(err).instanceOf(Error);
             calls++;
           });
           doc[method](function(err) {

--- a/test/db-memory.js
+++ b/test/db-memory.js
@@ -16,7 +16,7 @@ describe('DB base class', function() {
   it('returns an error if db.commit() is unimplemented', function(done) {
     var db = new DB();
     db.commit('testcollection', 'test', {}, {}, null, function(err) {
-      expect(err).ok;
+      expect(err).instanceOf(Error);
       done();
     });
   });
@@ -24,7 +24,7 @@ describe('DB base class', function() {
   it('returns an error if db.getSnapshot() is unimplemented', function(done) {
     var db = new DB();
     db.getSnapshot('testcollection', 'foo', null, null, function(err) {
-      expect(err).ok;
+      expect(err).instanceOf(Error);
       done();
     });
   });
@@ -32,7 +32,7 @@ describe('DB base class', function() {
   it('returns an error if db.getOps() is unimplemented', function(done) {
     var db = new DB();
     db.getOps('testcollection', 'foo', 0, null, null, function(err) {
-      expect(err).ok;
+      expect(err).instanceOf(Error);
       done();
     });
   });
@@ -40,7 +40,7 @@ describe('DB base class', function() {
   it('returns an error if db.query() is unimplemented', function(done) {
     var db = new DB();
     db.query('testcollection', {x: 5}, null, null, function(err) {
-      expect(err).ok;
+      expect(err).instanceOf(Error);
       done();
     });
   });
@@ -48,7 +48,7 @@ describe('DB base class', function() {
   it('returns an error if db.queryPollDoc() is unimplemented', function(done) {
     var db = new DB();
     db.queryPollDoc('testcollection', 'foo', {x: 5}, null, function(err) {
-      expect(err).ok;
+      expect(err).instanceOf(Error);
       done();
     });
   });

--- a/test/db-memory.js
+++ b/test/db-memory.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var DB = require('../lib/db');
 var MemoryDB = require('../lib/db/memory');
 
@@ -16,7 +16,7 @@ describe('DB base class', function() {
   it('returns an error if db.commit() is unimplemented', function(done) {
     var db = new DB();
     db.commit('testcollection', 'test', {}, {}, null, function(err) {
-      expect(err).an(Error);
+      expect(err).ok;
       done();
     });
   });
@@ -24,7 +24,7 @@ describe('DB base class', function() {
   it('returns an error if db.getSnapshot() is unimplemented', function(done) {
     var db = new DB();
     db.getSnapshot('testcollection', 'foo', null, null, function(err) {
-      expect(err).an(Error);
+      expect(err).ok;
       done();
     });
   });
@@ -32,7 +32,7 @@ describe('DB base class', function() {
   it('returns an error if db.getOps() is unimplemented', function(done) {
     var db = new DB();
     db.getOps('testcollection', 'foo', 0, null, null, function(err) {
-      expect(err).an(Error);
+      expect(err).ok;
       done();
     });
   });
@@ -40,7 +40,7 @@ describe('DB base class', function() {
   it('returns an error if db.query() is unimplemented', function(done) {
     var db = new DB();
     db.query('testcollection', {x: 5}, null, null, function(err) {
-      expect(err).an(Error);
+      expect(err).ok;
       done();
     });
   });
@@ -48,7 +48,7 @@ describe('DB base class', function() {
   it('returns an error if db.queryPollDoc() is unimplemented', function(done) {
     var db = new DB();
     db.queryPollDoc('testcollection', 'foo', {x: 5}, null, function(err) {
-      expect(err).an(Error);
+      expect(err).ok;
       done();
     });
   });

--- a/test/db.js
+++ b/test/db.js
@@ -1,5 +1,5 @@
 var async = require('async');
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var Backend = require('../lib/backend');
 var ot = require('../lib/ot');
 
@@ -87,7 +87,7 @@ module.exports = function(options) {
       function testCreateCommit(ops, snapshot) {
         expect(snapshot.v).eql(1);
         expect(ops.length).equal(1);
-        expect(ops[0].create).ok();
+        expect(ops[0].create).ok;
       }
 
       it('one commit succeeds from 2 simultaneous creates', function(done) {
@@ -117,8 +117,8 @@ module.exports = function(options) {
       function testOpCommit(ops, snapshot) {
         expect(snapshot.v).equal(2);
         expect(ops.length).equal(2);
-        expect(ops[0].create).ok();
-        expect(ops[1].op).ok();
+        expect(ops[0].create).ok;
+        expect(ops[1].op).ok;
       }
 
       function testDelCommit(ops, snapshot) {
@@ -126,7 +126,7 @@ module.exports = function(options) {
         expect(ops.length).equal(2);
         expect(snapshot.data).equal(undefined);
         expect(snapshot.type).equal(null);
-        expect(ops[0].create).ok();
+        expect(ops[0].create).ok;
         expect(ops[1].del).equal(true);
       }
 

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,5 +1,5 @@
 var Logger = require('../lib/logger/logger');
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var sinon = require('sinon');
 
 describe('Logger', function() {
@@ -15,7 +15,7 @@ describe('Logger', function() {
     it('logs to console by default', function() {
       var logger = new Logger();
       logger.warn('warning');
-      expect(console.warn.calledOnceWithExactly('warning')).to.be(true);
+      expect(console.warn.calledOnceWithExactly('warning')).to.equal(true);
     });
 
     it('overrides console', function() {
@@ -27,8 +27,8 @@ describe('Logger', function() {
 
       logger.warn('warning');
 
-      expect(console.warn.notCalled).to.be(true);
-      expect(customWarn.calledOnceWithExactly('warning')).to.be(true);
+      expect(console.warn.notCalled).to.equal(true);
+      expect(customWarn.calledOnceWithExactly('warning')).to.equal(true);
     });
 
     it('only overrides if provided with a method', function() {
@@ -40,7 +40,7 @@ describe('Logger', function() {
 
       logger.warn('warning');
 
-      expect(console.warn.calledOnceWithExactly('warning')).to.be(true);
+      expect(console.warn.calledOnceWithExactly('warning')).to.equal(true);
     });
   });
 });

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -1,5 +1,5 @@
 var Backend = require('../lib/backend');
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var util = require('./util');
 var types = require('../lib/types');
 

--- a/test/milestone-db.js
+++ b/test/milestone-db.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var Backend = require('../lib/backend');
 var MilestoneDB = require('../lib/milestone-db');
 var NoOpMilestoneDB = require('../lib/milestone-db/no-op');
@@ -14,14 +14,14 @@ describe('Base class', function() {
 
   it('calls back with an error when trying to get a snapshot', function(done) {
     db.getMilestoneSnapshot('books', '123', 1, function(error) {
-      expect(error.code).to.be(5019);
+      expect(error.code).to.equal(5019);
       done();
     });
   });
 
   it('emits an error when trying to get a snapshot', function(done) {
     db.on('error', function(error) {
-      expect(error.code).to.be(5019);
+      expect(error.code).to.equal(5019);
       done();
     });
 
@@ -30,14 +30,14 @@ describe('Base class', function() {
 
   it('calls back with an error when trying to save a snapshot', function(done) {
     db.saveMilestoneSnapshot('books', {}, function(error) {
-      expect(error.code).to.be(5020);
+      expect(error.code).to.equal(5020);
       done();
     });
   });
 
   it('emits an error when trying to save a snapshot', function(done) {
     db.on('error', function(error) {
-      expect(error.code).to.be(5020);
+      expect(error.code).to.equal(5020);
       done();
     });
 
@@ -46,14 +46,14 @@ describe('Base class', function() {
 
   it('calls back with an error when trying to get a snapshot before a time', function(done) {
     db.getMilestoneSnapshotAtOrBeforeTime('books', '123', 1000, function(error) {
-      expect(error.code).to.be(5021);
+      expect(error.code).to.equal(5021);
       done();
     });
   });
 
   it('calls back with an error when trying to get a snapshot after a time', function(done) {
     db.getMilestoneSnapshotAtOrAfterTime('books', '123', 1000, function(error) {
-      expect(error.code).to.be(5022);
+      expect(error.code).to.equal(5022);
       done();
     });
   });
@@ -83,7 +83,7 @@ describe('NoOpMilestoneDB', function() {
         db.getMilestoneSnapshot('books', 'catcher-in-the-rye', null, next);
       },
       function(snapshot, next) {
-        expect(snapshot).to.be(undefined);
+        expect(snapshot).to.equal(undefined);
         next();
       },
       done
@@ -269,35 +269,35 @@ module.exports = function(options) {
 
     it('errors when fetching an undefined version', function(done) {
       db.getMilestoneSnapshot('books', 'catcher-in-the-rye', undefined, function(error) {
-        expect(error).to.be.ok();
+        expect(error).to.be.ok;
         done();
       });
     });
 
     it('errors when fetching version -1', function(done) {
       db.getMilestoneSnapshot('books', 'catcher-in-the-rye', -1, function(error) {
-        expect(error).to.be.ok();
+        expect(error).to.be.ok;
         done();
       });
     });
 
     it('errors when fetching version "foo"', function(done) {
       db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 'foo', function(error) {
-        expect(error).to.be.ok();
+        expect(error).to.be.ok;
         done();
       });
     });
 
     it('errors when fetching a null collection', function(done) {
       db.getMilestoneSnapshot(null, 'catcher-in-the-rye', 1, function(error) {
-        expect(error).to.be.ok();
+        expect(error).to.be.ok;
         done();
       });
     });
 
     it('errors when fetching a null ID', function(done) {
       db.getMilestoneSnapshot('books', null, 1, function(error) {
-        expect(error).to.be.ok();
+        expect(error).to.be.ok;
         done();
       });
     });
@@ -312,7 +312,7 @@ module.exports = function(options) {
       );
 
       db.saveMilestoneSnapshot(null, snapshot, function(error) {
-        expect(error).to.be.ok();
+        expect(error).to.be.ok;
         done();
       });
     });
@@ -323,7 +323,7 @@ module.exports = function(options) {
           db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 1, next);
         },
         function(snapshot, next) {
-          expect(snapshot).to.be(undefined);
+          expect(snapshot).to.equal(undefined);
           next();
         },
         done
@@ -340,7 +340,7 @@ module.exports = function(options) {
           db.getMilestoneSnapshot('books', 'catcher-in-the-rye', null, next);
         },
         function(snapshot, next) {
-          expect(snapshot).to.be(undefined);
+          expect(snapshot).to.equal(undefined);
           next();
         },
         done
@@ -357,7 +357,7 @@ module.exports = function(options) {
       );
 
       db.on('save', function(collection, snapshot) {
-        expect(collection).to.be('books');
+        expect(collection).to.equal('books');
         expect(snapshot).to.eql(snapshot);
         done();
       });
@@ -367,7 +367,7 @@ module.exports = function(options) {
 
     it('errors when the snapshot is undefined', function(done) {
       db.saveMilestoneSnapshot('books', undefined, function(error) {
-        expect(error).to.be.ok();
+        expect(error).to.be.ok;
         done();
       });
     });
@@ -471,14 +471,14 @@ module.exports = function(options) {
 
         it('returns an error for a string timestamp', function(done) {
           db.getMilestoneSnapshotAtOrBeforeTime('books', 'catcher-in-the-rye', 'not-a-timestamp', function(error) {
-            expect(error).to.be.ok();
+            expect(error).to.be.ok;
             done();
           });
         });
 
         it('returns an error for a negative timestamp', function(done) {
           db.getMilestoneSnapshotAtOrBeforeTime('books', 'catcher-in-the-rye', -1, function(error) {
-            expect(error).to.be.ok();
+            expect(error).to.be.ok;
             done();
           });
         });
@@ -489,7 +489,7 @@ module.exports = function(options) {
               db.getMilestoneSnapshotAtOrBeforeTime('books', 'catcher-in-the-rye', 0, next);
             },
             function(snapshot, next) {
-              expect(snapshot).to.be(undefined);
+              expect(snapshot).to.equal(undefined);
               next();
             },
             done
@@ -498,14 +498,14 @@ module.exports = function(options) {
 
         it('errors if no collection is provided', function(done) {
           db.getMilestoneSnapshotAtOrBeforeTime(undefined, 'catcher-in-the-rye', 0, function(error) {
-            expect(error).to.be.ok();
+            expect(error).to.be.ok;
             done();
           });
         });
 
         it('errors if no ID is provided', function(done) {
           db.getMilestoneSnapshotAtOrBeforeTime('books', undefined, 0, function(error) {
-            expect(error).to.be.ok();
+            expect(error).to.be.ok;
             done();
           });
         });
@@ -553,14 +553,14 @@ module.exports = function(options) {
 
         it('returns an error for a string timestamp', function(done) {
           db.getMilestoneSnapshotAtOrAfterTime('books', 'catcher-in-the-rye', 'not-a-timestamp', function(error) {
-            expect(error).to.be.ok();
+            expect(error).to.be.ok;
             done();
           });
         });
 
         it('returns an error for a negative timestamp', function(done) {
           db.getMilestoneSnapshotAtOrAfterTime('books', 'catcher-in-the-rye', -1, function(error) {
-            expect(error).to.be.ok();
+            expect(error).to.be.ok;
             done();
           });
         });
@@ -571,7 +571,7 @@ module.exports = function(options) {
               db.getMilestoneSnapshotAtOrAfterTime('books', 'catcher-in-the-rye', 4000, next);
             },
             function(snapshot, next) {
-              expect(snapshot).to.be(undefined);
+              expect(snapshot).to.equal(undefined);
               next();
             },
             done
@@ -580,14 +580,14 @@ module.exports = function(options) {
 
         it('errors if no collection is provided', function(done) {
           db.getMilestoneSnapshotAtOrAfterTime(undefined, 'catcher-in-the-rye', 0, function(error) {
-            expect(error).to.be.ok();
+            expect(error).to.be.ok;
             done();
           });
         });
 
         it('errors if no ID is provided', function(done) {
           db.getMilestoneSnapshotAtOrAfterTime('books', undefined, 0, function(error) {
-            expect(error).to.be.ok();
+            expect(error).to.be.ok;
             done();
           });
         });
@@ -608,7 +608,7 @@ module.exports = function(options) {
 
       it('stores a milestone snapshot on commit', function(done) {
         db.on('save', function(collection, snapshot) {
-          expect(collection).to.be('books');
+          expect(collection).to.equal('books');
           expect(snapshot.data).to.eql({title: 'Catcher in the Rye'});
           done();
         });
@@ -639,28 +639,28 @@ module.exports = function(options) {
               db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 1, next);
             },
             function(snapshot, next) {
-              expect(snapshot).to.be(undefined);
+              expect(snapshot).to.equal(undefined);
               next();
             },
             function(next) {
               db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 2, next);
             },
             function(snapshot, next) {
-              expect(snapshot.v).to.be(2);
+              expect(snapshot.v).to.equal(2);
               next();
             },
             function(next) {
               db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 3, next);
             },
             function(snapshot, next) {
-              expect(snapshot.v).to.be(2);
+              expect(snapshot.v).to.equal(2);
               next();
             },
             function(next) {
               db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 4, next);
             },
             function(snapshot, next) {
-              expect(snapshot.v).to.be(4);
+              expect(snapshot.v).to.equal(4);
               next();
             },
             done
@@ -699,28 +699,28 @@ module.exports = function(options) {
               db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 1, next);
             },
             function(snapshot, next) {
-              expect(snapshot).to.be(undefined);
+              expect(snapshot).to.equal(undefined);
               next();
             },
             function(next) {
               db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 2, next);
             },
             function(snapshot, next) {
-              expect(snapshot).to.be(undefined);
+              expect(snapshot).to.equal(undefined);
               next();
             },
             function(next) {
               db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 3, next);
             },
             function(snapshot, next) {
-              expect(snapshot.v).to.be(3);
+              expect(snapshot.v).to.equal(3);
               next();
             },
             function(next) {
               db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 4, next);
             },
             function(snapshot, next) {
-              expect(snapshot.v).to.be(4);
+              expect(snapshot.v).to.equal(4);
               next();
             },
             done

--- a/test/milestone-db.js
+++ b/test/milestone-db.js
@@ -269,35 +269,35 @@ module.exports = function(options) {
 
     it('errors when fetching an undefined version', function(done) {
       db.getMilestoneSnapshot('books', 'catcher-in-the-rye', undefined, function(error) {
-        expect(error).to.be.ok;
+        expect(error).instanceOf(Error);
         done();
       });
     });
 
     it('errors when fetching version -1', function(done) {
       db.getMilestoneSnapshot('books', 'catcher-in-the-rye', -1, function(error) {
-        expect(error).to.be.ok;
+        expect(error).instanceOf(Error);
         done();
       });
     });
 
     it('errors when fetching version "foo"', function(done) {
       db.getMilestoneSnapshot('books', 'catcher-in-the-rye', 'foo', function(error) {
-        expect(error).to.be.ok;
+        expect(error).instanceOf(Error);
         done();
       });
     });
 
     it('errors when fetching a null collection', function(done) {
       db.getMilestoneSnapshot(null, 'catcher-in-the-rye', 1, function(error) {
-        expect(error).to.be.ok;
+        expect(error).instanceOf(Error);
         done();
       });
     });
 
     it('errors when fetching a null ID', function(done) {
       db.getMilestoneSnapshot('books', null, 1, function(error) {
-        expect(error).to.be.ok;
+        expect(error).instanceOf(Error);
         done();
       });
     });
@@ -312,7 +312,7 @@ module.exports = function(options) {
       );
 
       db.saveMilestoneSnapshot(null, snapshot, function(error) {
-        expect(error).to.be.ok;
+        expect(error).instanceOf(Error);
         done();
       });
     });
@@ -367,7 +367,7 @@ module.exports = function(options) {
 
     it('errors when the snapshot is undefined', function(done) {
       db.saveMilestoneSnapshot('books', undefined, function(error) {
-        expect(error).to.be.ok;
+        expect(error).instanceOf(Error);
         done();
       });
     });
@@ -471,14 +471,14 @@ module.exports = function(options) {
 
         it('returns an error for a string timestamp', function(done) {
           db.getMilestoneSnapshotAtOrBeforeTime('books', 'catcher-in-the-rye', 'not-a-timestamp', function(error) {
-            expect(error).to.be.ok;
+            expect(error).instanceOf(Error);
             done();
           });
         });
 
         it('returns an error for a negative timestamp', function(done) {
           db.getMilestoneSnapshotAtOrBeforeTime('books', 'catcher-in-the-rye', -1, function(error) {
-            expect(error).to.be.ok;
+            expect(error).instanceOf(Error);
             done();
           });
         });
@@ -498,14 +498,14 @@ module.exports = function(options) {
 
         it('errors if no collection is provided', function(done) {
           db.getMilestoneSnapshotAtOrBeforeTime(undefined, 'catcher-in-the-rye', 0, function(error) {
-            expect(error).to.be.ok;
+            expect(error).instanceOf(Error);
             done();
           });
         });
 
         it('errors if no ID is provided', function(done) {
           db.getMilestoneSnapshotAtOrBeforeTime('books', undefined, 0, function(error) {
-            expect(error).to.be.ok;
+            expect(error).instanceOf(Error);
             done();
           });
         });
@@ -553,14 +553,14 @@ module.exports = function(options) {
 
         it('returns an error for a string timestamp', function(done) {
           db.getMilestoneSnapshotAtOrAfterTime('books', 'catcher-in-the-rye', 'not-a-timestamp', function(error) {
-            expect(error).to.be.ok;
+            expect(error).instanceOf(Error);
             done();
           });
         });
 
         it('returns an error for a negative timestamp', function(done) {
           db.getMilestoneSnapshotAtOrAfterTime('books', 'catcher-in-the-rye', -1, function(error) {
-            expect(error).to.be.ok;
+            expect(error).instanceOf(Error);
             done();
           });
         });
@@ -580,14 +580,14 @@ module.exports = function(options) {
 
         it('errors if no collection is provided', function(done) {
           db.getMilestoneSnapshotAtOrAfterTime(undefined, 'catcher-in-the-rye', 0, function(error) {
-            expect(error).to.be.ok;
+            expect(error).instanceOf(Error);
             done();
           });
         });
 
         it('errors if no ID is provided', function(done) {
           db.getMilestoneSnapshotAtOrAfterTime('books', undefined, 0, function(error) {
-            expect(error).to.be.ok;
+            expect(error).instanceOf(Error);
             done();
           });
         });

--- a/test/ot.js
+++ b/test/ot.js
@@ -1,33 +1,33 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var ot = require('../lib/ot');
 var type = require('../lib/types').defaultType;
 
 describe('ot', function() {
   describe('checkOp', function() {
     it('fails if op is not an object', function() {
-      expect(ot.checkOp('hi')).ok();
-      expect(ot.checkOp()).ok();
-      expect(ot.checkOp(123)).ok();
-      expect(ot.checkOp([])).ok();
+      expect(ot.checkOp('hi')).ok;
+      expect(ot.checkOp()).ok;
+      expect(ot.checkOp(123)).ok;
+      expect(ot.checkOp([])).ok;
     });
 
     it('fails if op data is missing op, create and del', function() {
-      expect(ot.checkOp({v: 5})).ok();
+      expect(ot.checkOp({v: 5})).ok;
     });
 
     it('fails if src/seq data is invalid', function() {
-      expect(ot.checkOp({del: true, v: 5, src: 'hi'})).ok();
-      expect(ot.checkOp({del: true, v: 5, seq: 123})).ok();
-      expect(ot.checkOp({del: true, v: 5, src: 'hi', seq: 'there'})).ok();
+      expect(ot.checkOp({del: true, v: 5, src: 'hi'})).ok;
+      expect(ot.checkOp({del: true, v: 5, seq: 123})).ok;
+      expect(ot.checkOp({del: true, v: 5, src: 'hi', seq: 'there'})).ok;
     });
 
     it('fails if a create operation is missing its type', function() {
-      expect(ot.checkOp({create: {}})).ok();
-      expect(ot.checkOp({create: 123})).ok();
+      expect(ot.checkOp({create: {}})).ok;
+      expect(ot.checkOp({create: 123})).ok;
     });
 
     it('fails if the type is missing', function() {
-      expect(ot.checkOp({create: {type: 'something that does not exist'}})).ok();
+      expect(ot.checkOp({create: {type: 'something that does not exist'}})).ok;
     });
 
     it('accepts valid create operations', function() {
@@ -54,12 +54,12 @@ describe('ot', function() {
 
   describe('apply', function() {
     it('fails if the versions dont match', function() {
-      expect(ot.apply({v: 0}, {v: 1, create: {type: type.uri}})).ok();
-      expect(ot.apply({v: 0}, {v: 1, del: true})).ok();
-      expect(ot.apply({v: 0}, {v: 1, op: []})).ok();
-      expect(ot.apply({v: 5}, {v: 4, create: {type: type.uri}})).ok();
-      expect(ot.apply({v: 5}, {v: 4, del: true})).ok();
-      expect(ot.apply({v: 5}, {v: 4, op: []})).ok();
+      expect(ot.apply({v: 0}, {v: 1, create: {type: type.uri}})).ok;
+      expect(ot.apply({v: 0}, {v: 1, del: true})).ok;
+      expect(ot.apply({v: 0}, {v: 1, op: []})).ok;
+      expect(ot.apply({v: 5}, {v: 4, create: {type: type.uri}})).ok;
+      expect(ot.apply({v: 5}, {v: 4, del: true})).ok;
+      expect(ot.apply({v: 5}, {v: 4, op: []})).ok;
     });
 
     it('allows the version field to be missing', function() {
@@ -71,7 +71,7 @@ describe('ot', function() {
   describe('create', function() {
     it('fails if the document already exists', function() {
       var doc = {v: 6, create: {type: type.uri}};
-      expect(ot.apply({v: 6, type: type.uri, data: 'hi'}, doc)).ok();
+      expect(ot.apply({v: 6, type: type.uri, data: 'hi'}, doc)).ok;
       // The doc should be unmodified
       expect(doc).eql({v: 6, create: {type: type.uri}});
     });
@@ -105,11 +105,11 @@ describe('ot', function() {
 
   describe('op', function() {
     it('fails if the document does not exist', function() {
-      expect(ot.apply({v: 6}, {v: 6, op: [1, 2, 3]})).ok();
+      expect(ot.apply({v: 6}, {v: 6, op: [1, 2, 3]})).ok;
     });
 
     it('fails if the type is missing', function() {
-      expect(ot.apply({v: 6, type: 'some non existant type'}, {v: 6, op: [1, 2, 3]})).ok();
+      expect(ot.apply({v: 6, type: 'some non existant type'}, {v: 6, op: [1, 2, 3]})).ok;
     });
 
     it('applies the operation to the document data', function() {
@@ -138,21 +138,21 @@ describe('ot', function() {
     it('fails if the version is specified on both and does not match', function() {
       var op1 = {v: 5, op: [{p: [10], si: 'hi'}]};
       var op2 = {v: 6, op: [{p: [5], si: 'abcde'}]};
-      expect(ot.transform(type.uri, op1, op2)).ok();
+      expect(ot.transform(type.uri, op1, op2)).ok;
       expect(op1).eql({v: 5, op: [{p: [10], si: 'hi'}]});
     });
 
     // There's 9 cases here.
     it('create by create fails', function() {
-      expect(ot.transform(null, {v: 10, create: {type: type.uri}}, {v: 10, create: {type: type.uri}})).ok();
+      expect(ot.transform(null, {v: 10, create: {type: type.uri}}, {v: 10, create: {type: type.uri}})).ok;
     });
 
     it('create by delete fails', function() {
-      expect(ot.transform(null, {create: {type: type.uri}}, {del: true})).ok();
+      expect(ot.transform(null, {create: {type: type.uri}}, {del: true})).ok;
     });
 
     it('create by op fails', function() {
-      expect(ot.transform(null, {v: 10, create: {type: type.uri}}, {v: 10, op: [15, 'hi']})).ok();
+      expect(ot.transform(null, {v: 10, create: {type: type.uri}}, {v: 10, op: [15, 'hi']})).ok;
     });
 
     it('create by noop ok', function() {
@@ -162,7 +162,7 @@ describe('ot', function() {
     });
 
     it('delete by create fails', function() {
-      expect(ot.transform(null, {del: true}, {create: {type: type.uri}})).ok();
+      expect(ot.transform(null, {del: true}, {create: {type: type.uri}})).ok;
     });
 
     it('delete by delete ok', function() {
@@ -198,11 +198,11 @@ describe('ot', function() {
     });
 
     it('op by create fails', function() {
-      expect(ot.transform(null, {op: {}}, {create: {type: type.uri}})).ok();
+      expect(ot.transform(null, {op: {}}, {create: {type: type.uri}})).ok;
     });
 
     it('op by delete fails', function() {
-      expect(ot.transform(type.uri, {v: 10, op: []}, {v: 10, del: true})).ok();
+      expect(ot.transform(type.uri, {v: 10, op: []}, {v: 10, del: true})).ok;
     });
 
     it('op by op ok', function() {

--- a/test/projections.js
+++ b/test/projections.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var projections = require('../lib/projections');
 var type = require('../lib/types').defaultType.uri;
 
@@ -12,7 +12,7 @@ describe('projection utility methods', function() {
     it('throws on snapshots with the wrong type', function() {
       expect(function() {
         projections.projectSnapshot({}, {type: 'other', data: 123});
-      }).throwException();
+      }).throw(Error);
     });
 
     it('empty object filters out all properties', function() {
@@ -244,7 +244,7 @@ describe('projection utility methods', function() {
       it('throws on create ops with the wrong type', function() {
         expect(function() {
           projections.projectOp({}, {create: {type: 'other', data: 123}});
-        }).throwException();
+        }).throw(Error);
       });
 
       it('strips data in creates', function() {

--- a/test/pubsub-memory.js
+++ b/test/pubsub-memory.js
@@ -1,6 +1,6 @@
 var MemoryPubSub = require('../lib/pubsub/memory');
 var PubSub = require('../lib/pubsub');
-var expect = require('expect.js');
+var expect = require('chai').expect;
 
 require('./pubsub')(function(callback) {
   callback(null, new MemoryPubSub());
@@ -13,7 +13,7 @@ describe('PubSub base class', function() {
   it('returns an error if _subscribe is unimplemented', function(done) {
     var pubsub = new PubSub();
     pubsub.subscribe('x', function(err) {
-      expect(err).an(Error);
+      expect(err).ok;
       expect(err.code).to.equal(5015);
       done();
     });
@@ -22,7 +22,7 @@ describe('PubSub base class', function() {
   it('emits an error if _subscribe is unimplemented and callback is not provided', function(done) {
     var pubsub = new PubSub();
     pubsub.on('error', function(err) {
-      expect(err).an(Error);
+      expect(err).ok;
       expect(err.code).to.equal(5015);
       done();
     });
@@ -37,7 +37,7 @@ describe('PubSub base class', function() {
     pubsub.subscribe('x', function(err, stream) {
       if (err) return done(err);
       pubsub.on('error', function(err) {
-        expect(err).to.be.an(Error);
+        expect(err).ok;
         expect(err.code).to.equal(5016);
         done();
       });
@@ -49,7 +49,7 @@ describe('PubSub base class', function() {
     var pubsub = new PubSub();
     pubsub.on('error', done);
     pubsub.publish(['x', 'y'], {test: true}, function(err) {
-      expect(err).an(Error);
+      expect(err).ok;
       expect(err.code).to.equal(5017);
       done();
     });
@@ -58,7 +58,7 @@ describe('PubSub base class', function() {
   it('emits an error if _publish is unimplemented and callback is not provided', function(done) {
     var pubsub = new PubSub();
     pubsub.on('error', function(err) {
-      expect(err).an(Error);
+      expect(err).ok;
       expect(err.code).to.equal(5017);
       done();
     });
@@ -68,7 +68,7 @@ describe('PubSub base class', function() {
   it('can emit events', function(done) {
     var pubsub = new PubSub();
     pubsub.on('error', function(err) {
-      expect(err).an(Error);
+      expect(err).ok;
       expect(err.message).equal('test error');
       done();
     });

--- a/test/pubsub-memory.js
+++ b/test/pubsub-memory.js
@@ -13,7 +13,7 @@ describe('PubSub base class', function() {
   it('returns an error if _subscribe is unimplemented', function(done) {
     var pubsub = new PubSub();
     pubsub.subscribe('x', function(err) {
-      expect(err).ok;
+      expect(err).instanceOf(Error);
       expect(err.code).to.equal(5015);
       done();
     });
@@ -22,7 +22,7 @@ describe('PubSub base class', function() {
   it('emits an error if _subscribe is unimplemented and callback is not provided', function(done) {
     var pubsub = new PubSub();
     pubsub.on('error', function(err) {
-      expect(err).ok;
+      expect(err).instanceOf(Error);
       expect(err.code).to.equal(5015);
       done();
     });
@@ -37,7 +37,7 @@ describe('PubSub base class', function() {
     pubsub.subscribe('x', function(err, stream) {
       if (err) return done(err);
       pubsub.on('error', function(err) {
-        expect(err).ok;
+        expect(err).instanceOf(Error);
         expect(err.code).to.equal(5016);
         done();
       });
@@ -49,7 +49,7 @@ describe('PubSub base class', function() {
     var pubsub = new PubSub();
     pubsub.on('error', done);
     pubsub.publish(['x', 'y'], {test: true}, function(err) {
-      expect(err).ok;
+      expect(err).instanceOf(Error);
       expect(err.code).to.equal(5017);
       done();
     });
@@ -58,7 +58,7 @@ describe('PubSub base class', function() {
   it('emits an error if _publish is unimplemented and callback is not provided', function(done) {
     var pubsub = new PubSub();
     pubsub.on('error', function(err) {
-      expect(err).ok;
+      expect(err).instanceOf(Error);
       expect(err.code).to.equal(5017);
       done();
     });
@@ -68,7 +68,7 @@ describe('PubSub base class', function() {
   it('can emit events', function(done) {
     var pubsub = new PubSub();
     pubsub.on('error', function(err) {
-      expect(err).ok;
+      expect(err).instanceOf(Error);
       expect(err.message).equal('test error');
       done();
     });

--- a/test/pubsub.js
+++ b/test/pubsub.js
@@ -78,7 +78,7 @@ module.exports = function(create) {
 
     it('can emit events', function(done) {
       this.pubsub.on('error', function(err) {
-        expect(err).ok;
+        expect(err).instanceOf(Error);
         expect(err.message).equal('test error');
         done();
       });

--- a/test/pubsub.js
+++ b/test/pubsub.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 
 module.exports = function(create) {
   describe('pubsub', function() {
@@ -78,7 +78,7 @@ module.exports = function(create) {
 
     it('can emit events', function(done) {
       this.pubsub.on('error', function(err) {
-        expect(err).an(Error);
+        expect(err).ok;
         expect(err.message).equal('test error');
         done();
       });


### PR DESCRIPTION
Update dependencies to current versions:
* deep-is => fast-deep-equal, since deep-is has some correctness bugs, is much slower, and isn't well maintained
* expect.js => chai for assertions
* instanbul => nyc for generating coverage reports
* Update all dev-dependency versions to current
* Add Node 12 & remove Node 6 from travis configuration to bring current with Node LTS versions