### PR TITLE
Remove dependence on `util`

### DIFF
--- a/lib/op-stream.js
+++ b/lib/op-stream.js
@@ -1,4 +1,3 @@
-var inherits = require('util').inherits;
 var Readable = require('stream').Readable;
 var util = require('./util');
 
@@ -10,7 +9,7 @@ function OpStream() {
 }
 module.exports = OpStream;
 
-inherits(OpStream, Readable);
+Object.setPrototypeOf(OpStream.prototype, Readable.prototype);
 
 // This function is for notifying us that the stream is empty and needs data.
 // For now, we'll just ignore the signal and assume the reader reads as fast

--- a/lib/stream-socket.js
+++ b/lib/stream-socket.js
@@ -1,5 +1,4 @@
 var Duplex = require('stream').Duplex;
-var inherits = require('util').inherits;
 var logger = require('./logger');
 var util = require('./util');
 
@@ -47,7 +46,7 @@ function ServerStream(socket) {
     socket.close('stopped');
   });
 }
-inherits(ServerStream, Duplex);
+Object.setPrototypeOf(ServerStream.prototype, Duplex.prototype);
 
 ServerStream.prototype.isServer = true;
 


### PR DESCRIPTION
At the moment, ShareDB uses the Node.js `util` package just to use
`inherits()`.

Although this is only used server-side, it would be nice to keep the
code client-side compatible (eg for running unit tests in Karma, or
similar browser-based test environments).

Webpack v5 recently [removed][1] their Node.js polyfills, and it would
be nice if we didn't rely on Node.js modules where possible.

Since `util.inherits()` is just a [very thin wrapper][2] around
`Object.setPrototypeOf()`, this change simply swaps this usage for the
native method, which has support even back to Internet Explorer 11.

[1]: https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed
[2]: https://github.com/nodejs/node/blob/8353854ed7c658ae3692fb65f12adadf6f38307c/lib/util.js#L163-L181