### PR TITLE
Upgrade to async@2

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -244,7 +244,9 @@ Backend.prototype._sanitizeOp = function(agent, projection, collection, id, op, 
 Backend.prototype._sanitizeOps = function(agent, projection, collection, id, ops, callback) {
   var backend = this;
   async.each(ops, function(op, eachCb) {
-    backend._sanitizeOp(agent, projection, collection, id, op, eachCb);
+    backend._sanitizeOp(agent, projection, collection, id, op, function(err) {
+      process.nextTick(eachCb, err);
+    });
   }, callback);
 };
 Backend.prototype._sanitizeOpsBulk = function(agent, projection, collection, opsMap, callback) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "arraydiff": "^0.1.1",
-    "async": "^1.4.2",
+    "async": "^2.6.3",
     "fast-deep-equal": "^2.0.1",
     "hat": "0.0.3",
     "ot-json0": "^1.0.1"


### PR DESCRIPTION
We can't upgrade to async@3 because it uses ES6 features like arrow functions, and ShareDB currently targets ES5 without needing to transpile. async@2 is still actively receiving patch updates.

In the [async@2 breaking changes list](https://github.com/caolan/async/blob/master/CHANGELOG.md#v200), the only one that would affect Share is that `each`/`parallel`/etc no longer use `setImmediate` internally.

The only place in ShareDB core that uses those with a possibly-synchronous function is `_sanitizeOps`, so I've added a `process.nextTick` in its callback to prevent the call stack from getting too big.

I considered making `Db#_sanitizeOp` or `Db#trigger` (middleware triggering) async. However, it's possible that someone may be depending on multiple middleware functions triggering synchronously, so it's safer to leave that alone for now.

The other places are already invoking async functions inside `async.each`:
* lib/client/presence.js, which calls `.destroy(next)` on each local/remove presence instance, where the various Presence `destroy()` functions are async. https://github.com/share/sharedb/blob/a2c213a6d44ffbf6e5ddaa2030e7c274c0af34c4/lib/client/presence/presence.js#L54-L61
* lib/db/index.js, which calls the async `db.getSnapshot` inside the `each`. https://github.com/share/sharedb/blob/a2c213a6d44ffbf6e5ddaa2030e7c274c0af34c4/lib/db/index.js#L31-L32