### PR TITLE
Fix test for sync unsubscribe, to work with real DB (sharedb-mongo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ coverage
 node_modules
 package-lock.json
 jspm_packages
+
+# Don't commit generated JS bundles
+examples/**/static/dist/bundle.js

--- a/test/client/subscribe.js
+++ b/test/client/subscribe.js
@@ -675,11 +675,11 @@ module.exports = function() {
               if (error) return done(error);
               doc2.submitOp({p: ['name'], oi: 'rover'}, function(error) {
                 if (error) return done(error);
+                done();
               });
               doc.on('op', function() {
                 done(new Error('should not have received op'));
               });
-              done();
             });
           }
         };


### PR DESCRIPTION
Background: sharedb's tests get included and run inside of sharedb-mongo as well.

https://github.com/share/sharedb-mongo/pull/88 revealed that the new test case added in https://github.com/share/sharedb/pull/358 for "unsubscribes synchronously" doesn't work in sharedb-mongo's test suite, which has a DB connection per test case and closes that connection after the test. The second client's op submission then results in:
```
Error: Already closed (and Mocha's done() called multiple times)
```

This PR moves the `done()` in the test to after the second client has successfully submitted. If the first client is incorrectly still subscribed and receives the op through a subscription, that will still correctly cause the test case to fail with "Already closed (and Mocha's done() called multiple times)".