### PR TITLE
Fix flaky test

### DIFF
--- a/test/client/submit-json1.js
+++ b/test/client/submit-json1.js
@@ -21,15 +21,14 @@ module.exports = function() {
         if (err) return done(err);
         doc2.fetch(function(err) {
           if (err) return done(err);
-
-          doc.submitOp(json1Type.removeOp(['age']));
-          doc2.submitOp(json1Type.replaceOp(['age'], 3, 4), function(err) {
+          doc.submitOp(json1Type.removeOp(['age']), function(err) {
             if (err) return done(err);
-
-            // Ignores replaceOp
-            expect(doc.data).eql({});
-            expect(doc.version).eql(2);
-            done();
+            doc2.submitOp(json1Type.removeOp(['age']), function(err) {
+              if (err) return done(err);
+              expect(doc.data).eql({});
+              expect(doc.version).eql(2);
+              done();
+            });
           });
         });
       });


### PR DESCRIPTION
At the moment, we have a test that has a race condition. We submit ops
synchronously from two different connections, but it's not well defined
which of these will be committed first.

This change waits for the first submission to be acknowledged before
firing the second submit op. We still test the server `transformOp`,
because `doc2` is not subscribed (and hence submits an op at a version
behind the current snapshot version, which will need transforming).

We also fix the fact that the two ops previously did not combine into a
no-op by just firing off a redundant prop removal as the second op.