### PR TITLE
fix: replace action name with backend.MIDDLEWARE_ACTIONS

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -338,7 +338,7 @@ Agent.prototype._open = function() {
     }
 
     var request = {data: chunk};
-    agent.backend.trigger('receive', agent, request, function(err) {
+    agent.backend.trigger(agent.backend.MIDDLEWARE_ACTIONS.receive, agent, request, function(err) {
       var callback = function(err, message) {
         agent._reply(request.data, err, message);
       };

--- a/lib/submit-request.js
+++ b/lib/submit-request.js
@@ -131,7 +131,7 @@ SubmitRequest.prototype.apply = function(callback) {
   this.channels = this.backend.getChannels(this.collection, this.id);
 
   var request = this;
-  this.backend.trigger('apply', this.agent, this, function(err) {
+  this.backend.trigger(this.backend.MIDDLEWARE_ACTIONS.apply, this.agent, this, function(err) {
     if (err) return callback(err);
 
     // Apply the submitted op to the snapshot
@@ -145,7 +145,7 @@ SubmitRequest.prototype.apply = function(callback) {
 SubmitRequest.prototype.commit = function(callback) {
   var request = this;
   var backend = this.backend;
-  backend.trigger('commit', this.agent, this, function(err) {
+  backend.trigger(backend.MIDDLEWARE_ACTIONS.commit, this.agent, this, function(err) {
     if (err) return callback(err);
 
     // Try committing the operation and snapshot to the database atomically


### PR DESCRIPTION
Since `backend.MIDDLEWARE_ACTIONS` is defined in `Backend.prototype`, it's better to use it as an action name.