### PR TITLE
Skip mtime

### DIFF
--- a/lib/submit-request.js
+++ b/lib/submit-request.js
@@ -232,7 +232,8 @@ SubmitRequest.prototype._addSnapshotMeta = function() {
   } else if (this.op.del) {
     this.op.m.data = this.snapshot.data;
   }
-  meta.mtime = this.start;
+  // meta.mtime = this.start;
+  meta.mtimeSkippedAt = this.start;
 };
 
 SubmitRequest.prototype._shouldSaveMilestoneSnapshot = function(snapshot) {


### PR DESCRIPTION
It would be prohibitive to run a normal migration, since many customers have integrations that still rely on _m.mtime to determine which profiles need to be synced. 

As such, we will need to run a migration that skips writing mtime.