### PR TITLE
Only allow a single subscribe/unsubscribe request to be in-flight

### DIFF
--- a/lib/client/connection.js
+++ b/lib/client/connection.js
@@ -224,9 +224,8 @@ Connection.prototype.handleMessage = function(message) {
     case 'bf':
       return this._handleBulkMessage(err, message, '_handleFetch');
     case 'bs':
-      return this._handleBulkMessage(err, message, '_handleSubscribe');
     case 'bu':
-      return this._handleBulkMessage(err, message, '_handleUnsubscribe');
+      return this._handleBulkMessage(err, message, '_handleSubscribe');
 
     case 'nf':
     case 'nt':
@@ -237,12 +236,9 @@ Connection.prototype.handleMessage = function(message) {
       if (doc) doc._handleFetch(err, message.data);
       return;
     case 's':
-      var doc = this.getExisting(message.c, message.d);
-      if (doc) doc._handleSubscribe(err, message.data);
-      return;
     case 'u':
       var doc = this.getExisting(message.c, message.d);
-      if (doc) doc._handleUnsubscribe(err);
+      if (doc) doc._handleSubscribe(err, message.data);
       return;
     case 'op':
       var doc = this.getExisting(message.c, message.d);

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -63,9 +63,9 @@ function Doc(connection, collection, id) {
 
   // Array of callbacks or nulls as placeholders
   this.inflightFetch = [];
-  this.inflightSubscribe = [];
-  this.inflightUnsubscribe = [];
+  this.inflightSubscribe = null;
   this.pendingFetch = [];
+  this.pendingSubscribe = [];
 
   // Whether we think we are subscribed on the server. Synchronously set to
   // false on calls to unsubscribe and disconnect. Should never be true when
@@ -229,9 +229,9 @@ Doc.prototype.hasPending = function() {
     this.inflightOp ||
     this.pendingOps.length ||
     this.inflightFetch.length ||
-    this.inflightSubscribe.length ||
-    this.inflightUnsubscribe.length ||
-    this.pendingFetch.length
+    this.inflightSubscribe ||
+    this.pendingFetch.length ||
+    this.pendingSubscribe.length
   );
 };
 
@@ -266,33 +266,39 @@ Doc.prototype._emitResponseError = function(err, callback) {
   this.emit('error', err);
 };
 
-Doc.prototype._handleFetch = function(err, snapshot) {
+Doc.prototype._handleFetch = function(error, snapshot) {
+  var callbacks = this.pendingFetch;
+  this.pendingFetch = [];
   var callback = this.inflightFetch.shift();
-  if (err) return this._emitResponseError(err, callback);
+  if (callback) callbacks.push(callback);
+  if (callbacks.length) {
+    callback = function(error) {
+      util.callEach(callbacks, error);
+    };
+  }
+  if (error) return this._emitResponseError(error, callback);
   this.ingestSnapshot(snapshot, callback);
   this._emitNothingPending();
 };
 
-Doc.prototype._handleSubscribe = function(err, snapshot) {
-  var callback = this.inflightSubscribe.shift();
-  if (err) return this._emitResponseError(err, callback);
-  // Indicate we are subscribed only if the client still wants to be. In the
-  // time since calling subscribe and receiving a response from the server,
-  // unsubscribe could have been called and we might already be unsubscribed
-  // but not have received the response. Also, because requests from the
-  // client are not serialized and may take different async time to process,
-  // it is possible that we could hear responses back in a different order
-  // from the order originally sent
-  if (this.wantSubscribe) this.subscribed = true;
-  this.ingestSnapshot(snapshot, callback);
+Doc.prototype._handleSubscribe = function(error, snapshot) {
+  var request = this.inflightSubscribe;
+  this.inflightSubscribe = null;
+  var callbacks = this.pendingFetch;
+  this.pendingFetch = [];
+  if (request.callback) callbacks.push(request.callback);
+  var callback;
+  if (callbacks.length) {
+    callback = function(error) {
+      util.callEach(callbacks, error);
+    };
+  }
+  if (error) return this._emitResponseError(error, callback);
+  this.subscribed = request.wantSubscribe;
+  if (this.subscribed) this.ingestSnapshot(snapshot, callback);
+  else if (callback) callback();
   this._emitNothingPending();
-};
-
-Doc.prototype._handleUnsubscribe = function(err) {
-  var callback = this.inflightUnsubscribe.shift();
-  if (err) return this._emitResponseError(err, callback);
-  if (callback) callback();
-  this._emitNothingPending();
+  this._flushSubscribe();
 };
 
 Doc.prototype._handleOp = function(err, message) {
@@ -366,39 +372,30 @@ Doc.prototype._onConnectionStateChanged = function() {
       this.inflightOp = null;
     }
     this.subscribed = false;
-    if (this.inflightFetch.length || this.inflightSubscribe.length) {
-      this.pendingFetch = this.pendingFetch.concat(this.inflightFetch, this.inflightSubscribe);
-      this.inflightFetch.length = 0;
-      this.inflightSubscribe.length = 0;
+    if (this.inflightSubscribe) {
+      if (this.inflightSubscribe.wantSubscribe) {
+        this.pendingSubscribe.unshift(this.inflightSubscribe);
+        this.inflightSubscribe = null;
+      } else {
+        this._handleSubscribe();
+      }
     }
-    if (this.inflightUnsubscribe.length) {
-      var callbacks = this.inflightUnsubscribe;
-      this.inflightUnsubscribe = [];
-      util.callEach(callbacks);
+    if (this.inflightFetch.length) {
+      this.pendingFetch = this.pendingFetch.concat(this.inflightFetch);
+      this.inflightFetch.length = 0;
     }
   }
 };
 
 Doc.prototype._resubscribe = function() {
-  var callbacks = this.pendingFetch;
-  this.pendingFetch = [];
-
-  if (this.wantSubscribe) {
-    if (callbacks.length) {
-      this.subscribe(function(err) {
-        util.callEach(callbacks, err);
-      });
-      return;
-    }
-    this.subscribe();
-    return;
+  if (!this.pendingSubscribe.length && this.wantSubscribe) {
+    return this.subscribe();
   }
-
-  if (callbacks.length) {
-    this.fetch(function(err) {
-      util.callEach(callbacks, err);
-    });
-  }
+  var willFetch = this.pendingSubscribe.some(function(request) {
+    return request.wantSubscribe;
+  });
+  if (!willFetch && this.pendingFetch.length) this.fetch();
+  this._flushSubscribe();
 };
 
 // Request the current document snapshot or ops that bring us up to date
@@ -413,30 +410,66 @@ Doc.prototype.fetch = function(callback) {
 
 // Fetch the initial document and keep receiving updates
 Doc.prototype.subscribe = function(callback) {
-  this.wantSubscribe = true;
-  if (this.connection.canSend) {
-    var isDuplicate = this.connection.sendSubscribe(this);
-    pushActionCallback(this.inflightSubscribe, isDuplicate, callback);
-    return;
-  }
-  this.pendingFetch.push(callback);
+  var wantSubscribe = true;
+  this._queueSubscribe(wantSubscribe, callback);
 };
 
 // Unsubscribe. The data will stay around in local memory, but we'll stop
 // receiving updates
 Doc.prototype.unsubscribe = function(callback) {
-  this.wantSubscribe = false;
-  // The subscribed state should be conservative in indicating when we are
-  // subscribed on the server. We'll actually be unsubscribed some time
-  // between sending the message and hearing back, but we cannot know exactly
-  // when. Thus, immediately mark us as not subscribed
-  this.subscribed = false;
-  if (this.connection.canSend) {
-    var isDuplicate = this.connection.sendUnsubscribe(this);
-    pushActionCallback(this.inflightUnsubscribe, isDuplicate, callback);
+  var wantSubscribe = false;
+  this._queueSubscribe(wantSubscribe, callback);
+};
+
+Doc.prototype._queueSubscribe = function(wantSubscribe, callback) {
+  var nextRequest = this.inflightSubscribe || this.pendingSubscribe[0];
+  var hasOtherRequests = this.pendingSubscribe.some(function(request) {
+    return request !== nextRequest;
+  });
+  if (nextRequest && nextRequest.wantSubscribe === wantSubscribe && !hasOtherRequests) {
+    var callbacks = [];
+    if (nextRequest.callback) callbacks.push(nextRequest.callback);
+    if (callback) callbacks.push(callback);
+    if (callbacks.length) {
+      nextRequest.callback = function(error) {
+        util.callEach(callbacks, error);
+      };
+    }
     return;
   }
-  if (callback) process.nextTick(callback);
+  this.pendingSubscribe.push({
+    wantSubscribe: !!wantSubscribe,
+    callback: callback
+  });
+  this._flushSubscribe();
+};
+
+Doc.prototype._flushSubscribe = function() {
+  if (this.inflightSubscribe || !this.pendingSubscribe.length) return;
+
+  if (this.connection.canSend) {
+    this.inflightSubscribe = this.pendingSubscribe.shift();
+    this.wantSubscribe = this.inflightSubscribe.wantSubscribe;
+    if (this.wantSubscribe) {
+      this.connection.sendSubscribe(this);
+    } else {
+      // Be conservative about our subscription state. We'll be unsubscribed
+      // some time between sending this request, and receiving the callback,
+      // so let's just set ourselves to unsubscribed now.
+      this.subscribed = false;
+      this.connection.sendUnsubscribe(this);
+    }
+
+    return;
+  }
+
+  if (!this.pendingSubscribe[0].wantSubscribe) {
+    this.inflightSubscribe = this.pendingSubscribe.shift();
+    var doc = this;
+    process.nextTick(function() {
+      doc._handleSubscribe();
+    });
+  }
 };
 
 function pushActionCallback(inflight, isDuplicate, callback) {

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -478,7 +478,7 @@ function pushActionCallback(inflight, isDuplicate, callback) {
 }
 
 function combineCallbacks(callbacks) {
-  callbacks = callbacks.filter(Boolean);
+  callbacks = callbacks.filter(util.truthy);
   if (!callbacks.length) return null;
   return function(error) {
     util.callEach(callbacks, error);

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -422,19 +422,10 @@ Doc.prototype.unsubscribe = function(callback) {
 };
 
 Doc.prototype._queueSubscribe = function(wantSubscribe, callback) {
-  var nextRequest = this.inflightSubscribe || this.pendingSubscribe[0];
-  var hasOtherRequests = this.pendingSubscribe.some(function(request) {
-    return request !== nextRequest;
-  });
-  if (nextRequest && nextRequest.wantSubscribe === wantSubscribe && !hasOtherRequests) {
-    var callbacks = [];
-    if (nextRequest.callback) callbacks.push(nextRequest.callback);
-    if (callback) callbacks.push(callback);
-    if (callbacks.length) {
-      nextRequest.callback = function(error) {
-        util.callEach(callbacks, error);
-      };
-    }
+  var lastRequest = this.pendingSubscribe[this.pendingSubscribe.length - 1] || this.inflightSubscribe;
+  var isDuplicateRequest = lastRequest && lastRequest.wantSubscribe === wantSubscribe;
+  if (isDuplicateRequest) {
+    lastRequest.callback = combineCallbacks([lastRequest.callback, callback]);
     return;
   }
   this.pendingSubscribe.push({
@@ -463,6 +454,8 @@ Doc.prototype._flushSubscribe = function() {
     return;
   }
 
+  // If we're offline, then we're already unsubscribed. Therefore, call back
+  // the next request immediately if it's an unsubscribe request.
   if (!this.pendingSubscribe[0].wantSubscribe) {
     this.inflightSubscribe = this.pendingSubscribe.shift();
     var doc = this;
@@ -482,6 +475,14 @@ function pushActionCallback(inflight, isDuplicate, callback) {
   } else {
     inflight.push(callback);
   }
+}
+
+function combineCallbacks(callbacks) {
+  callbacks = callbacks.filter(Boolean);
+  if (!callbacks.length) return null;
+  return function(error) {
+    util.callEach(callbacks, error);
+  };
 }
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -77,3 +77,7 @@ exports.callEach = function(callbacks, error) {
   });
   return called;
 };
+
+exports.truthy = function(arg) {
+  return !!arg;
+};


### PR DESCRIPTION
Fixes https://github.com/share/sharedb/issues/357

This change is a rework of our subscribe/unsubscribe logic. At the
moment, subscribe and unsubscribe messages are handled completely
separately, which means that we can hit race conditions when
simultaneous subscribe and unsubscribe requests are submitted.

This currently manifests itself in this bug:

  1. `subscribe()`
  2. `unsubscribe()` synchronously (ie before receiving the `subscribe`
     response
  3. Expect to finish unsubscribed. Indeed, `Doc` claims that I'm
     unsubscribed, but actually - because subscribe happens to take a
     bit longer on the server - I'm really still subscribed

This change reworks subscribe and unsubscribe requests into a queue:

  - there may only ever be a single in-flight subscribe or unsubscribe
    request
  - other requests are queued and only submitted once we complete the
    in-flight request

# Special cases

In order to maintain existing behaviour, we also handle a couple of
special cases:

  - if there is _only_ a single subscription request (inflight, or
    pending), and a duplicate request is submitted by the client, we
    just roll the callback into the existing request
  - if the next request is an unsubscribe, we will immediately call back
    if disconnected (but we no longer call them if there is a preceding
    subscribe waiting)