### PR TITLE
📝 Escape pipe

### DIFF
--- a/docs/api/backend.md
+++ b/docs/api/backend.md
@@ -209,7 +209,7 @@ Registers [middleware]({% link middleware/index.md %}).
 backend.use(action, middleware)
 ```
 
-`action` -- string | string[]
+`action` -- string \| string[]
 
 > An action, or array of action names defining when to apply the middleware
 


### PR DESCRIPTION
Markdown renders a pipe as a table divider, which wasn't what was
intended here, so let's escape it.