### PR TITLE
Fix previously inflight op could be mutated

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -735,7 +735,7 @@ Doc.prototype._tryCompose = function(op) {
   // We can only compose into the last pending op. Inflight ops have already
   // been sent to the server, so we can't modify them
   var last = this.pendingOps[this.pendingOps.length - 1];
-  if (!last) return;
+  if (!last || last.sentAt) return;
 
   // Compose an op into a create by applying it. This effectively makes the op
   // invisible, as if the document were created including the op originally


### PR DESCRIPTION
A very rare case happens sometime to us were an operation is sent just before a deconnection, modified while disconnected, and sent again when connection is recovered. Local document assume last operation was applied, when in fact only the first one was and no error is ever raised. This happen with latest `ShareDB` + `ShareDB-Mongo`.

I traced back the issue, and here is what I understand from it:

- When a disconnection occurred while an op is inflight, the operation is put back on the stack of pending ones ensuring it is sent again when connection is recovered => [`client/doc.js#L348-L352`](https://github.com/Calyhre/sharedb/blob/d28eb71a4121eb9d9ad3b816c8093c960f5101e5/lib/client/doc.js#L348-L352)
- But this also makes it a potential candidate to be composed with when operations are added while connection is down and it's the only one available => [`client/doc.js#L737`](https://github.com/Calyhre/sharedb/blob/d28eb71a4121eb9d9ad3b816c8093c960f5101e5/lib/client/doc.js#L737)
- When operation are sent again, [`seq` is not changed if already set](https://github.com/Calyhre/sharedb/blob/d28eb71a4121eb9d9ad3b816c8093c960f5101e5/lib/client/doc.js#L629), thus the client can generate two different operation with the exact same `src`+`seq` tuple.
- This is supposed to be [caught by the backend](https://github.com/Calyhre/sharedb/blob/d28eb71a4121eb9d9ad3b816c8093c960f5101e5/lib/submit-request.js#L194-L200), `op` will be checked and transformed on all operation from `op.v` to `snapshot.v` => [`submit-request.js#L98-L106`](https://github.com/Calyhre/sharedb/blob/d28eb71a4121eb9d9ad3b816c8093c960f5101e5/lib/submit-request.js#L98-L106) But it entirely depends on the implementation of `db.getOpsToSnapshot`. ShareDB Mongo adapter for example, get ops from [`>= op.v`](https://github.com/share/sharedb-mongo/blob/master/index.js#L583) but [`< snapshot.v`](https://github.com/share/sharedb-mongo/blob/master/index.js#L587), meaning zero op will be checked if last one is replayed.