### PR TITLE
Silence logger in tests

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
 --reporter spec
 --check-leaks
 --recursive
+--file test/setup.js

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,10 @@
+var logger = require('../lib/logger');
+
+if (process.env.LOGGING !== 'true') {
+  // Silence the logger for tests by setting all its methods to no-ops
+  logger.setMethods({
+    info: function() {},
+    warn: function() {},
+    error: function() {}
+  });
+}


### PR DESCRIPTION
At the moment, the logger will log to console during tests, which is
noisy and undesirable.

This change adds a test setup file, which silences the logger by setting
all of its methods to no-ops.

This behaviour can be overridden with the `LOGGING` environment
variable:

```bash
LOGGING=true npm test
```