### PR TITLE
Fix `Presence._callEachOrEmit`

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -374,7 +374,7 @@ Doc.prototype._onConnectionStateChanged = function() {
     if (this.inflightUnsubscribe.length) {
       var callbacks = this.inflightUnsubscribe;
       this.inflightUnsubscribe = [];
-      callEach(callbacks);
+      util.callEach(callbacks);
     }
   }
 };
@@ -386,7 +386,7 @@ Doc.prototype._resubscribe = function() {
   if (this.wantSubscribe) {
     if (callbacks.length) {
       this.subscribe(function(err) {
-        callEach(callbacks, err);
+        util.callEach(callbacks, err);
       });
       return;
     }
@@ -396,7 +396,7 @@ Doc.prototype._resubscribe = function() {
 
   if (callbacks.length) {
     this.fetch(function(err) {
-      callEach(callbacks, err);
+      util.callEach(callbacks, err);
     });
   }
 };
@@ -945,7 +945,7 @@ Doc.prototype._hardRollback = function(err) {
     // then we emit the error.
     var allOpsHadCallbacks = !!pendingOps.length;
     for (var i = 0; i < pendingOps.length; i++) {
-      allOpsHadCallbacks = callEach(pendingOps[i].callbacks, err) && allOpsHadCallbacks;
+      allOpsHadCallbacks = util.callEach(pendingOps[i].callbacks, err) && allOpsHadCallbacks;
     }
     if (err && !allOpsHadCallbacks) return doc.emit('error', err);
   });
@@ -956,22 +956,10 @@ Doc.prototype._clearInflightOp = function(err) {
 
   this.inflightOp = null;
 
-  var called = callEach(inflightOp.callbacks, err);
+  var called = util.callEach(inflightOp.callbacks, err);
 
   this.flush();
   this._emitNothingPending();
 
   if (err && !called) return this.emit('error', err);
 };
-
-function callEach(callbacks, err) {
-  var called = false;
-  for (var i = 0; i < callbacks.length; i++) {
-    var callback = callbacks[i];
-    if (callback) {
-      callback(err);
-      called = true;
-    }
-  }
-  return called;
-}

--- a/lib/client/presence/presence.js
+++ b/lib/client/presence/presence.js
@@ -138,11 +138,11 @@ Presence.prototype._resubscribe = function() {
     callbacks.push(callback);
   }
 
-  if (!this.wantSubscribe) return this._callEachOrEmit(null, callbacks);
+  if (!this.wantSubscribe) return this._callEachOrEmit(callbacks);
 
   var presence = this;
   this.subscribe(function(error) {
-    presence._callEachOrEmit(error, callbacks);
+    presence._callEachOrEmit(callbacks, error);
   });
 };
 
@@ -165,12 +165,7 @@ Presence.prototype._createRemotePresence = function(id) {
   return new RemotePresence(this, id);
 };
 
-Presence.prototype._callEachOrEmit = function(error, callbacks) {
-  if (callbacks && callbacks.length) {
-    return callbacks.forEach(function(callback) {
-      process.nextTick(callback, error);
-    });
-  }
-
-  if (error) this.emit('error', error);
+Presence.prototype._callEachOrEmit = function(callbacks, error) {
+  var called = util.callEach(callbacks, error);
+  if (!called && error) this.emit('error', error);
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -66,3 +66,14 @@ exports.digAndRemove = function() {
 exports.supportsPresence = function(type) {
   return type && typeof type.transformPresence === 'function';
 };
+
+exports.callEach = function(callbacks, error) {
+  var called = false;
+  callbacks.forEach(function(callback) {
+    if (callback) {
+      callback(error);
+      called = true;
+    }
+  });
+  return called;
+};


### PR DESCRIPTION
At the moment, there's a bug where we:

  1. Start disconnected
  2. Submit a presence subscribe request with **no callback**
  3. Connect
  4. The presence then subscribes and calls each callback, but doesn't
     check whether the callback is truthy, which throws

We could check callbacks when we first assign them to the internal map,
but it's quite nice for debugging to see an `undefined` callback
attached to a `seq`.

Therefore, we should handle callbacks not existing when actually
calling them, which `Doc` already does.

This change moves the `Doc` `callEach` method into `utils`, where we can
also use it in `Presence`.