### PR TITLE
revert to using a simple shallowCopy for ops

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -172,11 +172,7 @@ Agent.prototype._onOp = function(collection, id, op) {
   // before calling into projection and middleware code
   var agent = this;
   process.nextTick(function() {
-    var copy = shallowCopyOp(op);
-    if (!copy) {
-      logger.error('Op emitted from subscription failed to copy', collection, id, op);
-      return;
-    }
+    var copy = shallowCopy(op);
     agent.backend.sanitizeOp(agent, collection, id, copy, function(err) {
       if (err) {
         logger.error('Error sanitizing op emitted from subscription', collection, id, copy, err);
@@ -640,11 +636,12 @@ function createClientOp(request, clientId) {
         undefined;
 }
 
-function shallowCopyOp(op) {
-  return (op.op) ? new EditOp(op.src, op.seq, op.v, op.op, op.c, op.d, op.m) :
-    (op.create) ? new CreateOp(op.src, op.seq, op.v, op.create, op.c, op.d, op.m) :
-      (op.del) ? new DeleteOp(op.src, op.seq, op.v, op.del, op.c, op.d, op.m) :
-        undefined;
+function shallowCopy(object) {
+  var out = {};
+  for (var key in object) {
+    out[key] = object[key];
+  }
+  return out;
 }
 
 function CreateOp(src, seq, v, create, c, d, m) {

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -303,4 +303,89 @@ describe('middleware', function() {
       });
     });
   });
+
+  describe('access control', function() {
+    function setupOpMiddleware(backend) {
+      backend.use('apply', function(request, next) {
+        request.priorAccountId = request.snapshot.data && request.snapshot.data.accountId;
+        next();
+      });
+      backend.use('commit', function(request, next) {
+        var accountId = (request.snapshot.data) ?
+          // For created documents, get the accountId from the document data
+          request.snapshot.data.accountId :
+          // For deleted documents, get the accountId from before
+          request.priorAccountId;
+        // Store the accountId for the document on the op for efficient access control
+        request.op.accountId = accountId;
+        next();
+      });
+      backend.use('op', function(request, next) {
+        if (request.op.accountId === request.agent.accountId) {
+          return next();
+        }
+        var err = {message: 'op accountId does not match', code: 'ERR_OP_READ_FORBIDDEN'};
+        return next(err);
+      });
+    }
+
+    it('is possible to cache add additional top-level fields on ops for access control', function(done) {
+      setupOpMiddleware(this.backend);
+      var connection1 = this.backend.connect();
+      var connection2 = this.backend.connect();
+      connection2.agent.accountId = 'foo';
+
+      // Fetching the snapshot here will cause subsequent fetches to get ops
+      connection2.get('dogs', 'fido').fetch(function(err) {
+        if (err) return done(err);
+        var data = {accountId: 'foo', age: 2};
+        connection1.get('dogs', 'fido').create(data, function(err) {
+          if (err) return done(err);
+          // This will go through the 'op' middleware and should pass
+          connection2.get('dogs', 'fido').fetch(done);
+        });
+      });
+    });
+
+    it('op middleware can reject ops', function(done) {
+      setupOpMiddleware(this.backend);
+      var connection1 = this.backend.connect();
+      var connection2 = this.backend.connect();
+      connection2.agent.accountId = 'baz';
+
+      // Fetching the snapshot here will cause subsequent fetches to get ops
+      connection2.get('dogs', 'fido').fetch(function(err) {
+        if (err) return done(err);
+        var data = {accountId: 'foo', age: 2};
+        connection1.get('dogs', 'fido').create(data, function(err) {
+          if (err) return done(err);
+          // This will go through the 'op' middleware and fail;
+          connection2.get('dogs', 'fido').fetch(function(err) {
+            expect(err.code).equal('ERR_OP_READ_FORBIDDEN');
+            done();
+          });
+        });
+      });
+    });
+
+    it('pubsub subscribe can check top-level fields for access control', function(done) {
+      setupOpMiddleware(this.backend);
+      var connection1 = this.backend.connect();
+      var connection2 = this.backend.connect();
+      connection2.agent.accountId = 'foo';
+
+      // Fetching the snapshot here will cause subsequent fetches to get ops
+      connection2.get('dogs', 'fido').subscribe(function(err) {
+        if (err) return done(err);
+        var data = {accountId: 'foo', age: 2};
+        connection1.get('dogs', 'fido').create(data, function(err) {
+          if (err) return done(err);
+          // The subscribed op will go through the 'op' middleware and should pass
+          connection2.get('dogs', 'fido').on('create', function() {
+            done();
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Previously, ops were copied by iterating over them in pubsub. This was changed in https://github.com/share/sharedb/pull/316 to copy the specific properties expected on an op. Copying the specific properties is faster than iterating and allows use of specifically typed objects.

However, this ended up being a breaking change, because middleware could be adding additional fields to the top level of the op, which do end up getting committed and fetched. Perhaps a way to add additional op fields explicitly should be implemented, but for now, let's just revert, since this was not intended to be breaking.