### PR TITLE
Optionally send `source` to the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Apply operation to document and send it to the server.
 `op` structure depends on the document type. See the
 [operations for the default `'ot-json0'` type](https://github.com/ottypes/json0#summary-of-operations).
 Call this after you've either fetched or subscribed to the document.
-* `options.source` Argument passed to the `'op'` event locally. This is not sent to the server or other clients. Defaults to `true`.
+* `options.source` Argument passed to the `'op'` event locally. This is not sent to other clients. Defaults to `true`. If `doc.submitSource` is `true`, then this will be sent to the server and made available in middleware at `request.extra.source`
 
 `doc.del([options][, function(err) {...}])`
 Delete the document locally and send delete operation to the server.
@@ -411,6 +411,9 @@ Prevents own ops being submitted to the server. If subscribed, remote ops will s
 
 `doc.resume()`
 Resume sending own ops to the server if paused. Will flush the queued ops when called.
+
+`doc.submitSource` (default: `false`)
+If set to `true`, an op's `source` will be submitted to the server, and made available to access in middleware at `request.extra.source`. Note that a necessary side-effect of this is that ops that have different values for `source` will not be composed.
 
 ### Class: `ShareDB.Query`
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -826,9 +826,9 @@ function createClientOp(request, clientId) {
   // such as a resubmission after a reconnect, but it usually isn't needed
   var src = request.src || clientId;
   // c, d, and m arguments are intentionally undefined. These are set later
-  return ('op' in request) ? new EditOp(src, request.seq, request.v, request.op) :
-    (request.create) ? new CreateOp(src, request.seq, request.v, request.create) :
-      (request.del) ? new DeleteOp(src, request.seq, request.v, request.del) :
+  return ('op' in request) ? new EditOp(src, request.seq, request.v, request.op, request.x) :
+    (request.create) ? new CreateOp(src, request.seq, request.v, request.create, request.x) :
+      (request.del) ? new DeleteOp(src, request.seq, request.v, request.del, request.x) :
         undefined;
 }
 
@@ -840,7 +840,7 @@ function shallowCopy(object) {
   return out;
 }
 
-function CreateOp(src, seq, v, create, c, d, m) {
+function CreateOp(src, seq, v, create, x, c, d, m) {
   this.src = src;
   this.seq = seq;
   this.v = v;
@@ -848,8 +848,9 @@ function CreateOp(src, seq, v, create, c, d, m) {
   this.c = c;
   this.d = d;
   this.m = m;
+  this.x = x;
 }
-function EditOp(src, seq, v, op, c, d, m) {
+function EditOp(src, seq, v, op, x, c, d, m) {
   this.src = src;
   this.seq = seq;
   this.v = v;
@@ -857,8 +858,9 @@ function EditOp(src, seq, v, op, c, d, m) {
   this.c = c;
   this.d = d;
   this.m = m;
+  this.x = x;
 }
-function DeleteOp(src, seq, v, del, c, d, m) {
+function DeleteOp(src, seq, v, del, x, c, d, m) {
   this.src = src;
   this.seq = seq;
   this.v = v;
@@ -866,4 +868,5 @@ function DeleteOp(src, seq, v, del, c, d, m) {
   this.c = c;
   this.d = d;
   this.m = m;
+  this.x = x;
 }

--- a/lib/client/connection.js
+++ b/lib/client/connection.js
@@ -454,11 +454,13 @@ Connection.prototype.sendOp = function(doc, op) {
     d: doc.id,
     v: doc.version,
     src: op.src,
-    seq: op.seq
+    seq: op.seq,
+    x: {}
   };
   if ('op' in op) message.op = op.op;
   if (op.create) message.create = op.create;
   if (op.del) message.del = op.del;
+  if (doc.submitSource) message.x.source = op.source;
   this.send(message);
 };
 

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -3,6 +3,7 @@ var logger = require('../logger');
 var ShareDBError = require('../error');
 var types = require('../types');
 var util = require('../util');
+var deepEqual = require('fast-deep-equal');
 
 var ERROR_CODE = ShareDBError.CODES;
 
@@ -102,6 +103,11 @@ function Doc(connection, collection, id) {
   // the time of op submit, so it may be toggled on before submitting a
   // specifc op and toggled off afterward
   this.preventCompose = false;
+
+  // If set to true, the source will be submitted over the connection. This
+  // will also have the side-effect of only composing ops whose sources are
+  // equal
+  this.submitSource = false;
 
   // Prevent own ops being submitted to the server. If subscribed, remote
   // ops are still received. Should be toggled through the pause() and
@@ -738,7 +744,7 @@ Doc.prototype._submit = function(op, source, callback) {
   }
 
   try {
-    this._pushOp(op, callback);
+    this._pushOp(op, source, callback);
     this._otApply(op, source);
   } catch (error) {
     return this._hardRollback(error);
@@ -752,7 +758,8 @@ Doc.prototype._submit = function(op, source, callback) {
   });
 };
 
-Doc.prototype._pushOp = function(op, callback) {
+Doc.prototype._pushOp = function(op, source, callback) {
+  op.source = source;
   if (this.applyStack) {
     // If we are in the process of incrementally applying an operation, don't
     // compose the op and push it onto the applyStack so it can be transformed
@@ -808,6 +815,10 @@ Doc.prototype._tryCompose = function(op) {
   // been sent to the server, so we can't modify them
   var last = this.pendingOps[this.pendingOps.length - 1];
   if (!last || last.sentAt) return;
+
+  // If we're submitting the op source, we can only combine ops that have
+  // a matching source
+  if (this.submitSource && !deepEqual(op.source, last.source)) return;
 
   // Compose an op into a create by applying it. This effectively makes the op
   // invisible, as if the document were created including the op originally

--- a/lib/submit-request.js
+++ b/lib/submit-request.js
@@ -16,6 +16,9 @@ function SubmitRequest(backend, agent, index, id, op, options) {
   this.op = op;
   this.options = options;
 
+  this.extra = op.x;
+  delete op.x;
+
   this.start = Date.now();
   this._addOpMeta();
 


### PR DESCRIPTION
This change adds the capability to send an op's `source` to the server,
for access in middleware.

# Motivation

The use-case that inspired this change was the ability to record some
usage stats based on users' ops. It's possible to record these stats
through separate HTTP calls, but recording stats through ShareDB would:

 - keep stats in sync with committed ops
 - allow servers to dictate stat definitions (enabling immediate
   roll-out; consistency; etc.)
 - leverage existing socket connections, which prevents having to open
   another socket; make lots of HTTP calls; or resort to
   [`sendBeacon`][1]

However, the type of stats we wish to record require more transient
information about the source of the op (eg keyboard; clipboard; mouse;
etc.).

It's clearly impractical to set this at connection time (where we set
other more "permanent" metadata, such as user ID), so we need some way
of signalling transient metadata attached to individual ops.

This can be communicated within the same client using the `source`
argument on `submitOp`, but this information never makes it to the
server.

# Implementation

## Usage

This new feature is opt-in, and is enabled on a per-`Doc` basis by
setting `doc.submitSource = true`.

No further configuration is required, and `source` can be set as it was
before in `submitOp`.

The `source` will be available in middleware at `request.extra.source`.

Of particular note is the fact that this feature supports complex
objects as `source`s, so it's possible to send complex metadata
structures to the server (although please note the side-effect mentioned
below).

## `op.x`

This change adds a new `x` property to the structure of a wrapped `op`.
This `x` represents "extra" information, which will not be committed to
the database, but will be made available in middleware (if consumers
want to commit it themselves, they are free to move data from `x` to `m`
in the middleware).

For now, the only property `x` can have is `source`, which will be
transmitted from the client.

## Side-effect

When using this feature, there is a necessary side-effect: any ops that
don't have a matching `source` will not be composed (since we don't know
how to disentangle these ops in the middleware).

This should be unimportant in the majority of cases (particularly if
`source` has not been actively set).

[1]: https://volument.com/blog/sendbeacon-is-broken