### PR TITLE
Add a try catch scenario to proceed with stream writes

### DIFF
--- a/lib/stream-socket.js
+++ b/lib/stream-socket.js
@@ -59,7 +59,7 @@ ServerStream.prototype._write = function(chunk, encoding, callback) {
     if (socket.readyState !== 1) return;
     try {
       socket.onmessage({data: JSON.stringify(chunk)});
-    } catch(e) {
+    } catch (error) {
       socket.onmessage({data: chunk});
     }
     callback();

--- a/lib/stream-socket.js
+++ b/lib/stream-socket.js
@@ -57,7 +57,11 @@ ServerStream.prototype._write = function(chunk, encoding, callback) {
   var socket = this.socket;
   process.nextTick(function() {
     if (socket.readyState !== 1) return;
-    socket.onmessage({data: JSON.stringify(chunk)});
+    try {
+      socket.onmessage({data: JSON.stringify(chunk)});
+    } catch(e) {
+      socket.onmessage({data: chunk});
+    }
     callback();
   });
 };


### PR DESCRIPTION
- when a chunk exceeds the capabilities of `JSON.stringify`, instead of erroring out, pass the raw chunk of data instead.