### PR TITLE
Run `sharedb-mongo` tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
+services:
+  - mongodb
 node_js:
   - "12"
   - "10"
   - "8"
 script: "npm run lint && npm run test-cover"
 # Send coverage data to Coveralls
-after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+after_script: "bash -e after-script.sh || travis_terminate 1"

--- a/after-script.sh
+++ b/after-script.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+
+cd ../
+git clone https://github.com/share/sharedb-mongo.git
+cd sharedb-mongo
+npm install
+npm install ../sharedb
+npm test
+
+exit 0


### PR DESCRIPTION
This change runs the [`sharedb-mongo`][1] test suite as part of the
Travis build, since `sharedb-mongo` pulls some tests directly from this
library.

[1]: https://github.com/share/sharedb-mongo