### PR TITLE
Test for calling `db.close()` multiple times

### DIFF
--- a/test/db.js
+++ b/test/db.js
@@ -36,6 +36,16 @@ module.exports = function(options) {
       });
     });
 
+    it('calls db.close() multiple times', function(done) {
+      var db = this.db;
+      db.close(function(error) {
+        if (error) return done(error);
+        db.close(function(error) {
+          done(error);
+        });
+      });
+    });
+
     require('./client/projections')({getQuery: getQuery});
     require('./client/query-subscribe')({getQuery: getQuery});
     require('./client/query')({getQuery: getQuery});


### PR DESCRIPTION
We should be able to call `db.close()` even after the database has
already been closed, and not get an error.

This change adds a test for this case.