### PR TITLE
Fix presence re-subscribe after destroy

### DIFF
--- a/lib/client/connection.js
+++ b/lib/client/connection.js
@@ -57,6 +57,9 @@ function Connection(socket) {
   // A unique message number for the given id
   this.seq = 1;
 
+  // A unique message number for presence
+  this._presenceSeq = 1;
+
   // Equals agent.src on the server
   this.id = null;
 

--- a/lib/client/presence/presence.js
+++ b/lib/client/presence/presence.js
@@ -20,7 +20,6 @@ function Presence(connection, channel) {
   this.subscribed = false;
   this.remotePresences = {};
   this.localPresences = {};
-  this.seq = 1;
 
   this._remotePresenceInstances = {};
   this._subscriptionCallbacksBySeq = {};
@@ -72,7 +71,7 @@ Presence.prototype.destroy = function(callback) {
 Presence.prototype._sendSubscriptionAction = function(wantSubscribe, callback) {
   this.wantSubscribe = !!wantSubscribe;
   var action = this.wantSubscribe ? 'ps' : 'pu';
-  var seq = this.seq++;
+  var seq = this.connection._presenceSeq++;
   this._subscriptionCallbacksBySeq[seq] = callback;
   if (this.connection.canSend) {
     this.connection._sendPresenceAction(action, seq, this);

--- a/test/client/presence/presence.js
+++ b/test/client/presence/presence.js
@@ -76,6 +76,28 @@ describe('Presence', function() {
     ], done);
   });
 
+  it('resubscribes after a destroy', function(done) {
+    var localPresence1 = presence1.create('presence-1');
+    var presence2a;
+
+    async.series([
+      presence2.subscribe.bind(presence2),
+      presence2.destroy.bind(presence2),
+      function(next) {
+        presence2a = connection2.getPresence('test-channel');
+        presence2a.subscribe(function(error) {
+          next(error);
+        });
+      },
+      function(next) {
+        localPresence1.submit({index: 5}, errorHandler(done));
+        presence2a.once('receive', function() {
+          next();
+        });
+      }
+    ], done);
+  });
+
   it('requests existing presence from other subscribed clients when subscribing', function(done) {
     var localPresence1 = presence1.create('presence-1');
     async.series([


### PR DESCRIPTION
This change fixes the following edge case:

  1. Create a `Presence` object
  2. Subscribe the presence
  3. Destroy the presence
  4. Create a new `Presence` object for the same channel on the same
     `Connection` object
  5. Attempt to re-subscribe
  6. `Agent` ignores the re-subscribe request, because the `seq` was
     reset to `1` on the new `Presence` object, but is still `2` on the
     `Agent`

We fix this by using a universal `_presenceSeq` counter on the
`Connection`, which is never reset, meaning that all presence messages
will have a strictly higher number than one another.