### PR TITLE
Ponyfill `nextTick`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,8 @@ const SHAREDB_RULES = {
   'no-unused-vars': ['error', {vars: 'all', args: 'after-used'}],
   // It's more readable to ensure we only have one statement per line
   'max-statements-per-line': ['error', {max: 1}],
+  // ES3 doesn't support spread
+  'prefer-spread': 'off',
   // as-needed quote props are easier to write
   'quote-props': ['error', 'as-needed'],
   'require-jsdoc': 'off',

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -221,7 +221,7 @@ Agent.prototype._onOp = function(collection, id, op) {
   // precaution against op middleware breaking query subscriptions, we delay
   // before calling into projection and middleware code
   var agent = this;
-  process.nextTick(function() {
+  util.nextTick(function() {
     var copy = shallowCopy(op);
     agent.backend.sanitizeOp(agent, collection, id, copy, function(err) {
       if (err) {
@@ -571,7 +571,7 @@ Agent.prototype._queryUnsubscribe = function(queryId, callback) {
     emitter.destroy();
     delete this.subscribedQueries[queryId];
   }
-  process.nextTick(callback);
+  util.nextTick(callback);
 };
 
 Agent.prototype._fetch = function(collection, id, version, callback) {
@@ -679,18 +679,18 @@ Agent.prototype._unsubscribe = function(collection, id, callback) {
   var docs = this.subscribedDocs[collection];
   var stream = docs && docs[id];
   if (stream) stream.destroy();
-  process.nextTick(callback);
+  util.nextTick(callback);
 };
 
 Agent.prototype._unsubscribeBulk = function(collection, ids, callback) {
   var docs = this.subscribedDocs[collection];
-  if (!docs) return process.nextTick(callback);
+  if (!docs) return util.nextTick(callback);
   for (var i = 0; i < ids.length; i++) {
     var id = ids[i];
     var stream = docs[id];
     if (stream) stream.destroy();
   }
-  process.nextTick(callback);
+  util.nextTick(callback);
 };
 
 Agent.prototype._submit = function(collection, id, op, callback) {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -13,6 +13,7 @@ var Snapshot = require('./snapshot');
 var StreamSocket = require('./stream-socket');
 var SubmitRequest = require('./submit-request');
 var ReadSnapshotsRequest = require('./read-snapshots-request');
+var util = require('./util');
 
 var ERROR_CODE = ShareDBError.CODES;
 
@@ -251,7 +252,7 @@ Backend.prototype._sanitizeOps = function(agent, projection, collection, id, ops
   var backend = this;
   async.each(ops, function(op, eachCb) {
     backend._sanitizeOp(agent, projection, collection, id, op, function(err) {
-      process.nextTick(eachCb, err);
+      util.nextTick(eachCb, err);
     });
   }, callback);
 };

--- a/lib/client/connection.js
+++ b/lib/client/connection.js
@@ -141,7 +141,7 @@ Connection.prototype.bindToSocket = function(socket) {
     try {
       connection.handleMessage(request.data);
     } catch (err) {
-      process.nextTick(function() {
+      util.nextTick(function() {
         connection.emit('error', err);
       });
     }
@@ -605,12 +605,12 @@ Connection.prototype.whenNothingPending = function(callback) {
     return;
   }
   // Call back when no pending operations
-  process.nextTick(callback);
+  util.nextTick(callback);
 };
 Connection.prototype._nothingPendingRetry = function(callback) {
   var connection = this;
   return function() {
-    process.nextTick(function() {
+    util.nextTick(function() {
       connection.whenNothingPending(callback);
     });
   };

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -226,7 +226,7 @@ Doc.prototype.ingestSnapshot = function(snapshot, callback) {
 
 Doc.prototype.whenNothingPending = function(callback) {
   var doc = this;
-  process.nextTick(function() {
+  util.nextTick(function() {
     if (doc.hasPending()) {
       doc.once('nothing pending', callback);
       return;
@@ -470,7 +470,7 @@ Doc.prototype._flushSubscribe = function() {
   if (!this.pendingSubscribe[0].wantSubscribe) {
     this.inflightSubscribe = this.pendingSubscribe.shift();
     var doc = this;
-    process.nextTick(function() {
+    util.nextTick(function() {
       doc._handleSubscribe();
     });
   }
@@ -753,7 +753,7 @@ Doc.prototype._submit = function(op, source, callback) {
   // The call to flush is delayed so if submit() is called multiple times
   // synchronously, all the ops are combined before being sent to the server.
   var doc = this;
-  process.nextTick(function() {
+  util.nextTick(function() {
     doc.flush();
   });
 };

--- a/lib/client/presence/local-presence.js
+++ b/lib/client/presence/local-presence.js
@@ -1,4 +1,5 @@
 var emitter = require('../../emitter');
+var util = require('../../util');
 
 module.exports = LocalPresence;
 function LocalPresence(presence, presenceId) {
@@ -73,6 +74,6 @@ LocalPresence.prototype._getCallback = function(presenceVersion) {
 };
 
 LocalPresence.prototype._callbackOrEmit = function(error, callback) {
-  if (callback) return process.nextTick(callback, error);
+  if (callback) return util.nextTick(callback, error);
   if (error) this.emit('error', error);
 };

--- a/lib/client/presence/presence.js
+++ b/lib/client/presence/presence.js
@@ -153,7 +153,7 @@ Presence.prototype._subscriptionCallback = function(seq) {
 };
 
 Presence.prototype._callbackOrEmit = function(error, callback) {
-  if (callback) return process.nextTick(callback, error);
+  if (callback) return util.nextTick(callback, error);
   if (error) this.emit('error', error);
 };
 

--- a/lib/client/presence/remote-presence.js
+++ b/lib/client/presence/remote-presence.js
@@ -1,3 +1,5 @@
+var util = require('../../util');
+
 module.exports = RemotePresence;
 function RemotePresence(presence, presenceId) {
   this.presence = presence;
@@ -18,5 +20,5 @@ RemotePresence.prototype.receiveUpdate = function(message) {
 RemotePresence.prototype.destroy = function(callback) {
   delete this.presence._remotePresenceInstances[this.presenceId];
   delete this.presence.remotePresences[this.presenceId];
-  if (callback) process.nextTick(callback);
+  if (callback) util.nextTick(callback);
 };

--- a/lib/client/query.js
+++ b/lib/client/query.js
@@ -1,4 +1,5 @@
 var emitter = require('../emitter');
+var util = require('../util');
 
 // Queries are live requests to the database for particular sets of fields.
 //
@@ -80,7 +81,7 @@ Query.prototype.destroy = function(callback) {
   this.connection._destroyQuery(this);
   // There is a callback for consistency, but we don't actually wait for the
   // server's unsubscribe message currently
-  if (callback) process.nextTick(callback);
+  if (callback) util.nextTick(callback);
 };
 
 Query.prototype._onConnectionStateChanged = function() {

--- a/lib/db/memory.js
+++ b/lib/db/memory.js
@@ -1,5 +1,6 @@
 var DB = require('./index');
 var Snapshot = require('../snapshot');
+var util = require('../util');
 
 // In-memory ShareDB database
 //
@@ -38,7 +39,7 @@ MemoryDB.prototype.close = function(callback) {
 MemoryDB.prototype.commit = function(collection, id, op, snapshot, options, callback) {
   var db = this;
   if (typeof callback !== 'function') throw new Error('Callback required');
-  process.nextTick(function() {
+  util.nextTick(function() {
     var version = db._getVersionSync(collection, id);
     if (snapshot.v !== version + 1) {
       var succeeded = false;
@@ -61,7 +62,7 @@ MemoryDB.prototype.getSnapshot = function(collection, id, fields, options, callb
   var includeMetadata = (fields && fields.$submit) || (options && options.metadata);
   var db = this;
   if (typeof callback !== 'function') throw new Error('Callback required');
-  process.nextTick(function() {
+  util.nextTick(function() {
     var snapshot = db._getSnapshotSync(collection, id, includeMetadata);
     callback(null, snapshot);
   });
@@ -80,7 +81,7 @@ MemoryDB.prototype.getOps = function(collection, id, from, to, options, callback
   var includeMetadata = options && options.metadata;
   var db = this;
   if (typeof callback !== 'function') throw new Error('Callback required');
-  process.nextTick(function() {
+  util.nextTick(function() {
     var opLog = db._getOpLogSync(collection, id);
     if (to == null) {
       to = opLog.length;
@@ -101,7 +102,7 @@ MemoryDB.prototype.query = function(collection, query, fields, options, callback
   var includeMetadata = options && options.metadata;
   var db = this;
   if (typeof callback !== 'function') throw new Error('Callback required');
-  process.nextTick(function() {
+  util.nextTick(function() {
     var collectionDocs = db.docs[collection];
     var snapshots = [];
     for (var id in collectionDocs || {}) {

--- a/lib/milestone-db/index.js
+++ b/lib/milestone-db/index.js
@@ -14,7 +14,7 @@ function MilestoneDB(options) {
 emitter.mixin(MilestoneDB);
 
 MilestoneDB.prototype.close = function(callback) {
-  if (callback) process.nextTick(callback);
+  if (callback) util.nextTick(callback);
 };
 
 /**
@@ -73,6 +73,6 @@ MilestoneDB.prototype._isValidTimestamp = function(timestamp) {
 };
 
 MilestoneDB.prototype._callBackOrEmitError = function(error, callback) {
-  if (callback) return process.nextTick(callback, error);
+  if (callback) return util.nextTick(callback, error);
   this.emit('error', error);
 };

--- a/lib/milestone-db/memory.js
+++ b/lib/milestone-db/memory.js
@@ -1,5 +1,6 @@
 var MilestoneDB = require('./index');
 var ShareDBError = require('../error');
+var util = require('../util');
 
 var ERROR_CODE = ShareDBError.CODES;
 
@@ -26,7 +27,7 @@ MemoryMilestoneDB.prototype = Object.create(MilestoneDB.prototype);
 
 MemoryMilestoneDB.prototype.getMilestoneSnapshot = function(collection, id, version, callback) {
   if (!this._isValidVersion(version)) {
-    return process.nextTick(callback, new ShareDBError(ERROR_CODE.ERR_MILESTONE_ARGUMENT_INVALID, 'Invalid version'));
+    return util.nextTick(callback, new ShareDBError(ERROR_CODE.ERR_MILESTONE_ARGUMENT_INVALID, 'Invalid version'));
   }
 
   var predicate = versionLessThanOrEqualTo(version);
@@ -48,12 +49,12 @@ MemoryMilestoneDB.prototype.saveMilestoneSnapshot = function(collection, snapsho
     return a.v - b.v;
   });
 
-  process.nextTick(callback, null);
+  util.nextTick(callback, null);
 };
 
 MemoryMilestoneDB.prototype.getMilestoneSnapshotAtOrBeforeTime = function(collection, id, timestamp, callback) {
   if (!this._isValidTimestamp(timestamp)) {
-    return process.nextTick(callback, new ShareDBError(ERROR_CODE.ERR_MILESTONE_ARGUMENT_INVALID, 'Invalid timestamp'));
+    return util.nextTick(callback, new ShareDBError(ERROR_CODE.ERR_MILESTONE_ARGUMENT_INVALID, 'Invalid timestamp'));
   }
 
   var filter = timestampLessThanOrEqualTo(timestamp);
@@ -62,29 +63,29 @@ MemoryMilestoneDB.prototype.getMilestoneSnapshotAtOrBeforeTime = function(collec
 
 MemoryMilestoneDB.prototype.getMilestoneSnapshotAtOrAfterTime = function(collection, id, timestamp, callback) {
   if (!this._isValidTimestamp(timestamp)) {
-    return process.nextTick(callback, new ShareDBError(ERROR_CODE.ERR_MILESTONE_ARGUMENT_INVALID, 'Invalid timestamp'));
+    return util.nextTick(callback, new ShareDBError(ERROR_CODE.ERR_MILESTONE_ARGUMENT_INVALID, 'Invalid timestamp'));
   }
 
   var filter = timestampGreaterThanOrEqualTo(timestamp);
   this._findMilestoneSnapshot(collection, id, filter, function(error, snapshot) {
-    if (error) return process.nextTick(callback, error);
+    if (error) return util.nextTick(callback, error);
 
     var mtime = snapshot && snapshot.m && snapshot.m.mtime;
     if (timestamp !== null && mtime < timestamp) {
       snapshot = undefined;
     }
 
-    process.nextTick(callback, null, snapshot);
+    util.nextTick(callback, null, snapshot);
   });
 };
 
 MemoryMilestoneDB.prototype._findMilestoneSnapshot = function(collection, id, breakCondition, callback) {
   if (!collection) {
-    return process.nextTick(
+    return util.nextTick(
       callback, new ShareDBError(ERROR_CODE.ERR_MILESTONE_ARGUMENT_INVALID, 'Missing collection')
     );
   }
-  if (!id) return process.nextTick(callback, new ShareDBError(ERROR_CODE.ERR_MILESTONE_ARGUMENT_INVALID, 'Missing ID'));
+  if (!id) return util.nextTick(callback, new ShareDBError(ERROR_CODE.ERR_MILESTONE_ARGUMENT_INVALID, 'Missing ID'));
 
   var milestoneSnapshots = this._getMilestoneSnapshotsSync(collection, id);
 
@@ -98,7 +99,7 @@ MemoryMilestoneDB.prototype._findMilestoneSnapshot = function(collection, id, br
     }
   }
 
-  process.nextTick(callback, null, milestoneSnapshot);
+  util.nextTick(callback, null, milestoneSnapshot);
 };
 
 MemoryMilestoneDB.prototype._getMilestoneSnapshotsSync = function(collection, id) {

--- a/lib/milestone-db/no-op.js
+++ b/lib/milestone-db/no-op.js
@@ -1,4 +1,5 @@
 var MilestoneDB = require('./index');
+var util = require('../util');
 
 /**
  * A no-op implementation of the MilestoneDB class.
@@ -15,20 +16,20 @@ NoOpMilestoneDB.prototype = Object.create(MilestoneDB.prototype);
 
 NoOpMilestoneDB.prototype.getMilestoneSnapshot = function(collection, id, version, callback) {
   var snapshot = undefined;
-  process.nextTick(callback, null, snapshot);
+  util.nextTick(callback, null, snapshot);
 };
 
 NoOpMilestoneDB.prototype.saveMilestoneSnapshot = function(collection, snapshot, callback) {
-  if (callback) return process.nextTick(callback, null);
+  if (callback) return util.nextTick(callback, null);
   this.emit('save', collection, snapshot);
 };
 
 NoOpMilestoneDB.prototype.getMilestoneSnapshotAtOrBeforeTime = function(collection, id, timestamp, callback) {
   var snapshot = undefined;
-  process.nextTick(callback, null, snapshot);
+  util.nextTick(callback, null, snapshot);
 };
 
 NoOpMilestoneDB.prototype.getMilestoneSnapshotAtOrAfterTime = function(collection, id, timestamp, callback) {
   var snapshot = undefined;
-  process.nextTick(callback, null, snapshot);
+  util.nextTick(callback, null, snapshot);
 };

--- a/lib/pubsub/index.js
+++ b/lib/pubsub/index.js
@@ -35,11 +35,11 @@ PubSub.prototype.close = function(callback) {
       map[id].destroy();
     }
   }
-  if (callback) process.nextTick(callback);
+  if (callback) util.nextTick(callback);
 };
 
 PubSub.prototype._subscribe = function(channel, callback) {
-  process.nextTick(function() {
+  util.nextTick(function() {
     callback(new ShareDBError(
       ERROR_CODE.ERR_DATABASE_METHOD_NOT_IMPLEMENTED,
       '_subscribe PubSub method unimplemented'
@@ -48,7 +48,7 @@ PubSub.prototype._subscribe = function(channel, callback) {
 };
 
 PubSub.prototype._unsubscribe = function(channel, callback) {
-  process.nextTick(function() {
+  util.nextTick(function() {
     callback(new ShareDBError(
       ERROR_CODE.ERR_DATABASE_METHOD_NOT_IMPLEMENTED,
       '_unsubscribe PubSub method unimplemented'
@@ -57,7 +57,7 @@ PubSub.prototype._unsubscribe = function(channel, callback) {
 };
 
 PubSub.prototype._publish = function(channels, data, callback) {
-  process.nextTick(function() {
+  util.nextTick(function() {
     callback(new ShareDBError(ERROR_CODE.ERR_DATABASE_METHOD_NOT_IMPLEMENTED, '_publish PubSub method unimplemented'));
   });
 };
@@ -70,7 +70,7 @@ PubSub.prototype.subscribe = function(channel, callback) {
 
   var pubsub = this;
   if (this.subscribed[channel]) {
-    process.nextTick(function() {
+    util.nextTick(function() {
       var stream = pubsub._createStream(channel);
       callback(null, stream);
     });

--- a/lib/pubsub/memory.js
+++ b/lib/pubsub/memory.js
@@ -1,4 +1,5 @@
 var PubSub = require('./index');
+var util = require('../util');
 
 // In-memory ShareDB pub/sub
 //
@@ -17,16 +18,16 @@ module.exports = MemoryPubSub;
 MemoryPubSub.prototype = Object.create(PubSub.prototype);
 
 MemoryPubSub.prototype._subscribe = function(channel, callback) {
-  process.nextTick(callback);
+  util.nextTick(callback);
 };
 
 MemoryPubSub.prototype._unsubscribe = function(channel, callback) {
-  process.nextTick(callback);
+  util.nextTick(callback);
 };
 
 MemoryPubSub.prototype._publish = function(channels, data, callback) {
   var pubsub = this;
-  process.nextTick(function() {
+  util.nextTick(function() {
     for (var i = 0; i < channels.length; i++) {
       var channel = channels[i];
       if (pubsub.subscribed[channel]) {

--- a/lib/stream-socket.js
+++ b/lib/stream-socket.js
@@ -55,7 +55,7 @@ ServerStream.prototype._read = util.doNothing;
 
 ServerStream.prototype._write = function(chunk, encoding, callback) {
   var socket = this.socket;
-  process.nextTick(function() {
+  util.nextTick(function() {
     if (socket.readyState !== 1) return;
     socket.onmessage({data: JSON.stringify(chunk)});
     callback();

--- a/lib/util.js
+++ b/lib/util.js
@@ -81,3 +81,18 @@ exports.callEach = function(callbacks, error) {
 exports.truthy = function(arg) {
   return !!arg;
 };
+
+exports.nextTick = function(callback) {
+  if (process && process.nextTick) {
+    return process.nextTick.apply(null, arguments);
+  }
+
+  var args = [];
+  for (var i = 1; i < arguments.length; i++) {
+    args[i - 1] = arguments[i];
+  }
+
+  setTimeout(function() {
+    callback.apply(null, args);
+  });
+};

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -1,0 +1,50 @@
+var util = require('../lib/util');
+var expect = require('chai').expect;
+
+describe('util', function() {
+  describe('nextTick', function() {
+    it('uses process.nextTick if present', function(done) {
+      expect(process.nextTick).to.be.ok;
+
+      util.nextTick(function(arg1, arg2, arg3) {
+        expect(arg1).to.equal('foo');
+        expect(arg2).to.equal(123);
+        expect(arg3).to.be.undefined;
+        done();
+      }, 'foo', 123);
+    });
+
+    describe('without nextTick', function() {
+      var nextTick;
+
+      before(function() {
+        nextTick = process.nextTick;
+        delete process.nextTick;
+      });
+
+      after(function() {
+        process.nextTick = nextTick;
+      });
+
+      it('uses a ponyfill if process.nextTick is not present', function(done) {
+        expect(process.nextTick).to.be.undefined;
+
+        util.nextTick(function(arg1, arg2, arg3) {
+          expect(arg1).to.equal('foo');
+          expect(arg2).to.equal(123);
+          expect(arg3).to.be.undefined;
+          done();
+        }, 'foo', 123);
+      });
+
+      it('calls asynchronously', function(done) {
+        var called = false;
+        util.nextTick(function() {
+          called = true;
+          done();
+        });
+        expect(called).to.be.false;
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/share/sharedb/issues/255 & https://github.com/share/sharedb/issues/427

At the moment, ShareDB uses the Node.js `process.nextTick` everywhere,
including in client-side code.

ShareDB's current advice is to use a modern build-chain tool, such as
Webpack or Browserify to add support for these Node.js functions.
However, Webpack v5 has [removed][1] their Node.js polyfills. Webpack
actively recommends package authors to "provide alternative
implementations/dependencies for the browser."

It's now quite weird that ShareDB forces consumers to polyfill the
entire `process` module, when we really just need `nextTick`. In order
to keep ShareDB usage as simple as possible, this change ponyfills
`process.nextTick`:

 - If `process.nextTick` is already defined, we just use this directly
 - Otherwise use `setTimeout` (which is essentially the underlying
   behaviour in the recommended [`process`][2] module)

[1]: https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed
[2]: https://github.com/defunctzombie/node-process/blob/master/browser.js#L134-L145