### PR TITLE
Document `pause` and `resume`

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,12 @@ Invokes the given callback function after
 
 Note that `whenNothingPending` does NOT wait for pending `model.query()` calls.
 
+`doc.pause()`
+Prevents own ops being submitted to the server. If subscribed, remote ops will still be received.
+
+`doc.resume()`
+Resume sending own ops to the server if paused. Will flush the queued ops when called.
+
 ### Class: `ShareDB.Query`
 
 `query.ready` _(Boolean)_

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -102,6 +102,11 @@ function Doc(connection, collection, id) {
   // the time of op submit, so it may be toggled on before submitting a
   // specifc op and toggled off afterward
   this.preventCompose = false;
+
+  // Prevent own ops being submitted to the server. If subscribed, remote
+  // ops are still received. Should be toggled through the pause() and
+  // resume() methods to correctly flush on resume.
+  this.paused = false;
 }
 emitter.mixin(Doc);
 


### PR DESCRIPTION
This change:

 - initialises `doc.paused` with a value
 - adds some documentation to the variable
 - adds the `pause()` and `resume()` methods to the `README`