### PR TITLE
Allow an op to be falsy

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -257,7 +257,7 @@ Agent.prototype._sendOp = function(collection, id, op) {
     src: op.src,
     seq: op.seq
   };
-  if (op.op) message.op = op.op;
+  if ('op' in op) message.op = op.op;
   if (op.create) message.create = op.create;
   if (op.del) message.del = true;
 
@@ -826,7 +826,7 @@ function createClientOp(request, clientId) {
   // such as a resubmission after a reconnect, but it usually isn't needed
   var src = request.src || clientId;
   // c, d, and m arguments are intentionally undefined. These are set later
-  return (request.op) ? new EditOp(src, request.seq, request.v, request.op) :
+  return ('op' in request) ? new EditOp(src, request.seq, request.v, request.op) :
     (request.create) ? new CreateOp(src, request.seq, request.v, request.create) :
       (request.del) ? new DeleteOp(src, request.seq, request.v, request.del) :
         undefined;

--- a/lib/client/connection.js
+++ b/lib/client/connection.js
@@ -456,7 +456,7 @@ Connection.prototype.sendOp = function(doc, op) {
     src: op.src,
     seq: op.seq
   };
-  if (op.op) message.op = op.op;
+  if ('op' in op) message.op = op.op;
   if (op.create) message.create = op.create;
   if (op.del) message.del = op.del;
   this.send(message);

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -528,7 +528,7 @@ function transformX(client, server) {
   }
 
   // Ignore no-op coming from server
-  if (!server.op) return;
+  if (!('op' in server)) return;
 
   // I believe that this should not occur, but check just in case
   if (client.create) {
@@ -567,7 +567,7 @@ function transformX(client, server) {
  * @private
  */
 Doc.prototype._otApply = function(op, source) {
-  if (op.op) {
+  if ('op' in op) {
     if (!this.type) {
       // Throw here, because all usage of _otApply should be wrapped with a try/catch
       throw new ShareDBError(
@@ -713,7 +713,7 @@ Doc.prototype._submit = function(op, source, callback) {
   if (!source) source = true;
 
   // The op contains either op, create, delete, or none of the above (a no-op).
-  if (op.op) {
+  if ('op' in op) {
     if (!this.type) {
       var err = new ShareDBError(
         ERROR_CODE.ERR_DOC_DOES_NOT_EXIST,
@@ -800,14 +800,14 @@ Doc.prototype._tryCompose = function(op) {
 
   // Compose an op into a create by applying it. This effectively makes the op
   // invisible, as if the document were created including the op originally
-  if (last.create && op.op) {
+  if (last.create && 'op' in op) {
     last.create.data = this.type.apply(last.create.data, op.op);
     return last;
   }
 
   // Compose two ops into a single op if supported by the type. Types that
   // support compose must be able to compose any two ops together
-  if (last.op && op.op && this.type.compose) {
+  if ('op' in last && 'op' in op && this.type.compose) {
     last.op = this.type.compose(last.op, op.op);
     return last;
   }
@@ -925,7 +925,7 @@ Doc.prototype._rollback = function(err) {
   // working state, then call back
   var op = this.inflightOp;
 
-  if (op.op && op.type.invert) {
+  if ('op' in op && op.type.invert) {
     op.op = op.type.invert(op.op);
 
     // Transform the undo operation by any pending ops.

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -504,7 +504,7 @@ Doc.prototype.flush = function() {
 
 // Helper function to set op to contain a no-op.
 function setNoOp(op) {
-  op.op = null;
+  delete op.op;
   delete op.create;
   delete op.del;
 }
@@ -528,7 +528,7 @@ function transformX(client, server) {
   }
 
   // Ignore no-op coming from server
-  if (!server.op) return;
+  if (!('op' in server)) return;
 
   // I believe that this should not occur, but check just in case
   if (client.create) {
@@ -567,7 +567,7 @@ function transformX(client, server) {
  * @private
  */
 Doc.prototype._otApply = function(op, source) {
-  if (op.op === null) {
+  if ('op' in op) {
     if (!this.type) {
       // Throw here, because all usage of _otApply should be wrapped with a try/catch
       throw new ShareDBError(

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -567,7 +567,7 @@ function transformX(client, server) {
  * @private
  */
 Doc.prototype._otApply = function(op, source) {
-  if ('op' in op) {
+  if (op.op === null) {
     if (!this.type) {
       // Throw here, because all usage of _otApply should be wrapped with a try/catch
       throw new ShareDBError(

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -504,7 +504,7 @@ Doc.prototype.flush = function() {
 
 // Helper function to set op to contain a no-op.
 function setNoOp(op) {
-  delete op.op;
+  op.op = null;
   delete op.create;
   delete op.del;
 }
@@ -528,7 +528,7 @@ function transformX(client, server) {
   }
 
   // Ignore no-op coming from server
-  if (!('op' in server)) return;
+  if (!server.op) return;
 
   // I believe that this should not occur, but check just in case
   if (client.create) {

--- a/lib/ot.js
+++ b/lib/ot.js
@@ -29,7 +29,7 @@ exports.checkOp = function(op) {
     }
   } else if (op.del != null) {
     if (op.del !== true) return new ShareDBError(ERROR_CODE.ERR_OT_OP_BADLY_FORMED, 'del value must be true');
-  } else if (op.op == null) {
+  } else if (!('op' in op)) {
     return new ShareDBError(ERROR_CODE.ERR_OT_OP_BADLY_FORMED, 'Missing op, create, or del');
   }
 
@@ -90,7 +90,7 @@ exports.apply = function(snapshot, op) {
     snapshot.v++;
 
   // Edit operation
-  } else if (op.op) {
+  } else if ('op' in op) {
     var err = applyOpEdit(snapshot, op.op);
     if (err) return err;
     snapshot.v++;
@@ -104,7 +104,7 @@ exports.apply = function(snapshot, op) {
 function applyOpEdit(snapshot, edit) {
   if (!snapshot.type) return new ShareDBError(ERROR_CODE.ERR_DOC_DOES_NOT_EXIST, 'Document does not exist');
 
-  if (edit == null) return new ShareDBError(ERROR_CODE.ERR_OT_OP_NOT_PROVIDED, 'Missing op');
+  if (edit === undefined) return new ShareDBError(ERROR_CODE.ERR_OT_OP_NOT_PROVIDED, 'Missing op');
   var type = types[snapshot.type];
   if (!type) return new ShareDBError(ERROR_CODE.ERR_DOC_TYPE_NOT_RECOGNIZED, 'Unknown type');
 
@@ -123,17 +123,17 @@ exports.transform = function(type, op, appliedOp) {
   }
 
   if (appliedOp.del) {
-    if (op.create || op.op) {
+    if (op.create || 'op' in op) {
       return new ShareDBError(ERROR_CODE.ERR_DOC_WAS_DELETED, 'Document was deleted');
     }
   } else if (
-    (appliedOp.create && (op.op || op.create || op.del)) ||
-    (appliedOp.op && op.create)
+    (appliedOp.create && ('op' in op || op.create || op.del)) ||
+    ('op' in appliedOp && op.create)
   ) {
     // If appliedOp.create is not true, appliedOp contains an op - which
     // also means the document exists remotely.
     return new ShareDBError(ERROR_CODE.ERR_DOC_ALREADY_CREATED, 'Document was created remotely');
-  } else if (appliedOp.op && op.op) {
+  } else if ('op' in appliedOp && 'op' in op) {
     // If we reach here, they both have a .op property.
     if (!type) return new ShareDBError(ERROR_CODE.ERR_DOC_DOES_NOT_EXIST, 'Document does not exist');
 

--- a/lib/projections.js
+++ b/lib/projections.js
@@ -30,7 +30,7 @@ function projectOp(fields, op) {
   if (op.create) {
     projectSnapshot(fields, op.create);
   }
-  if (op.op) {
+  if ('op' in op) {
     op.op = projectEdit(fields, op.op);
   }
 }
@@ -69,7 +69,7 @@ function isOpAllowed(knownType, fields, op) {
   if (op.create) {
     return isSnapshotAllowed(fields, op.create);
   }
-  if (op.op) {
+  if ('op' in op) {
     if (knownType && knownType !== json0.uri) return false;
     return isEditAllowed(fields, op.op);
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lolex": "^5.1.1",
     "mocha": "^6.2.2",
     "nyc": "^14.1.1",
+    "ot-json1": "^0.3.0",
     "sharedb-legacy": "npm:sharedb@=1.1.0",
     "sinon": "^7.5.0"
   },

--- a/test/client/submit-json1.js
+++ b/test/client/submit-json1.js
@@ -1,0 +1,36 @@
+var expect = require('chai').expect;
+var types = require('../../lib/types');
+var json1Type = require('ot-json1');
+types.register(json1Type.type);
+
+
+module.exports = function() {
+  describe('client json1 submit', function() {
+    it('ops submitted sync get composed even if the composition returns null', function(done) {
+      var doc = this.backend.connect().get('dogs', 'fido');
+      doc.create({age: 3}, json1Type.type.uri);
+      doc.submitOp(json1Type.insertOp(['color'], 'gold'));
+      doc.submitOp(json1Type.removeOp(['color']), function(err) {
+        if (err) return done(err);
+        expect(doc.data).eql({age: 3});
+        // Version is 1 instead of 3, because the create and ops got composed
+        expect(doc.version).eql(1);
+        doc.submitOp(json1Type.insertOp(['size'], 1));
+        doc.submitOp(json1Type.removeOp(['size']), function(err) {
+          if (err) return done(err);
+          expect(doc.data).eql({age: 3});
+          // Ops get composed
+          expect(doc.version).eql(2);
+          doc.submitOp(json1Type.insertOp(['size'], 1));
+          doc.del(function(err) {
+            if (err) return done(err);
+            expect(doc.data).eql(undefined);
+            // del DOES NOT get composed
+            expect(doc.version).eql(4);
+            done();
+          });
+        });
+      });
+    });
+  });
+};

--- a/test/client/submit-json1.js
+++ b/test/client/submit-json1.js
@@ -14,6 +14,27 @@ module.exports = function() {
       expect(json1Type.type.compose(firstOp, secondOp)).eql(null);
     });
 
+    it('composes server operations', function(done) {
+      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc2 = this.backend.connect().get('dogs', 'fido');
+      doc.create({age: 3}, json1Type.type.uri, function(err) {
+        if (err) return done(err);
+        doc2.fetch(function(err) {
+          if (err) return done(err);
+
+          doc.submitOp(json1Type.removeOp(['age']));
+          doc2.submitOp(json1Type.replaceOp(['age'], 3, 4), function(err) {
+            if (err) return done(err);
+
+            // Ignores replaceOp
+            expect(doc.data).eql({});
+            expect(doc.version).eql(2);
+            done();
+          });
+        });
+      });
+    });
+
     it('create and ops submitted sync get composed even if the composition returns null', function(done) {
       var doc = this.backend.connect().get('dogs', 'fido');
       doc.create({age: 3}, json1Type.type.uri);

--- a/test/client/submit-json1.js
+++ b/test/client/submit-json1.js
@@ -3,32 +3,58 @@ var types = require('../../lib/types');
 var json1Type = require('ot-json1');
 types.register(json1Type.type);
 
-
 module.exports = function() {
-  describe('client json1 submit', function() {
-    it('ops submitted sync get composed even if the composition returns null', function(done) {
+  describe('with json1 and composition returns null', function() {
+    var firstOp = json1Type.insertOp(['color'], 'gold');
+    var secondOp = json1Type.removeOp(['color']);
+
+    it('uses composed ops that returns null', function() {
+      var firstOp = json1Type.insertOp(['color'], 'gold');
+      var secondOp = json1Type.removeOp(['color']);
+      expect(json1Type.type.compose(firstOp, secondOp)).eql(null);
+    });
+
+    it('create and ops submitted sync get composed even if the composition returns null', function(done) {
       var doc = this.backend.connect().get('dogs', 'fido');
       doc.create({age: 3}, json1Type.type.uri);
-      doc.submitOp(json1Type.insertOp(['color'], 'gold'));
-      doc.submitOp(json1Type.removeOp(['color']), function(err) {
+      doc.submitOp(firstOp);
+      doc.submitOp(secondOp, function(err) {
         if (err) return done(err);
         expect(doc.data).eql({age: 3});
         // Version is 1 instead of 3, because the create and ops got composed
         expect(doc.version).eql(1);
-        doc.submitOp(json1Type.insertOp(['size'], 1));
-        doc.submitOp(json1Type.removeOp(['size']), function(err) {
+        done();
+      });
+    });
+
+    it('ops submitted sync get composed even if the composition returns null', function(done) {
+      var doc = this.backend.connect().get('dogs', 'fido');
+      doc.create({age: 3}, json1Type.type.uri, function(err) {
+        if (err) return done(err);
+
+        doc.submitOp(firstOp);
+        doc.submitOp(secondOp, function(err) {
           if (err) return done(err);
           expect(doc.data).eql({age: 3});
           // Ops get composed
           expect(doc.version).eql(2);
-          doc.submitOp(json1Type.insertOp(['size'], 1));
-          doc.del(function(err) {
-            if (err) return done(err);
-            expect(doc.data).eql(undefined);
-            // del DOES NOT get composed
-            expect(doc.version).eql(4);
-            done();
-          });
+          done();
+        });
+      });
+    });
+
+    it('delete ops submitted sync does not get composed', function(done) {
+      var doc = this.backend.connect().get('dogs', 'fido');
+      doc.create({age: 3}, json1Type.type.uri, function(err) {
+        if (err) return done(err);
+
+        doc.submitOp(firstOp);
+        doc.del(function(err) {
+          if (err) return done(err);
+          expect(doc.data).eql(undefined);
+          // del DOES NOT get composed
+          expect(doc.version).eql(3);
+          done();
         });
       });
     });

--- a/test/client/submit.js
+++ b/test/client/submit.js
@@ -1,13 +1,11 @@
 var async = require('async');
 var expect = require('chai').expect;
 var types = require('../../lib/types');
-var json1Type = require('ot-json1');
 var deserializedType = require('./deserialized-type');
 var numberType = require('./number-type');
 types.register(deserializedType.type);
 types.register(deserializedType.type2);
 types.register(numberType.type);
-types.register(json1Type.type);
 
 module.exports = function() {
   describe('client submit', function() {
@@ -1195,35 +1193,6 @@ module.exports = function() {
           expect(doc.data.value).equal(3);
           expect(doc.data.next).equal(null);
           done();
-        });
-      });
-    });
-
-    describe('type.json1', function() {
-      it('ops submitted sync get composed even if the composition returns null', function(done) {
-        var doc = this.backend.connect().get('dogs', 'fido');
-        doc.create({age: 3}, json1Type.type.uri);
-        doc.submitOp(json1Type.insertOp(['color'], 'gold'));
-        doc.submitOp(json1Type.removeOp(['color']), function(err) {
-          if (err) return done(err);
-          expect(doc.data).eql({age: 3});
-          // Version is 1 instead of 3, because the create and ops got composed
-          expect(doc.version).eql(1);
-          doc.submitOp(json1Type.insertOp(['size'], 1));
-          doc.submitOp(json1Type.removeOp(['size']), function(err) {
-            if (err) return done(err);
-            expect(doc.data).eql({age: 3});
-            // Ops get composed
-            expect(doc.version).eql(2);
-            doc.submitOp(json1Type.insertOp(['size'], 1));
-            doc.del(function(err) {
-              if (err) return done(err);
-              expect(doc.data).eql(undefined);
-              // del DOES NOT get composed
-              expect(doc.version).eql(4);
-              done();
-            });
-          });
         });
       });
     });

--- a/test/db.js
+++ b/test/db.js
@@ -40,6 +40,7 @@ module.exports = function(options) {
     require('./client/query-subscribe')({getQuery: getQuery});
     require('./client/query')({getQuery: getQuery});
     require('./client/submit')();
+    require('./client/submit-json1')();
     require('./client/subscribe')();
 
     // Simplified mock of how submit request applies operations. The


### PR DESCRIPTION
Hi!

This is a fix for https://github.com/share/sharedb/issues/373

I chose to use `'op' in op` as the check to know if we are doing an edit.

I've added a simple test to verify that it works (it was actually really useful to find all the places I needed to change).