### PR TITLE
Add hook for end of op lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,16 @@ Fetch snapshots that match the provided query. In most cases, querying the backi
 * `options` _Object_: an object that may contain a `db` property, which specifies which database to run the query against. These extra databases can be attached via the `extraDbs` option in the `Backend` constructor
 * `callback` _Function_: a callback with the signature `function (error: Error, snapshots: Snapshot[], extra: Object): void;`, where `snapshots` is an array of the snapshots matching the query, and `extra` is an (optional) object that the database adapter might return with more information about the results (such as counts)
 
+#### `on`
+
+```javascript
+backend.on('submitRequestEnd', callback): void;
+```
+
+A submit request is about to return to the client. This is called whether the request was a success or a failure.
+
+* `callback` _Function_: callback for handling the event: `function (error, request): void;`
+
 ### Class: `ShareDB.Agent`
 
 An `Agent` is the representation of a client's `Connection` state on the server. If the `Connection` was created through `backend.connect` (ie the client is running on the server), then the `Agent` associated with a `Connection` can be accessed through a direct reference: `connection.agent`.

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -204,11 +204,17 @@ Backend.prototype.trigger = function(action, agent, request, callback) {
 // Submit an operation on the named collection/docname. op should contain a
 // {op:}, {create:} or {del:} field. It should probably contain a v: field (if
 // it doesn't, it defaults to the current version).
-Backend.prototype.submit = function(agent, index, id, op, options, callback) {
+Backend.prototype.submit = function(agent, index, id, op, options, originalCallback) {
+  var backend = this;
+  var request = new SubmitRequest(this, agent, index, id, op, options);
+
+  var callback = function(error, ops) {
+    backend.emit('submitRequestEnd', error, request);
+    originalCallback(error, ops);
+  };
+
   var err = ot.checkOp(op);
   if (err) return callback(err);
-  var request = new SubmitRequest(this, agent, index, id, op, options);
-  var backend = this;
   backend.trigger(backend.MIDDLEWARE_ACTIONS.submit, agent, request, function(err) {
     if (err) return callback(err);
     request.submit(function(err) {

--- a/test/backend.js
+++ b/test/backend.js
@@ -100,5 +100,45 @@ describe('Backend', function() {
         });
       });
     });
+
+    describe('submitRequestEnd', function() {
+      it('emits after write', function(done) {
+        var afterWriteCalled = false;
+
+        backend.use(backend.MIDDLEWARE_ACTIONS.afterWrite, function(request, next) {
+          afterWriteCalled = true;
+          next();
+        });
+
+        backend.on('submitRequestEnd', function(error, request) {
+          expect(error).not.to.be.ok;
+          expect(request).to.be.ok;
+          expect(afterWriteCalled).to.be.true;
+          done();
+        });
+
+        var op = {op: {p: ['publicationYear'], oi: 1949}};
+        backend.submit(null, 'books', '1984', op, null, function(error) {
+          if (error) done(error);
+        });
+      });
+
+      it('emits after an error is raised in the middleware', function(done) {
+        backend.use(backend.MIDDLEWARE_ACTIONS.submit, function(request, next) {
+          next(new Error());
+        });
+
+        backend.on('submitRequestEnd', function(error, request) {
+          expect(error).to.be.ok;
+          expect(request).to.be.ok;
+          done();
+        });
+
+        var op = {op: {p: ['publicationYear'], oi: 1949}};
+        backend.submit(null, 'books', '1984', op, null, function() {
+          // Swallow the error
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This change adds a new `after submit` event at the end of an op
submission, *regardless of success*.

At the moment, we have:

 - `submit`: called when an op is submitted
 - `afterWrite`: called after an op is successfully committed to the
   database
 - `reply`: called when the `Agent` is about to send a non-errored
   reply back to the client

However, it's currently impossible to react to ops that error, or to
ensure that you catch an event whenever an op is finally "done"
processing, regardless of success or failure.