### PR TITLE
Bump mocha

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,0 +1,4 @@
+reporter: spec
+check-leaks: true
+recursive: true
+file: test/setup.js

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "eslint": "^6.5.1",
     "eslint-config-google": "^0.14.0",
     "lolex": "^5.1.1",
-    "mocha": "^6.2.2",
+    "mocha": "^8.2.1",
     "nyc": "^14.1.1",
     "ot-json1": "^0.3.0",
     "sharedb-legacy": "npm:sharedb@=1.1.0",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,0 @@
---reporter spec
---check-leaks
---recursive
---file test/setup.js


### PR DESCRIPTION
This change bumps `mocha` to the latest version. v8 [dropped support][1]
for `mocha.opts`, so we replace it with a `.mocharc.yml` config file
instead.

[1]: https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#boom-breaking-changes