### PR TITLE
Ignore doc does not exist on presence destroy

### DIFF
--- a/lib/client/presence/local-doc-presence.js
+++ b/lib/client/presence/local-doc-presence.js
@@ -23,6 +23,10 @@ LocalDocPresence.prototype = Object.create(LocalPresence.prototype);
 
 LocalDocPresence.prototype.submit = function(value, callback) {
   if (!this._doc.type) {
+    // If the Doc hasn't been created, we already assume all presence to
+    // be null. Let's early return, instead of error since this is a harmless
+    // no-op
+    if (value === null) return this._callbackOrEmit(null, callback);
     var error = {
       code: ERROR_CODE.ERR_DOC_DOES_NOT_EXIST,
       message: 'Cannot submit presence. Document has not been created'
@@ -40,13 +44,7 @@ LocalDocPresence.prototype.destroy = function(callback) {
   this._doc.removeListener('load', this._loadHandler);
   this._doc.removeListener('destroy', this._destroyHandler);
 
-  var presence = this;
-  LocalPresence.prototype.destroy.call(this, function(error) {
-    // If the doc does not exist, let's just ignore the error. There's no need to
-    // tidy up presence on a deleted doc.
-    if (error && error.code === ERROR_CODE.ERR_DOC_DOES_NOT_EXIST) error = null;
-    presence._callbackOrEmit(error, callback);
-  });
+  LocalPresence.prototype.destroy.call(this, callback);
 };
 
 LocalDocPresence.prototype._sendPending = function() {

--- a/lib/client/presence/local-doc-presence.js
+++ b/lib/client/presence/local-doc-presence.js
@@ -40,7 +40,13 @@ LocalDocPresence.prototype.destroy = function(callback) {
   this._doc.removeListener('load', this._loadHandler);
   this._doc.removeListener('destroy', this._destroyHandler);
 
-  LocalPresence.prototype.destroy.call(this, callback);
+  var presence = this;
+  LocalPresence.prototype.destroy.call(this, function(error) {
+    // If the doc does not exist, let's just ignore the error. There's no need to
+    // tidy up presence on a deleted doc.
+    if (error && error.code === ERROR_CODE.ERR_DOC_DOES_NOT_EXIST) error = null;
+    presence._callbackOrEmit(error, callback);
+  });
 };
 
 LocalDocPresence.prototype._sendPending = function() {

--- a/test/client/presence/doc-presence.js
+++ b/test/client/presence/doc-presence.js
@@ -945,4 +945,13 @@ describe('DocPresence', function() {
       }
     ], done);
   });
+
+  it('does not error when destroying presence for a deleted doc', function(done) {
+    var localPresence1 = presence1.create('presence-1');
+
+    async.series([
+      doc1.del.bind(doc1),
+      localPresence1.destroy.bind(localPresence1)
+    ], done);
+  });
 });

--- a/test/client/presence/doc-presence.js
+++ b/test/client/presence/doc-presence.js
@@ -951,7 +951,11 @@ describe('DocPresence', function() {
 
     async.series([
       doc1.del.bind(doc1),
-      localPresence1.destroy.bind(localPresence1)
+      localPresence1.destroy.bind(localPresence1),
+      function(next) {
+        expect(Object.keys(presence1.localPresences)).to.be.empty;
+        next();
+      }
     ], done);
   });
 });


### PR DESCRIPTION
When we destroy local presence, we attempt to update the presence to
`null` for remote clients as part of the cleanup.

However, if we delete a doc, and then destroy the associated presence,
the presence attempts to send a message on a deleted doc, which returns
an error.

Let's just ignore this error. There's no need to reset presence on a
deleted doc, because remote clients will [already assume it's `null`][1].

[1]: https://github.com/share/sharedb/blob/a81e2c99af77da12885f0fa860e87cc2602a6cc1/lib/client/presence/local-doc-presence.js#L90-L96