### PR TITLE
Add ability for "readSnapshots" middleware to reject reads of specific snapshots for bulk fetch/subscribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,16 +602,16 @@ An `Agent` is the representation of a client's `Connection` state on the server.
 The `Agent` will be made available in all [middleware](#middlewares) requests. The `agent.custom` field is an object that can be used for storing arbitrary information for use in middleware. For example:
 
 ```javascript
-backend.useMiddleware('connect', function (request, callback) {
+backend.useMiddleware('connect', (request, callback) => {
   // Best practice to clone to prevent mutating the object after connection.
   // You may also want to consider a deep clone, depending on the shape of request.req.
   Object.assign(request.agent.custom, request.req);
   callback();
 });
 
-backend.useMiddleware('readSnapshots', function (request, callback) {
-  var connectionInfo = request.agent.custom;
-  var snapshots = request.snapshots;
+backend.useMiddleware('readSnapshots', (request, callback) => {
+  const connectionInfo = request.agent.custom;
+  const snapshots = request.snapshots;
 
   // Use the information provided at connection to determine if a user can access the snapshots.
   // This should also be checked when fetching and submitting ops.
@@ -619,9 +619,7 @@ backend.useMiddleware('readSnapshots', function (request, callback) {
     return callback(new Error('Not allowed to access collection ' + request.collection));
   }
   // Check each snapshot individually.
-  // In ES6, this could be `for (const snapshot of snapshots)`
-  for (var i = 0; i < snapshots.length; i++) {
-    var snapshot = snapshots[i];
+  for (const snapshot of snapshots) {
     if (!userCanAccessSnapshot(connectionInfo, request.collection, snapshot)) {
       request.rejectSnapshotRead(snapshot,
         new Error('Not allowed to access snapshot in ' request.collection));
@@ -635,10 +633,10 @@ backend.useMiddleware('readSnapshots', function (request, callback) {
 // potentially making some database request to check which documents they can access, or which
 // roles they have, etc. If doing this asynchronously, make sure you call backend.connect
 // after the permissions have been fetched.
-var connectionInfo = getUserPermissions();
+const connectionInfo = getUserPermissions();
 // Pass info in as the second argument. This will be made available as request.req in the
 // 'connection' middleware.
-var connection = backend.connect(null, connectionInfo);
+const connection = backend.connect(null, connectionInfo);
 ```
 
 ### Logging

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Register a new middleware.
     * `query`: The query object being handled (for 'query')
     * `snapshots`: Array of retrieved snapshots (for 'readSnapshots')
     * `rejectSnapshotRead(snapshot, error)`: Reject a specific snapshot read (for 'readSnapshots')
+      - `rejectSnapshotReadSilent(snapshot, errorMessage)`: As above, but causes the ShareDB client to treat it as a silent rejection, not passing the error back to user code.
     * `data`: Received client message (for 'receive')
     * `request`: Client message being replied to (for 'reply')
     * `reply`: Reply to be sent to the client (for 'reply')

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -424,7 +424,7 @@ Agent.prototype._querySubscribe = function(queryId, collection, query, options, 
     wait++;
     this.backend.fetchBulk(this, collection, options.fetch, function(err, snapshotMap) {
       if (err) return finish(err);
-      message = {data: getMapData(snapshotMap)};
+      message = getMapResult(snapshotMap);
       finish();
     });
   }
@@ -463,12 +463,23 @@ function getResultsData(results) {
   return items;
 }
 
-function getMapData(snapshotMap) {
+function getMapResult(snapshotMap) {
   var data = {};
+  var errorMap = {};
+  var hasSnapshotError = false;
   for (var id in snapshotMap) {
-    data[id] = getSnapshotData(snapshotMap[id]);
+    var mapValue = snapshotMap[id];
+    // fetchBulk / subscribeBulk map data can have either a Snapshot or an object
+    // `{error: Error | string}` as a value.
+    if (mapValue.error) {
+      hasSnapshotError = true;
+      // Transform errors to serialization-friendly objects.
+      errorMap[id] = getReplyErrorObject(mapValue.error);
+    } else {
+      data[id] = getSnapshotData(mapValue);
+    }
   }
-  return data;
+  return hasSnapshotError ? {data: data, errorMap: errorMap} : {data: data};
 }
 
 function getSnapshotData(snapshot) {
@@ -517,20 +528,11 @@ Agent.prototype._fetchOps = function(collection, id, version, callback) {
 Agent.prototype._fetchBulk = function(collection, versions, callback) {
   if (Array.isArray(versions)) {
     this.backend.fetchBulk(this, collection, versions, function(err, snapshotMap) {
-      var isPartialError = err != null && err.code === ERROR_CODE.ERR_SNAPSHOT_READS_REJECTED;
-      if (err && !isPartialError) {
+      if (err) {
         return callback(err);
       }
       if (snapshotMap) {
-        var result = {data: getMapData(snapshotMap)};
-        if (err && isPartialError) {
-          var errorMap = {};
-          for (var docId in err.idToError) {
-            // Transform Error instances to serialization-friendly objects.
-            errorMap[docId] = getReplyErrorObject(err.idToError[docId]);
-          }
-          result.errorMap = errorMap;
-        }
+        var result = getMapResult(snapshotMap);
         callback(null, result);
       } else {
         callback();
@@ -581,8 +583,7 @@ Agent.prototype._subscribeBulk = function(collection, versions, callback) {
   // See _subscribe() above. This function's logic should match but in bulk
   var agent = this;
   this.backend.subscribeBulk(this, collection, versions, function(err, streams, snapshotMap, opsMap) {
-    var isPartialError = err != null && err.code === ERROR_CODE.ERR_SNAPSHOT_READS_REJECTED;
-    if (err && !isPartialError) {
+    if (err) {
       return callback(err);
     }
     if (opsMap) {
@@ -592,15 +593,7 @@ Agent.prototype._subscribeBulk = function(collection, versions, callback) {
       agent._subscribeToStream(collection, id, streams[id]);
     }
     if (snapshotMap) {
-      var result = {data: getMapData(snapshotMap)};
-      if (err && isPartialError) {
-        var errorMap = {};
-        for (var docId in err.idToError) {
-          // Transform Error instances to serialization-friendly objects.
-          errorMap[docId] = getReplyErrorObject(err.idToError[docId]);
-        }
-        result.errorMap = errorMap;
-      }
+      var result = getMapResult(snapshotMap);
       callback(null, result);
     } else {
       callback();

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -517,8 +517,24 @@ Agent.prototype._fetchOps = function(collection, id, version, callback) {
 Agent.prototype._fetchBulk = function(collection, versions, callback) {
   if (Array.isArray(versions)) {
     this.backend.fetchBulk(this, collection, versions, function(err, snapshotMap) {
-      if (err) return callback(err);
-      callback(null, {data: getMapData(snapshotMap)});
+      var isPartialError = err != null && err.code === ERROR_CODE.ERR_SNAPSHOT_READS_PARTIALLY_REJECTED;
+      if (err && !isPartialError) {
+        return callback(err);
+      }
+      if (snapshotMap) {
+        var result = {data: getMapData(snapshotMap)};
+        if (err && isPartialError) {
+          var errorMap = {};
+          for (var docId in err.idToError) {
+            // Transform Error instances to serialization-friendly objects.
+            errorMap[docId] = getReplyErrorObject(err.idToError[docId]);
+          }
+          result.errorMap = errorMap;
+        }
+        callback(null, result);
+      } else {
+        callback();
+      }
     });
   } else {
     this._fetchBulkOps(collection, versions, callback);
@@ -565,7 +581,10 @@ Agent.prototype._subscribeBulk = function(collection, versions, callback) {
   // See _subscribe() above. This function's logic should match but in bulk
   var agent = this;
   this.backend.subscribeBulk(this, collection, versions, function(err, streams, snapshotMap, opsMap) {
-    if (err) return callback(err);
+    var isPartialError = err != null && err.code === ERROR_CODE.ERR_SNAPSHOT_READS_PARTIALLY_REJECTED;
+    if (err && !isPartialError) {
+      return callback(err);
+    }
     if (opsMap) {
       agent._sendOpsBulk(collection, opsMap);
     }
@@ -573,7 +592,16 @@ Agent.prototype._subscribeBulk = function(collection, versions, callback) {
       agent._subscribeToStream(collection, id, streams[id]);
     }
     if (snapshotMap) {
-      callback(null, {data: getMapData(snapshotMap)});
+      var result = {data: getMapData(snapshotMap)};
+      if (err && isPartialError) {
+        var errorMap = {};
+        for (var docId in err.idToError) {
+          // Transform Error instances to serialization-friendly objects.
+          errorMap[docId] = getReplyErrorObject(err.idToError[docId]);
+        }
+        result.errorMap = errorMap;
+      }
+      callback(null, result);
     } else {
       callback();
     }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -465,21 +465,18 @@ function getResultsData(results) {
 
 function getMapResult(snapshotMap) {
   var data = {};
-  var errorMap = {};
-  var hasSnapshotError = false;
   for (var id in snapshotMap) {
     var mapValue = snapshotMap[id];
     // fetchBulk / subscribeBulk map data can have either a Snapshot or an object
     // `{error: Error | string}` as a value.
     if (mapValue.error) {
-      hasSnapshotError = true;
       // Transform errors to serialization-friendly objects.
-      errorMap[id] = getReplyErrorObject(mapValue.error);
+      data[id] = {error: getReplyErrorObject(mapValue.error)};
     } else {
       data[id] = getSnapshotData(mapValue);
     }
   }
-  return hasSnapshotError ? {data: data, errorMap: errorMap} : {data: data};
+  return {data: data};
 }
 
 function getSnapshotData(snapshot) {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -517,7 +517,7 @@ Agent.prototype._fetchOps = function(collection, id, version, callback) {
 Agent.prototype._fetchBulk = function(collection, versions, callback) {
   if (Array.isArray(versions)) {
     this.backend.fetchBulk(this, collection, versions, function(err, snapshotMap) {
-      var isPartialError = err != null && err.code === ERROR_CODE.ERR_SNAPSHOT_READS_PARTIALLY_REJECTED;
+      var isPartialError = err != null && err.code === ERROR_CODE.ERR_SNAPSHOT_READS_REJECTED;
       if (err && !isPartialError) {
         return callback(err);
       }
@@ -581,7 +581,7 @@ Agent.prototype._subscribeBulk = function(collection, versions, callback) {
   // See _subscribe() above. This function's logic should match but in bulk
   var agent = this;
   this.backend.subscribeBulk(this, collection, versions, function(err, streams, snapshotMap, opsMap) {
-    var isPartialError = err != null && err.code === ERROR_CODE.ERR_SNAPSHOT_READS_PARTIALLY_REJECTED;
+    var isPartialError = err != null && err.code === ERROR_CODE.ERR_SNAPSHOT_READS_REJECTED;
     if (err && !isPartialError) {
       return callback(err);
     }

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -258,8 +258,63 @@ Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, s
     snapshotType: snapshotType
   };
 
-  this.trigger(this.MIDDLEWARE_ACTIONS.readSnapshots, agent, request, callback);
+  this.trigger(this.MIDDLEWARE_ACTIONS.readSnapshots, agent, request, function(err) {
+    if (err) return callback(err);
+    // Handle "partial rejection" - "readSnapshots" middleware functions can set `snapshot.error`
+    // to reject the read of a specific snapshot.
+    err = getReadSnapshotsError(snapshots);
+    if (err) {
+      callback(err);
+    } else {
+      callback();
+    }
+  });
 };
+
+/**
+ * Returns an overall error from "readSnapshots" based on the snapshot-specific errors, if any.
+ *
+ * - If there's exactly one snapshot and it has an error, then that error is returned.
+ * - If there's more than one snapshot and at least one has an error, then an overall
+ *   "ERR_SNAPSHOT_READS_PARTIALLY_REJECTED" is returned, with an `idToError` property
+ *
+ * @param {Snapshot[]} snapshots - Array of snapshots, each of which may have an `error` property
+ */
+function getReadSnapshotsError(snapshots) {
+  // If there are 0 snapshots, there can't be any snapshot-specific errors.
+  if (snapshots.length === 0) {
+    return;
+  }
+
+  // Single snapshot with error is treated as a full error.
+  if (snapshots.length === 1) {
+    if (snapshots[0].error) {
+      return snapshots[0].error;
+    } else {
+      return;
+    }
+  }
+
+  // Errors in some snapshots result in an overall ERR_SNAPSHOT_READS_PARTIALLY_REJECTED.
+  //
+  // fetchBulk and subscribeBulk know how to handle that special error by sending a doc-by-doc
+  // success/failure to the client. Other methods that don't or can't handle partial failures
+  // will treat it as a full rejection.
+  var hasSnapshotError = false;
+  var idToError = {};
+  for (var i = 0; i < snapshots.length; i++) {
+    var snapshot = snapshots[i];
+    if (snapshot.error) {
+      hasSnapshotError = true;
+      idToError[snapshot.id] = snapshot.error;
+    }
+  }
+  if (hasSnapshotError) {
+    var err = new ShareDBError('ERR_SNAPSHOT_READS_PARTIALLY_REJECTED');
+    err.idToError = idToError;
+    return err;
+  }
+}
 
 Backend.prototype._getSnapshotProjection = function(db, projection) {
   return (db.projectsSnapshots) ? null : projection;
@@ -410,9 +465,17 @@ Backend.prototype.fetchBulk = function(agent, index, ids, options, callback) {
       snapshots,
       backend.SNAPSHOT_TYPES.current,
       function(err) {
-        if (err) return callback(err);
+        if (err) {
+          if (err.code === ERROR_CODE.ERR_SNAPSHOT_READS_PARTIALLY_REJECTED) {
+            for (var docId in err.idToError) {
+              delete snapshotMap[docId];
+            }
+          } else {
+            snapshotMap = undefined;
+          }
+        }
         backend.emit('timing', 'fetchBulk', Date.now() - start, request);
-        callback(null, snapshotMap);
+        callback(err, snapshotMap);
       });
   });
 };
@@ -501,11 +564,21 @@ Backend.prototype.subscribeBulk = function(agent, index, versions, callback) {
       // If an array of ids, get current snapshots
       backend.fetchBulk(agent, index, ids, function(err, snapshotMap) {
         if (err) {
-          destroyStreams(streams);
-          return callback(err);
+          if (err.code === ERROR_CODE.ERR_SNAPSHOT_READS_PARTIALLY_REJECTED) {
+            // Partial error, destroy only streams for docs with errors.
+            for (var docId in err.idToError) {
+              streams[docId].destroy();
+              delete streams[docId];
+            }
+          } else {
+            // Full error, destroy all streams.
+            destroyStreams(streams);
+            streams = undefined;
+            snapshotMap = undefined;
+          }
         }
         backend.emit('timing', 'subscribeBulk.snapshot', Date.now() - start, request);
-        callback(null, streams, snapshotMap);
+        callback(err, streams, snapshotMap);
       });
     } else {
       // If a versions map, get ops since requested versions

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -288,7 +288,7 @@ function getReadSnapshotsError(snapshots, idToError) {
 
   // Single snapshot with error is treated as a full error.
   if (snapshots.length === 1) {
-    var snapshotError = idToError[snapshot.id];
+    var snapshotError = idToError[snapshots[0].id];
     if (snapshotError) {
       return snapshotError;
     } else {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -12,6 +12,7 @@ var ShareDBError = require('./error');
 var Snapshot = require('./snapshot');
 var StreamSocket = require('./stream-socket');
 var SubmitRequest = require('./submit-request');
+var ReadSnapshotsRequest = require('./readSnapshots-request');
 
 var ERROR_CODE = ShareDBError.CODES;
 
@@ -252,17 +253,15 @@ Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, s
     }
   }
 
-  var request = {
-    collection: collection,
-    snapshots: snapshots,
-    snapshotType: snapshotType
-  };
+  var request = new ReadSnapshotsRequest(collection, snapshots, snapshotType);
 
   this.trigger(this.MIDDLEWARE_ACTIONS.readSnapshots, agent, request, function(err) {
     if (err) return callback(err);
-    // Handle "partial rejection" - "readSnapshots" middleware functions can set `snapshot.error`
-    // to reject the read of a specific snapshot.
-    err = getReadSnapshotsError(snapshots);
+    // Handle "partial rejection" - "readSnapshots" middleware functions can use
+    // `request.rejectSnapshotRead(snapshot, error)` to reject the read of a specific snapshot.
+    if (request.hasSnapshotRejection()) {
+      err = getReadSnapshotsError(snapshots, request._idToError);
+    }
     if (err) {
       callback(err);
     } else {
@@ -272,15 +271,16 @@ Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, s
 };
 
 /**
- * Returns an overall error from "readSnapshots" based on the snapshot-specific errors, if any.
+ * Returns an overall error from "readSnapshots" based on the snapshot-specific errors.
  *
  * - If there's exactly one snapshot and it has an error, then that error is returned.
  * - If there's more than one snapshot and at least one has an error, then an overall
- *   "ERR_SNAPSHOT_READS_PARTIALLY_REJECTED" is returned, with an `idToError` property
+ *   "ERR_SNAPSHOT_READS_REJECTED" is returned, with an `idToError` property.
  *
- * @param {Snapshot[]} snapshots - Array of snapshots, each of which may have an `error` property
+ * @param {Snapshot[]} snapshots
+ * @param {{[docId: string]: string | Error}} idToError
  */
-function getReadSnapshotsError(snapshots) {
+function getReadSnapshotsError(snapshots, idToError) {
   // If there are 0 snapshots, there can't be any snapshot-specific errors.
   if (snapshots.length === 0) {
     return;
@@ -288,32 +288,22 @@ function getReadSnapshotsError(snapshots) {
 
   // Single snapshot with error is treated as a full error.
   if (snapshots.length === 1) {
-    if (snapshots[0].error) {
-      return snapshots[0].error;
+    var snapshotError = idToError[snapshot.id];
+    if (snapshotError) {
+      return snapshotError;
     } else {
       return;
     }
   }
 
-  // Errors in some snapshots result in an overall ERR_SNAPSHOT_READS_PARTIALLY_REJECTED.
+  // Errors in specific snapshots result in an overall ERR_SNAPSHOT_READS_REJECTED.
   //
   // fetchBulk and subscribeBulk know how to handle that special error by sending a doc-by-doc
   // success/failure to the client. Other methods that don't or can't handle partial failures
   // will treat it as a full rejection.
-  var hasSnapshotError = false;
-  var idToError = {};
-  for (var i = 0; i < snapshots.length; i++) {
-    var snapshot = snapshots[i];
-    if (snapshot.error) {
-      hasSnapshotError = true;
-      idToError[snapshot.id] = snapshot.error;
-    }
-  }
-  if (hasSnapshotError) {
-    var err = new ShareDBError('ERR_SNAPSHOT_READS_PARTIALLY_REJECTED');
-    err.idToError = idToError;
-    return err;
-  }
+  var err = new ShareDBError('ERR_SNAPSHOT_READS_REJECTED');
+  err.idToError = idToError;
+  return err;
 }
 
 Backend.prototype._getSnapshotProjection = function(db, projection) {
@@ -466,7 +456,7 @@ Backend.prototype.fetchBulk = function(agent, index, ids, options, callback) {
       backend.SNAPSHOT_TYPES.current,
       function(err) {
         if (err) {
-          if (err.code === ERROR_CODE.ERR_SNAPSHOT_READS_PARTIALLY_REJECTED) {
+          if (err.code === ERROR_CODE.ERR_SNAPSHOT_READS_REJECTED) {
             for (var docId in err.idToError) {
               delete snapshotMap[docId];
             }
@@ -564,7 +554,7 @@ Backend.prototype.subscribeBulk = function(agent, index, versions, callback) {
       // If an array of ids, get current snapshots
       backend.fetchBulk(agent, index, ids, function(err, snapshotMap) {
         if (err) {
-          if (err.code === ERROR_CODE.ERR_SNAPSHOT_READS_PARTIALLY_REJECTED) {
+          if (err.code === ERROR_CODE.ERR_SNAPSHOT_READS_REJECTED) {
             // Partial error, destroy only streams for docs with errors.
             for (var docId in err.idToError) {
               streams[docId].destroy();

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -12,7 +12,7 @@ var ShareDBError = require('./error');
 var Snapshot = require('./snapshot');
 var StreamSocket = require('./stream-socket');
 var SubmitRequest = require('./submit-request');
-var ReadSnapshotsRequest = require('./readSnapshots-request');
+var ReadSnapshotsRequest = require('./read-snapshots-request');
 
 var ERROR_CODE = ShareDBError.CODES;
 
@@ -260,7 +260,7 @@ Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, s
     // Handle "partial rejection" - "readSnapshots" middleware functions can use
     // `request.rejectSnapshotRead(snapshot, error)` to reject the read of a specific snapshot.
     if (request.hasSnapshotRejection()) {
-      err = getReadSnapshotsError(snapshots, request._idToError);
+      err = request.getReadSnapshotsError();
     }
     if (err) {
       callback(err);
@@ -269,42 +269,6 @@ Backend.prototype._sanitizeSnapshots = function(agent, projection, collection, s
     }
   });
 };
-
-/**
- * Returns an overall error from "readSnapshots" based on the snapshot-specific errors.
- *
- * - If there's exactly one snapshot and it has an error, then that error is returned.
- * - If there's more than one snapshot and at least one has an error, then an overall
- *   "ERR_SNAPSHOT_READS_REJECTED" is returned, with an `idToError` property.
- *
- * @param {Snapshot[]} snapshots
- * @param {{[docId: string]: string | Error}} idToError
- */
-function getReadSnapshotsError(snapshots, idToError) {
-  // If there are 0 snapshots, there can't be any snapshot-specific errors.
-  if (snapshots.length === 0) {
-    return;
-  }
-
-  // Single snapshot with error is treated as a full error.
-  if (snapshots.length === 1) {
-    var snapshotError = idToError[snapshots[0].id];
-    if (snapshotError) {
-      return snapshotError;
-    } else {
-      return;
-    }
-  }
-
-  // Errors in specific snapshots result in an overall ERR_SNAPSHOT_READS_REJECTED.
-  //
-  // fetchBulk and subscribeBulk know how to handle that special error by sending a doc-by-doc
-  // success/failure to the client. Other methods that don't or can't handle partial failures
-  // will treat it as a full rejection.
-  var err = new ShareDBError('ERR_SNAPSHOT_READS_REJECTED');
-  err.idToError = idToError;
-  return err;
-}
 
 Backend.prototype._getSnapshotProjection = function(db, projection) {
   return (db.projectsSnapshots) ? null : projection;
@@ -427,6 +391,18 @@ Backend.prototype.fetch = function(agent, index, id, options, callback) {
   });
 };
 
+/**
+ * Map of document id to Snapshot or error object.
+ * @typedef {{ [id: string]: Snapshot | { error: Error | string } }} SnapshotMap
+ */
+
+/**
+ * @param {Agent} agent
+ * @param {string} index
+ * @param {string[]} ids
+ * @param {*} options
+ * @param {(err?: Error | string, snapshotMap?: SnapshotMap) => void} callback
+ */
 Backend.prototype.fetchBulk = function(agent, index, ids, options, callback) {
   if (typeof options === 'function') {
     callback = options;
@@ -458,8 +434,9 @@ Backend.prototype.fetchBulk = function(agent, index, ids, options, callback) {
         if (err) {
           if (err.code === ERROR_CODE.ERR_SNAPSHOT_READS_REJECTED) {
             for (var docId in err.idToError) {
-              delete snapshotMap[docId];
+              snapshotMap[docId] = {error: err.idToError[docId]};
             }
+            err = undefined;
           } else {
             snapshotMap = undefined;
           }
@@ -524,6 +501,26 @@ Backend.prototype.subscribe = function(agent, index, id, version, options, callb
   });
 };
 
+/**
+ * Map of document id to pubsub stream.
+ * @typedef {{ [id: string]: Stream }} StreamMap
+ */
+/**
+ * Map of document id to array of ops for the doc.
+ * @typedef {{ [id: string]: Op[] }} OpsMap
+ */
+
+/**
+ * @param {Agent} agent
+ * @param {string} index
+ * @param {string[]} versions
+ * @param {(
+ *   err?: Error | string | null,
+ *   streams?: StreamMap,
+ *   snapshotMap?: SnapshotMap | null
+ *   opsMap?: OpsMap
+ * ) => void} callback
+ */
 Backend.prototype.subscribeBulk = function(agent, index, versions, callback) {
   var start = Date.now();
   var projection = this.projections[index];
@@ -554,17 +551,17 @@ Backend.prototype.subscribeBulk = function(agent, index, versions, callback) {
       // If an array of ids, get current snapshots
       backend.fetchBulk(agent, index, ids, function(err, snapshotMap) {
         if (err) {
-          if (err.code === ERROR_CODE.ERR_SNAPSHOT_READS_REJECTED) {
-            // Partial error, destroy only streams for docs with errors.
-            for (var docId in err.idToError) {
-              streams[docId].destroy();
-              delete streams[docId];
-            }
-          } else {
-            // Full error, destroy all streams.
-            destroyStreams(streams);
-            streams = undefined;
-            snapshotMap = undefined;
+          // Full error, destroy all streams.
+          destroyStreams(streams);
+          streams = undefined;
+          snapshotMap = undefined;
+        }
+        for (var docId in snapshotMap) {
+          // The doc id could map to an object `{error: Error | string}`, which indicates that
+          // particular snapshot's read was rejected. Destroy the streams fur such docs.
+          if (snapshotMap[docId].error) {
+            streams[docId].destroy();
+            delete streams[docId];
           }
         }
         backend.emit('timing', 'subscribeBulk.snapshot', Date.now() - start, request);

--- a/lib/client/connection.js
+++ b/lib/client/connection.js
@@ -175,11 +175,7 @@ Connection.prototype.bindToSocket = function(socket) {
 Connection.prototype.handleMessage = function(message) {
   var err = null;
   if (message.error) {
-    // wrap in Error object so can be passed through event emitters
-    err = new Error(message.error.message);
-    err.code = message.error.code;
-    // Add the message data to the error object for more context
-    err.data = message;
+    err = wrapErrorData(message.error, message);
     delete message.error;
   }
   // Switch on the message action. Most messages are for documents and are
@@ -233,11 +229,11 @@ Connection.prototype.handleMessage = function(message) {
       return;
 
     case 'bf':
-      return this._handleBulkMessage(message, '_handleFetch');
+      return this._handleBulkMessage(err, message, '_handleFetch');
     case 'bs':
-      return this._handleBulkMessage(message, '_handleSubscribe');
+      return this._handleBulkMessage(err, message, '_handleSubscribe');
     case 'bu':
-      return this._handleBulkMessage(message, '_handleUnsubscribe');
+      return this._handleBulkMessage(err, message, '_handleUnsubscribe');
 
     case 'nf':
     case 'nt':
@@ -265,22 +261,38 @@ Connection.prototype.handleMessage = function(message) {
   }
 };
 
-Connection.prototype._handleBulkMessage = function(message, method) {
+function wrapErrorData(errorData, fullMessage) {
+  // wrap in Error object so can be passed through event emitters
+  var err = new Error(errorData.message);
+  err.code = errorData.code;
+  if (fullMessage) {
+    // Add the message data to the error object for more context
+    err.data = fullMessage;
+  }
+  return err;
+}
+
+Connection.prototype._handleBulkMessage = function(err, message, method) {
   if (message.data) {
     for (var id in message.data) {
       var doc = this.getExisting(message.c, id);
-      if (doc) doc[method](message.error, message.data[id]);
+      if (doc) doc[method](err, message.data[id]);
+    }
+    // Handle doc-specific errors.
+    for (var id in message.errorMap) {
+      var doc = this.getExisting(message.c, id);
+      if (doc) doc[method](wrapErrorData(message.errorMap[id]));
     }
   } else if (Array.isArray(message.b)) {
     for (var i = 0; i < message.b.length; i++) {
       var id = message.b[i];
       var doc = this.getExisting(message.c, id);
-      if (doc) doc[method](message.error);
+      if (doc) doc[method](err);
     }
   } else if (message.b) {
     for (var id in message.b) {
       var doc = this.getExisting(message.c, id);
-      if (doc) doc[method](message.error);
+      if (doc) doc[method](err);
     }
   } else {
     logger.error('Invalid bulk message', message);

--- a/lib/client/connection.js
+++ b/lib/client/connection.js
@@ -275,13 +275,18 @@ function wrapErrorData(errorData, fullMessage) {
 Connection.prototype._handleBulkMessage = function(err, message, method) {
   if (message.data) {
     for (var id in message.data) {
+      var dataForId = message.data[id];
       var doc = this.getExisting(message.c, id);
-      if (doc) doc[method](err, message.data[id]);
-    }
-    // Handle doc-specific errors.
-    for (var id in message.errorMap) {
-      var doc = this.getExisting(message.c, id);
-      if (doc) doc[method](wrapErrorData(message.errorMap[id]));
+      if (doc) {
+        if (err) {
+          doc[method](err);
+        } else if (dataForId.error) {
+          // Bulk reply snapshot-specific errorr - see agent.js getMapResult
+          doc[method](wrapErrorData(dataForId.error));
+        } else {
+          doc[method](null, dataForId);
+        }
+      }
     }
   } else if (Array.isArray(message.b)) {
     for (var i = 0; i < message.b.length; i++) {

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -246,7 +246,7 @@ Doc.prototype._emitNothingPending = function() {
 // **** Helpers for network messages
 
 Doc.prototype._emitResponseError = function(err, callback) {
-  if (err && err.code === ERROR_CODE.ERR_SNAPSHOT_READ_IGNORABLE_REJECTION) {
+  if (err && err.code === ERROR_CODE.ERR_SNAPSHOT_READ_SILENT_REJECTION) {
     this.wantSubscribe = false;
     if (callback) {
       callback();

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -246,6 +246,14 @@ Doc.prototype._emitNothingPending = function() {
 // **** Helpers for network messages
 
 Doc.prototype._emitResponseError = function(err, callback) {
+  if (err && err.code === ERROR_CODE.ERR_SNAPSHOT_READ_IGNORABLE_REJECTION) {
+    this.wantSubscribe = false;
+    if (callback) {
+      callback();
+    }
+    this._emitNothingPending();
+    return;
+  }
   if (callback) {
     callback(err);
     this._emitNothingPending();

--- a/lib/error.js
+++ b/lib/error.js
@@ -42,6 +42,13 @@ ShareDBError.CODES = {
   ERR_PROTOCOL_VERSION_NOT_SUPPORTED: 'ERR_PROTOCOL_VERSION_NOT_SUPPORTED',
   ERR_QUERY_EMITTER_LISTENER_NOT_ASSIGNED: 'ERR_QUERY_EMITTER_LISTENER_NOT_ASSIGNED',
   /**
+   * A special error that a "readSnapshots" middleware implementation can use to indicate that it
+   * wishes for the ShareDB client to "ignore" the error, not passing it back to user code.
+   *
+   * For subscribes, the ShareDB client will still cancel the document subscription.
+   */
+  ERR_SNAPSHOT_READ_IGNORABLE_REJECTION: 'ERR_SNAPSHOT_READ_IGNORABLE_REJECTION',
+  /**
    * A "readSnapshots" middleware rejected the reads of specific snapshots.
    *
    * This error code is mostly for server use and generally will not be encountered on the client.

--- a/lib/error.js
+++ b/lib/error.js
@@ -41,6 +41,17 @@ ShareDBError.CODES = {
   ERR_OT_OP_NOT_PROVIDED: 'ERR_OT_OP_NOT_PROVIDED',
   ERR_PROTOCOL_VERSION_NOT_SUPPORTED: 'ERR_PROTOCOL_VERSION_NOT_SUPPORTED',
   ERR_QUERY_EMITTER_LISTENER_NOT_ASSIGNED: 'ERR_QUERY_EMITTER_LISTENER_NOT_ASSIGNED',
+  /**
+   * A "readSnapshots" middleware rejected the reads of specific snapshots.
+   *
+   * This error code is mostly for server use and generally will not be encountered on the client.
+   * Instead, each specific doc that encountered an error will receive its specific error.
+   *
+   * The one exception is for queries, where a "readSnapshots" rejection of specific snapshots will
+   * cause the client to receive this error for the whole query, since queries don't support
+   * doc-specific errors.
+   */
+  ERR_SNAPSHOT_READS_PARTIALLY_REJECTED: 'ERR_SNAPSHOT_READS_PARTIALLY_REJECTED',
   ERR_SUBMIT_TRANSFORM_OPS_NOT_FOUND: 'ERR_SUBMIT_TRANSFORM_OPS_NOT_FOUND',
   ERR_TYPE_CANNOT_BE_PROJECTED: 'ERR_TYPE_CANNOT_BE_PROJECTED',
   ERR_UNKNOWN_ERROR: 'ERR_UNKNOWN_ERROR'

--- a/lib/error.js
+++ b/lib/error.js
@@ -43,11 +43,12 @@ ShareDBError.CODES = {
   ERR_QUERY_EMITTER_LISTENER_NOT_ASSIGNED: 'ERR_QUERY_EMITTER_LISTENER_NOT_ASSIGNED',
   /**
    * A special error that a "readSnapshots" middleware implementation can use to indicate that it
-   * wishes for the ShareDB client to "ignore" the error, not passing it back to user code.
+   * wishes for the ShareDB client to treat it as a silent rejection, not passing the error back to
+   * user code.
    *
    * For subscribes, the ShareDB client will still cancel the document subscription.
    */
-  ERR_SNAPSHOT_READ_IGNORABLE_REJECTION: 'ERR_SNAPSHOT_READ_IGNORABLE_REJECTION',
+  ERR_SNAPSHOT_READ_SILENT_REJECTION: 'ERR_SNAPSHOT_READ_SILENT_REJECTION',
   /**
    * A "readSnapshots" middleware rejected the reads of specific snapshots.
    *
@@ -58,7 +59,7 @@ ShareDBError.CODES = {
    * cause the client to receive this error for the whole query, since queries don't support
    * doc-specific errors.
    */
-  ERR_SNAPSHOT_READS_PARTIALLY_REJECTED: 'ERR_SNAPSHOT_READS_PARTIALLY_REJECTED',
+  ERR_SNAPSHOT_READS_REJECTED: 'ERR_SNAPSHOT_READS_REJECTED',
   ERR_SUBMIT_TRANSFORM_OPS_NOT_FOUND: 'ERR_SUBMIT_TRANSFORM_OPS_NOT_FOUND',
   ERR_TYPE_CANNOT_BE_PROJECTED: 'ERR_TYPE_CANNOT_BE_PROJECTED',
   ERR_UNKNOWN_ERROR: 'ERR_UNKNOWN_ERROR'

--- a/lib/read-snapshots-request.js
+++ b/lib/read-snapshots-request.js
@@ -32,10 +32,12 @@ function ReadSnapshotsRequest(collection, snapshots, snapshotType) {
  *
  * If the error has a `code` property of `"ERR_SNAPSHOT_READ_SILENT_REJECTION"`, then the Share
  * client will not pass the error to user code, but will still do things like cancel subscriptions.
+ * The `#rejectSnapshotReadSilent(snapshot, errorMessage)` method can also be used for convenience.
  *
  * @param {Snapshot} snapshot
  * @param {string | Error} error
  *
+ * @see #rejectSnapshotReadSilent
  * @see ShareDBError.CODES.ERR_SNAPSHOT_READ_SILENT_REJECTION
  * @see ShareDBError.CODES.ERR_SNAPSHOT_READS_REJECTED
  */
@@ -44,6 +46,24 @@ ReadSnapshotsRequest.prototype.rejectSnapshotRead = function(snapshot, error) {
     this._idToError = {};
   }
   this._idToError[snapshot.id] = error;
+};
+
+/**
+ * Rejects the read of a specific snapshot. A rejected snapshot read will not have that snapshot's
+ * data sent down to the client.
+ *
+ * This method will set a special error code that causes the Share client to not pass the error to
+ * user code, though it will still do things like cancel subscriptions.
+ *
+ * @param {Snapshot} snapshot
+ * @param {string} errorMessage
+ */
+ReadSnapshotsRequest.prototype.rejectSnapshotReadSilent = function(snapshot, errorMessage) {
+  this.rejectSnapshotRead(snapshot, this.silentRejectionError(errorMessage));
+};
+
+ReadSnapshotsRequest.prototype.silentRejectionError = function(errorMessage) {
+  return new ShareDBError(ShareDBError.CODES.ERR_SNAPSHOT_READ_SILENT_REJECTION, errorMessage);
 };
 
 /**

--- a/lib/read-snapshots-request.js
+++ b/lib/read-snapshots-request.js
@@ -1,3 +1,5 @@
+var ShareDBError = require('./error');
+
 module.exports = ReadSnapshotsRequest;
 
 /**
@@ -18,6 +20,9 @@ function ReadSnapshotsRequest(collection, snapshots, snapshotType) {
   this.agent = null;
   this.backend = null;
 
+  /**
+   * Map of doc id to error: `{[docId: string]: string | Error}`
+   */
   this._idToError = null;
 }
 
@@ -46,4 +51,39 @@ ReadSnapshotsRequest.prototype.rejectSnapshotRead = function(snapshot, error) {
  */
 ReadSnapshotsRequest.prototype.hasSnapshotRejection = function() {
   return this._idToError != null;
+};
+
+/**
+ * Returns an overall error from "readSnapshots" based on the snapshot-specific errors.
+ *
+ * - If there's exactly one snapshot and it has an error, then that error is returned.
+ * - If there's more than one snapshot and at least one has an error, then an overall
+ *   "ERR_SNAPSHOT_READS_REJECTED" is returned, with an `idToError` property.
+ */
+ReadSnapshotsRequest.prototype.getReadSnapshotsError = function() {
+  var snapshots = this.snapshots;
+  var idToError = this._idToError;
+  // If there are 0 snapshots, there can't be any snapshot-specific errors.
+  if (snapshots.length === 0) {
+    return;
+  }
+
+  // Single snapshot with error is treated as a full error.
+  if (snapshots.length === 1) {
+    var snapshotError = idToError[snapshots[0].id];
+    if (snapshotError) {
+      return snapshotError;
+    } else {
+      return;
+    }
+  }
+
+  // Errors in specific snapshots result in an overall ERR_SNAPSHOT_READS_REJECTED.
+  //
+  // fetchBulk and subscribeBulk know how to handle that special error by sending a doc-by-doc
+  // success/failure to the client. Other methods that don't or can't handle partial failures
+  // will treat it as a full rejection.
+  var err = new ShareDBError(ShareDBError.CODES.ERR_SNAPSHOT_READS_REJECTED);
+  err.idToError = idToError;
+  return err;
 };

--- a/lib/readSnapshots-request.js
+++ b/lib/readSnapshots-request.js
@@ -1,0 +1,49 @@
+module.exports = ReadSnapshotsRequest;
+
+/**
+ * Context object passed to "readSnapshots" middleware functions
+ *
+ * @param {string} collection
+ * @param {Snapshot[]} snapshots - snapshots being read
+ * @param {keyof Backend.prototype.SNAPSHOT_TYPES} snapshotType - the type of snapshot read being
+ *   performed
+ */
+function ReadSnapshotsRequest(collection, snapshots, snapshotType) {
+  this.collection = collection;
+  this.snapshots = snapshots;
+  this.snapshotType = snapshotType;
+
+  // Added by Backend#trigger
+  this.action = null;
+  this.agent = null;
+  this.backend = null;
+
+  this._idToError = null;
+}
+
+/**
+ * Rejects the read of a specific snapshot. A rejected snapshot read will not have that snapshot's
+ * data sent down to the client.
+ *
+ * If the error has a `code` property of `"ERR_SNAPSHOT_READ_SILENT_REJECTION"`, then the Share
+ * client will not pass the error to user code, but will still do things like cancel subscriptions.
+ *
+ * @param {Snapshot} snapshot
+ * @param {string | Error} error
+ *
+ * @see ShareDBError.CODES.ERR_SNAPSHOT_READ_SILENT_REJECTION
+ * @see ShareDBError.CODES.ERR_SNAPSHOT_READS_REJECTED
+ */
+ReadSnapshotsRequest.prototype.rejectSnapshotRead = function(snapshot, error) {
+  if (!this._idToError) {
+    this._idToError = {};
+  }
+  this._idToError[snapshot.id] = error;
+};
+
+/**
+ * Returns whether this trigger of "readSnapshots" has had a snapshot read rejected.
+ */
+ReadSnapshotsRequest.prototype.hasSnapshotRejection = function() {
+  return this._idToError != null;
+};

--- a/test/client/query.js
+++ b/test/client/query.js
@@ -140,6 +140,39 @@ module.exports = function(options) {
           });
         });
       });
+
+      it(method + ' on collection with readSnapshots partial failure', function(done) {
+        var backend = this.backend;
+        var connection = backend.connect();
+        var connection2 = backend.connect();
+        var matchAllDbQuery = this.matchAllDbQuery;
+        async.parallel([
+          function(cb) {
+            connection.get('dogs', 'fido').create({age: 3}, cb);
+          },
+          function(cb) {
+            connection.get('dogs', 'spot').create({age: 5}, cb);
+          },
+          function(cb) {
+            connection.get('cats', 'finn').create({age: 2}, cb);
+          }
+        ], function(err) {
+          if (err) return done(err);
+          backend.use('readSnapshots', function(context, cb) {
+            expect(context.snapshots).to.be.an('array').of.length(2);
+            // Signal snapshot-specific error by setting one snapshot's `error` property.
+            context.snapshots[0].error = new Error('Failed to fetch dog');
+            cb();
+          });
+          // Queries have no way of supporting partial readSnapshots rejections, so the entire query
+          // fails if at least one of the snapshots has an error.
+          connection2[method]('dogs', matchAllDbQuery, null, function(err, results) {
+            expect(err).to.be.an('error').with.property('code', 'ERR_SNAPSHOT_READS_PARTIALLY_REJECTED');
+            expect(results).to.equal(undefined);
+            done();
+          });
+        });
+      });
     });
   });
 };

--- a/test/client/subscribe.js
+++ b/test/client/subscribe.js
@@ -158,7 +158,7 @@ module.exports = function() {
       function testSnapshotSpecificError(label, fns) {
         var createReadSnapshotsError = fns.createReadSnapshotsError;
         var verifyClientError = fns.verifyClientError;
-        it(method + ' bulk with readSnapshots snapshot-specific ' + label, function(done) {
+        it(method + ' bulk with readSnapshots rejectSnapshotRead ' + label, function(done) {
           var backend = this.backend;
           var connection = backend.connect();
           var connection2 = backend.connect();
@@ -175,8 +175,7 @@ module.exports = function() {
             backend.use('readSnapshots', function(context, cb) {
               expect(context.snapshots).to.be.an('array').of.length(2);
               expect(context.snapshots[0]).to.have.property('id', 'fido');
-              // Signal snapshot-specific error by setting the snapshot's `error` property.
-              context.snapshots[0].error = createReadSnapshotsError();
+              context.rejectSnapshotRead(context.snapshots[0], createReadSnapshotsError());
               cb();
             });
 
@@ -239,7 +238,7 @@ module.exports = function() {
       testSnapshotSpecificError('special ignorable error', {
         createReadSnapshotsError: function() {
           var err = new Error('Failed to fetch fido');
-          err.code = ERROR_CODES.ERR_SNAPSHOT_READ_IGNORABLE_REJECTION;
+          err.code = ERROR_CODES.ERR_SNAPSHOT_READ_SILENT_REJECTION;
           return err;
         },
         verifyClientError: function(err) {

--- a/test/client/subscribe.js
+++ b/test/client/subscribe.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect;
 var async = require('async');
+var ERROR_CODES = require('../../lib/error').CODES;
 
 module.exports = function() {
   describe('client subscribe', function() {
@@ -154,74 +155,96 @@ module.exports = function() {
         });
       });
 
-      it(method + ' bulk with readSnapshots snapshot-specific error', function(done) {
-        var backend = this.backend;
-        var connection = backend.connect();
-        var connection2 = backend.connect();
-        async.parallel([
-          function(cb) {
-            connection.get('dogs', 'fido').create({age: 3}, cb);
-          },
-          function(cb) {
-            connection.get('dogs', 'spot').create({age: 5}, cb);
-          }
-        ], function(err) {
-          if (err) return done(err);
-
-          backend.use('readSnapshots', function(context, cb) {
-            expect(context.snapshots).to.be.an('array').of.length(2);
-            expect(context.snapshots[0]).to.have.property('id', 'fido');
-            // Signal snapshot-specific error by setting the snapshot's `error` property.
-            context.snapshots[0].error = new Error('Failed to fetch fido');
-            cb();
-          });
-
-          var fido = connection2.get('dogs', 'fido');
-          var spot = connection2.get('dogs', 'spot');
-          connection2.debug = true;
-          connection2.startBulk();
+      function testSnapshotSpecificError(label, fns) {
+        var createReadSnapshotsError = fns.createReadSnapshotsError;
+        var verifyClientError = fns.verifyClientError;
+        it(method + ' bulk with readSnapshots snapshot-specific ' + label, function(done) {
+          var backend = this.backend;
+          var connection = backend.connect();
+          var connection2 = backend.connect();
           async.parallel([
             function(cb) {
-              fido[method](function(err) {
-                expect(err).to.be.an('error').with.property('message', 'Failed to fetch fido');
-                cb();
-              });
+              connection.get('dogs', 'fido').create({age: 3}, cb);
             },
             function(cb) {
-              spot[method](cb);
+              connection.get('dogs', 'spot').create({age: 5}, cb);
             }
           ], function(err) {
             if (err) return done(err);
-            // An error for 'fido' means the data shouldn't get loaded.
-            expect(fido.data).eql(undefined);
-            // Data for 'spot' should still be loaded.
-            expect(spot.data).eql({age: 5});
 
-            // For subscribe, also test that further remote ops will only get sent for the doc
-            // without the error.
-            if (method !== 'subscribe') {
-              return done();
-            }
-            // Issue some operations on connection1.
-            connection.get('dogs', 'fido').submitOp([{p: ['age'], na: 1}]);
-            connection.get('dogs', 'spot').submitOp([{p: ['age'], na: 1}]);
-            // Add listeners on connection2 for those operations.
-            fido.on('before op', function(op) {
-              done(new Error('fido on connection2 should not have received any ops, got:' +
-                JSON.stringify(op)));
+            backend.use('readSnapshots', function(context, cb) {
+              expect(context.snapshots).to.be.an('array').of.length(2);
+              expect(context.snapshots[0]).to.have.property('id', 'fido');
+              // Signal snapshot-specific error by setting the snapshot's `error` property.
+              context.snapshots[0].error = createReadSnapshotsError();
+              cb();
             });
-            connection2.once('receive', function() {
-              // 'receive' happens before the client processes the message. Wait an extra tick so we
-              // can check the effects of the message.
-              process.nextTick(function() {
-                expect(fido.data).eql(undefined);
-                expect(spot.data).eql({age: 6});
-                done();
+
+            var fido = connection2.get('dogs', 'fido');
+            var spot = connection2.get('dogs', 'spot');
+            connection2.debug = true;
+            connection2.startBulk();
+            async.parallel([
+              function(cb) {
+                fido[method](function(err) {
+                  verifyClientError(err);
+                  cb();
+                });
+              },
+              function(cb) {
+                spot[method](cb);
+              }
+            ], function(err) {
+              if (err) return done(err);
+              // An error for 'fido' means the data shouldn't get loaded.
+              expect(fido.data).eql(undefined);
+              // Data for 'spot' should still be loaded.
+              expect(spot.data).eql({age: 5});
+
+              // For subscribe, also test that further remote ops will only get sent for the doc
+              // without the error.
+              if (method !== 'subscribe') {
+                return done();
+              }
+              // Issue some operations on connection1.
+              connection.get('dogs', 'fido').submitOp([{p: ['age'], na: 1}]);
+              connection.get('dogs', 'spot').submitOp([{p: ['age'], na: 1}]);
+              // Add listeners on connection2 for those operations.
+              fido.on('before op', function(op) {
+                done(new Error('fido on connection2 should not have received any ops, got:' +
+                  JSON.stringify(op)));
+              });
+              connection2.once('receive', function() {
+                // 'receive' happens before the client processes the message. Wait an extra tick so we
+                // can check the effects of the message.
+                process.nextTick(function() {
+                  expect(fido.data).eql(undefined);
+                  expect(spot.data).eql({age: 6});
+                  done();
+                });
               });
             });
+            connection2.endBulk();
           });
-          connection2.endBulk();
         });
+      }
+      testSnapshotSpecificError('normal error', {
+        createReadSnapshotsError: function() {
+          return new Error('Failed to fetch fido');
+        },
+        verifyClientError: function(err) {
+          expect(err).to.be.an('error').with.property('message', 'Failed to fetch fido');
+        }
+      });
+      testSnapshotSpecificError('special ignorable error', {
+        createReadSnapshotsError: function() {
+          var err = new Error('Failed to fetch fido');
+          err.code = ERROR_CODES.ERR_SNAPSHOT_READ_IGNORABLE_REJECTION;
+          return err;
+        },
+        verifyClientError: function(err) {
+          expect(err).to.equal(undefined);
+        }
       });
 
       it(method + ' bulk on same collection from known version', function(done) {


### PR DESCRIPTION
## Background

The "readSnapshots" middleware can be used to reject snapshot reads, such as for access control. However, it's currently all or nothing. When doing a bulk fetch or subscribe, the middleware receives many snapshots at once, and you currently can't reject reads for specific snapshots while allowing others through.

Bulk fetch/subscribe is automatically used on reconnection, when multiple fetches/subscribes by id are issued while a client is offline. It can also be manually triggered via the currently-undocumented `Connection#startBulk` and `#endBulk` methods.

## Changes

1. Add ability for "readSnapshots" middleware to reject reads of specific snapshots for bulk fetch/subscribe
2. Fix client handling of errors in replies to bulk actions. Such errors were getting silently ignored before.

### Add ability for "readSnapshots" middleware to reject reads of specific snapshots for bulk fetch/subscribe

This is accomplished via calling `context.rejectSnapshotRead(snapshot, error)` or `context.rejectSnapshotReadSilent(snapshot, errorMessage)`.

```js
backend.use('readSnapshots', (context, callback) => {
  if (context.collection === 'dogs') {
    for (const snapshot of context.snapshots) {
      if (snapshot.data.trainerId !== context.agent.custom.userId) {
        context.rejectSnapshotRead(snapshot, new Error('Cannot see dogs for other trainers'));
      }
    }
  }
  callback();
});
```

Setting a snapshot error has different effects depending on the situation:

* For single-doc reads, which is the typical case, a snapshot-specific error is "promoted" to an error on the entire request, as if the middleware had called `callback(error)`. This enables backwards compatibility with older clients, and it's just more useful to have the unwrapped error in a single-doc read case.
* For bulk fetch/subscribe of multiple docs by id, snapshot-specific errors will cause those specific docs' data to _not_ be sent to the client. Instead, the client docs will each receive their specific corresponding error. Other non-error snapshots will be sent to the client as usual.
* For queries, any snapshot-specific error will cause the entire query to receive an error. This is because queries have no clean way of handling an error in a specific doc in the query's results.
* `rejectSnapshotReadSilent` will cause the ShareDB client to treat it as a silent rejection, not passing the error back to user code. ShareDB itself will still cancel fetches/subscribes as usual.

### Fix client handling of errors in replies to bulk actions

In the client, an incoming `message.error` gets extracted and deleted from the message:
https://github.com/share/sharedb/blob/ca35a5c9faf1d11b827302fb328a7b82ed714eb9/lib/client/connection.js#L177-L184

However, `_handleBulkMessage` then tries to use that `message.error`, which is always undefined at that point.
https://github.com/share/sharedb/blob/master/lib/client/connection.js#L272-L283

That means errors in bulk action replies were always getting silently ignored.

This PR fixes that issue, so such errors get properly emitted now.