### PR TITLE
fix for process being undefined in browser environment

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -83,7 +83,7 @@ exports.truthy = function(arg) {
 };
 
 exports.nextTick = function(callback) {
-  if (process && process.nextTick) {
+  if (typeof process !== 'undefined' && process.nextTick) {
     return process.nextTick.apply(null, arguments);
   }
 


### PR DESCRIPTION
Still seeing an issue with Webpack v5 even after #434.

`process` is undefined in a browser environment, so `if (process) ...` will throw a reference error. A check with `typeof` needs to be used instead.

Couldn't come up with a way to unit test this differently.

