### PR TITLE
add test coverage for queryPollDoc

### DIFF
--- a/test/BasicQueryableMemoryDB.js
+++ b/test/BasicQueryableMemoryDB.js
@@ -14,17 +14,7 @@ BasicQueryableMemoryDB.prototype.constructor = BasicQueryableMemoryDB;
 BasicQueryableMemoryDB.prototype._querySync = function(snapshots, query) {
   if (query.filter) {
     snapshots = snapshots.filter(function(snapshot) {
-      for (var queryKey in query.filter) {
-        // This fake only supports simple property equality filters, so
-        // throw an error on Mongo-like filter properties with dots.
-        if (queryKey.includes('.')) {
-          throw new Error('Only simple property filters are supported, got:', queryKey);
-        }
-        if (snapshot.data[queryKey] !== query.filter[queryKey]) {
-          return false;
-        }
-      }
-      return true;
+      return querySnapshot(snapshot, query);
     });
   }
 
@@ -39,6 +29,42 @@ BasicQueryableMemoryDB.prototype._querySync = function(snapshots, query) {
 
   return {snapshots: snapshots};
 };
+
+BasicQueryableMemoryDB.prototype.queryPollDoc = function(collection, id, query, options, callback) {
+  var db = this;
+  process.nextTick(function() {
+    var snapshot = db._getSnapshotSync(collection, id);
+    try {
+      var matches = querySnapshot(snapshot, query);
+    } catch (err) {
+      return callback(err);
+    }
+    callback(null, matches);
+  });
+};
+
+BasicQueryableMemoryDB.prototype.canPollDoc = function(collection, query) {
+  return !query.sort;
+};
+
+function querySnapshot(snapshot, query) {
+  // Never match uncreated or deleted snapshots
+  if (snapshot.type == null) return false;
+  // Match any snapshot when there is no query filter
+  if (!query.filter) return true;
+  // Check that each property in the filter equals the snapshot data
+  for (var queryKey in query.filter) {
+    // This fake only supports simple property equality filters, so
+    // throw an error on Mongo-like filter properties with dots.
+    if (queryKey.includes('.')) {
+      throw new Error('Only simple property filters are supported, got:', queryKey);
+    }
+    if (snapshot.data[queryKey] !== query.filter[queryKey]) {
+      return false;
+    }
+  }
+  return true;
+}
 
 // sortProperties is an array whose items are each [propertyName, direction].
 function snapshotComparator(sortProperties) {

--- a/test/db.js
+++ b/test/db.js
@@ -734,7 +734,8 @@ module.exports = function(options) {
         var db = this.db;
         db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, null, function(err) {
           if (err) return done(err);
-          db.queryPoll('testcollection', {x: 5}, null, function(err, ids) {
+          var dbQuery = getQuery({query: {x: 5}});
+          db.queryPoll('testcollection', dbQuery, null, function(err, ids) {
             if (err) return done(err);
             expect(ids).eql(['test']);
             done();
@@ -743,7 +744,8 @@ module.exports = function(options) {
       });
 
       it('returns nothing when there is no data', function(done) {
-        this.db.queryPoll('testcollection', {x: 5}, null, function(err, ids) {
+        var dbQuery = getQuery({query: {x: 5}});
+        this.db.queryPoll('testcollection', dbQuery, null, function(err, ids) {
           if (err) return done(err);
           expect(ids).eql([]);
           done();
@@ -753,11 +755,11 @@ module.exports = function(options) {
 
     describe('queryPollDoc', function() {
       it('returns false when the document does not exist', function(done) {
-        var query = {};
-        if (!this.db.canPollDoc('testcollection', query)) return done();
+        var dbQuery = getQuery({query: {}});
+        if (!this.db.canPollDoc('testcollection', dbQuery)) return done();
 
         var db = this.db;
-        db.queryPollDoc('testcollection', 'doesnotexist', query, null, function(err, result) {
+        db.queryPollDoc('testcollection', 'doesnotexist', dbQuery, null, function(err, result) {
           if (err) return done(err);
           expect(result).equal(false);
           done();
@@ -765,14 +767,14 @@ module.exports = function(options) {
       });
 
       it('returns true when the document matches', function(done) {
-        var query = {x: 5};
-        if (!this.db.canPollDoc('testcollection', query)) return done();
+        var dbQuery = getQuery({query: {x: 5}});
+        if (!this.db.canPollDoc('testcollection', dbQuery)) return done();
 
         var snapshot = {type: 'json0', v: 1, data: {x: 5, y: 6}};
         var db = this.db;
         db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, null, function(err) {
           if (err) return done(err);
-          db.queryPollDoc('testcollection', 'test', query, null, function(err, result) {
+          db.queryPollDoc('testcollection', 'test', dbQuery, null, function(err, result) {
             if (err) return done(err);
             expect(result).equal(true);
             done();
@@ -781,14 +783,14 @@ module.exports = function(options) {
       });
 
       it('returns false when the document does not match', function(done) {
-        var query = {x: 6};
-        if (!this.db.canPollDoc('testcollection', query)) return done();
+        var dbQuery = getQuery({query: {x: 6}});
+        if (!this.db.canPollDoc('testcollection', dbQuery)) return done();
 
         var snapshot = {type: 'json0', v: 1, data: {x: 5, y: 6}};
         var db = this.db;
         db.commit('testcollection', 'test', {v: 0, create: {}}, snapshot, null, function(err) {
           if (err) return done(err);
-          db.queryPollDoc('testcollection', 'test', query, null, function(err, result) {
+          db.queryPollDoc('testcollection', 'test', dbQuery, null, function(err, result) {
             if (err) return done(err);
             expect(result).equal(false);
             done();


### PR DESCRIPTION
Implement additional BasicQueryableMemoryDB implementation methods, so that code paths in query-emitter are exercised by tests