### PR TITLE
Held ops

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -88,6 +88,9 @@ function Doc(connection, collection, id) {
   // This is a list of {[create:{...}], [del:true], [op:...], callbacks:[...]}
   this.pendingOps = [];
 
+  this._heldOpId = 1;
+  this._heldOps = {};
+
   // The OT type of this document. An uncreated document has type `null`
   this.type = null;
 
@@ -342,13 +345,15 @@ Doc.prototype._handleOp = function(err, message) {
     return;
   }
 
-  if (this.inflightOp) {
-    var transformErr = transformX(this.inflightOp, message);
-    if (transformErr) return this._hardRollback(transformErr);
+  var opsToTransform = [];
+  if (this.inflightOp) opsToTransform.push(this.inflightOp);
+  opsToTransform = opsToTransform.concat(this.pendingOps);
+  for (var id in this._heldOps) {
+    opsToTransform.push(this._heldOps[id]);
   }
 
-  for (var i = 0; i < this.pendingOps.length; i++) {
-    var transformErr = transformX(this.pendingOps[i], message);
+  for (var i = 0; i < opsToTransform.length; i++) {
+    var transformErr = transformX(opsToTransform[i], message);
     if (transformErr) return this._hardRollback(transformErr);
   }
 
@@ -712,18 +717,9 @@ Doc.prototype._submit = function(op, source, callback) {
   // Locally submitted ops must always have a truthy source
   if (!source) source = true;
 
-  // The op contains either op, create, delete, or none of the above (a no-op).
   if ('op' in op) {
-    if (!this.type) {
-      var err = new ShareDBError(
-        ERROR_CODE.ERR_DOC_DOES_NOT_EXIST,
-        'Cannot submit op. Document has not been created. ' + this.collection + '.' + this.id
-      );
-      if (callback) return callback(err);
-      return this.emit('error', err);
-    }
-    // Try to normalize the op. This removes trailing skip:0's and things like that.
-    if (this.type.normalize) op.op = this.type.normalize(op.op);
+    var error = this._normalizeOp(op);
+    if (error) return this._callbackOrEmit(error, callback);
   }
 
   try {
@@ -739,6 +735,19 @@ Doc.prototype._submit = function(op, source, callback) {
   process.nextTick(function() {
     doc.flush();
   });
+};
+
+// Try to normalize the op. This removes trailing skip:0's and things like that.
+Doc.prototype._normalizeOp = function(op) {
+  if (!this.type) {
+    var err = new ShareDBError(
+      ERROR_CODE.ERR_DOC_DOES_NOT_EXIST,
+      'Cannot submit op. Document has not been created. ' + this.collection + '.' + this.id
+    );
+    return err;
+  }
+
+  if (this.type.normalize) op.op = this.type.normalize(op.op);
 };
 
 Doc.prototype._pushOp = function(op, callback) {
@@ -760,6 +769,12 @@ Doc.prototype._pushOp = function(op, callback) {
   op.type = this.type;
   op.callbacks = [callback];
   this.pendingOps.push(op);
+
+  if (op.del) this._heldOps = {};
+  for (var id in this._heldOps) {
+    var transformErr = transformX(op, this._heldOps[id]);
+    if (transformErr) return this._hardRollback(transformErr);
+  }
 };
 
 Doc.prototype._popApplyStack = function(to) {
@@ -828,7 +843,8 @@ Doc.prototype.submitOp = function(component, options, callback) {
     options = null;
   }
   var op = {op: component};
-  var source = options && options.source;
+  options = this._initOpSubmitOptions(options);
+  var source = options.source;
   this._submit(op, source, callback);
 };
 
@@ -885,6 +901,40 @@ Doc.prototype.del = function(options, callback) {
   this._submit(op, source, callback);
 };
 
+Doc.prototype.submitHeldOp = function(component, options) {
+  var op = {
+    op: component,
+    type: this.type
+  };
+  options = this._initOpSubmitOptions(options);
+  var source = options.source;
+
+  var error = this._normalizeOp(op);
+  if (error) return this._callbackOrEmit(error, callback);
+
+  var heldOpId = this._heldOpId++;
+  this._heldOps[heldOpId] = op;
+
+  try {
+    this._otApply(op, source);
+  } catch (error) {
+    return this._hardRollback(error);
+  }
+
+  var doc = this;
+  return function(callback) {
+    var heldOp = doc._heldOps[heldOpId];
+    if (!heldOp || !heldOp.op) return callback();
+    delete doc._heldOps[heldOpId];
+    doc._pushOp(heldOp, callback);
+
+    // The call to flush is delayed so if multiple submit callbacks are called
+    // synchronously, all the ops are combined before being sent to the server.
+    process.nextTick(function() {
+      doc.flush();
+    });
+  };
+};
 
 // Stops the document from sending any operations to the server.
 Doc.prototype.pause = function() {
@@ -968,6 +1018,7 @@ Doc.prototype._hardRollback = function(err) {
   this.version = null;
   this.inflightOp = null;
   this.pendingOps = [];
+  this._heldOps = {};
 
   // Fetch the latest version from the server to get us back into a working state
   var doc = this;
@@ -996,4 +1047,15 @@ Doc.prototype._clearInflightOp = function(err) {
   this._emitNothingPending();
 
   if (err && !called) return this.emit('error', err);
+};
+
+Doc.prototype._initOpSubmitOptions = function(options) {
+  options = options || {};
+  options.source = options.source || true;
+  return options;
+};
+
+Doc.prototype._callbackOrEmit = function(error, callback) {
+  if (callback) return callback(error);
+  if (error) this.emit(error);
 };


### PR DESCRIPTION
# Introduction

This change adds support for a "held op". Held ops are ops which are:

 - Only applied locally
 - Not necessarily submitted to the server
 - May be submtted to the server at some later time
 - Will be lost at the end of a "session" if not flushed (since they
   haven't been submitted to the server)

# Motivation

Held ops allow for some level of disconnect with the server, whilst
keeping the `Doc` "live". The primary use case this was designed for is
for when a `Doc` is in a "confirming" state: that is, some change has
been made to the `Doc`, but we're waiting for some confirmation that
this change should be comitted to the server (eg user input).

This sort of thing can be achieved with `pause()` and `resume()`, but:

 - Pausing a document will stop all ops from being submitted, even if
   those other ops don't need confirmation
 - Resuming a `Doc` is not fool-proof. It would be a much nicer failure
   mode to only fail to commit the changes that require confirmation,
   rather than all subsequent changes

We could try to address these issues by having a side-channel: a second
`Connection` which we funnel all ops that need confirmation, which we
can safely pause, but this has its own issues:

 - Can't flush individual ops (unless we keep opening more
   side-channels)
 - We now have two clients to handle, which can cause confusion around
   how to merge data, and what constitutes a "local" op (ie everything
   submitted down the pauseable connection, will look remote to the
   mainline channel, even though it came from our own machine)

Held ops attempts to solve this issue by providing a mechanism for
submitting everything through a single client, and holding ops that can
be individually flushed to the server.

Note that one other possible (ab)use for held ops is to simply have
local-only data, which benefits from type transformations, although it
should be possible to achieve something like that with Presence.

# API

We add a new method for submitting a held op:

```js
var flush = doc.submitHeldOp(op, options);
```

Where `op` and `options` are the same as for `submitOp`. We could
potentially add a flag to `options`, like `{held: true}`, and just use
`submitOp`, but `submitHeldOp` returns a value, which `submitOp` does
not.

The returned value `flush` is a function that takes a callback:

```js
flush(function(error) {})
```

This method will flush that particular held op to the server, and then
call the provided callback on acknowledgement, as if we'd used
`submitOp`.