### PR TITLE
📝 Fix links

### DIFF
--- a/docs/adapters/database.md
+++ b/docs/adapters/database.md
@@ -36,7 +36,7 @@ ShareDB ships with an in-memory, non-persistent database. This is useful for tes
 
 ## Usage
 
-An instance of a database adapter should be provided to the [`Backend()` constructor]({% link api/backend.md %}#backend-constructor)'s `db` option:
+An instance of a database adapter should be provided to the [`Backend()` constructor]({{ site.baseurl }}{% link api/backend.md %}#backend-constructor)'s `db` option:
 
 ```js
 const backend = new Backend({

--- a/docs/adapters/milestone.md
+++ b/docs/adapters/milestone.md
@@ -11,7 +11,7 @@ parent: Adapters
 1. TOC
 {:toc}
 
-The milestone adapter is responsible for storing periodic snapshots of documents, primarily in order to speed up [document history]({% link document-history.md %}).
+The milestone adapter is responsible for storing periodic snapshots of documents, primarily in order to speed up [document history]({{ site.baseurl }}{% link document-history.md %}).
 
 ## Available adapters
 
@@ -21,7 +21,7 @@ The milestone adapter is responsible for storing periodic snapshots of documents
 
 ## Usage
 
-An instance of a milestone adapter should be provided to the [`Backend()` constructor]({% link api/backend.md %}#backend-constructor)'s `milestoneDb` option:
+An instance of a milestone adapter should be provided to the [`Backend()` constructor]({{ site.baseurl }}{% link api/backend.md %}#backend-constructor)'s `milestoneDb` option:
 
 ```js
 const backend = new Backend({
@@ -31,7 +31,7 @@ const backend = new Backend({
 
 ## Requesting snapshots
 
-Adapters will define default snapshot behaviour. However, this logic can be overridden using the `saveMilestoneSnapshot` option in [middleware]({% link middleware/index.md %}).
+Adapters will define default snapshot behaviour. However, this logic can be overridden using the `saveMilestoneSnapshot` option in [middleware]({{ site.baseurl }}{% link middleware/index.md %}).
 
 Setting `context.saveMilestoneSnapshot` to `true` will request a snapshot be saved, and setting it to `false` means a snapshot will not be saved.
 

--- a/docs/adapters/pub-sub.md
+++ b/docs/adapters/pub-sub.md
@@ -20,7 +20,7 @@ The pub/sub adapter is responsible for notifying other ShareDB instances of chan
 ShareDB ships with an in-memory Pub/Sub, which can be used for a single, standalone ShareDB instance.
 
 {: .info }
-Unlike the [database adapter]({% link adapters/database.md %}), the in-memory Pub/Sub adapter **is** suitable for use in a Production environment, where only a single, standalone ShareDB instance is being used.
+Unlike the [database adapter]({{ site.baseurl }}{% link adapters/database.md %}), the in-memory Pub/Sub adapter **is** suitable for use in a Production environment, where only a single, standalone ShareDB instance is being used.
 
 ### ShareDBRedisPubSub
 
@@ -32,7 +32,7 @@ Unlike the [database adapter]({% link adapters/database.md %}), the in-memory Pu
 
 ## Usage
 
-An instance of a pub/sub adapter should be provided to the [`Backend()` constructor]({% link api/backend.md %}#backend-constructor)'s `pubsub` option:
+An instance of a pub/sub adapter should be provided to the [`Backend()` constructor]({{ site.baseurl }}{% link api/backend.md %}#backend-constructor)'s `pubsub` option:
 
 ```js
 const backend = new Backend({

--- a/docs/api/agent.md
+++ b/docs/api/agent.md
@@ -10,12 +10,12 @@ parent: API
 1. TOC
 {:toc}
 
-An `Agent` is the representation of a client's [`Connection`]({% link api/connection.md %}) state on the server.
+An `Agent` is the representation of a client's [`Connection`]({{ site.baseurl }}{% link api/connection.md %}) state on the server.
 
-The `Agent` instance will be made available in all [middleware]({% link middleware/index.md %}) contexts, where [`agent.custom`](#custom--object) can be particularly useful for storing custom context.
+The `Agent` instance will be made available in all [middleware]({{ site.baseurl }}{% link middleware/index.md %}) contexts, where [`agent.custom`](#custom--object) can be particularly useful for storing custom context.
 
 {: .info }
-If the `Connection` was created through [`backend.connect()`]({% link api/backend.md %}#connect()) (i.e. the client is running on the server), then the `Agent` associated with a `Connection` can be accessed through [`connection.agent`]({% link api/connection.md %}#agent--agent).
+If the `Connection` was created through [`backend.connect()`]({{ site.baseurl }}{% link api/backend.md %}#connect()) (i.e. the client is running on the server), then the `Agent` associated with a `Connection` can be accessed through [`connection.agent`]({{ site.baseurl }}{% link api/connection.md %}#agent--agent).
 
 ## Properties
 
@@ -23,6 +23,6 @@ If the `Connection` was created through [`backend.connect()`]({% link api/backen
 
 > An object that consumers can use to pass information around through the middleware.
 
-### `backend` -- [Backend]({% link api/backend.md %})
+### `backend` -- [Backend]({{ site.baseurl }}{% link api/backend.md %})
 
-> The [`Backend`]({% link api/backend.md %}) instance that created this `Agent`
+> The [`Backend`]({{ site.baseurl }}{% link api/backend.md %}) instance that created this `Agent`

--- a/docs/api/backend.md
+++ b/docs/api/backend.md
@@ -10,9 +10,9 @@ parent: API
 1. TOC
 {:toc}
 
-The `Backend` class represents the server-side instance of ShareDB. It is primarily responsible for connecting to clients, and sending requests to the [database adapters]({% link adapters/database.md %}).
+The `Backend` class represents the server-side instance of ShareDB. It is primarily responsible for connecting to clients, and sending requests to the [database adapters]({{ site.baseurl }}{% link adapters/database.md %}).
 
-It is also responsible for some [configuration](#backend-constructor), setting up [middleware]({% link middleware/index.md %}) and defining [projections]({% link projections.md %}).
+It is also responsible for some [configuration](#backend-constructor), setting up [middleware]({{ site.baseurl }}{% link middleware/index.md %}) and defining [projections]({{ site.baseurl }}{% link projections.md %}).
 
 ## Backend() constructor
 
@@ -25,28 +25,28 @@ new Backend([options])
 
 {: .d-inline-block }
 
-`db` -- [DB]({% link adapters/database.md %})
+`db` -- [DB]({{ site.baseurl }}{% link adapters/database.md %})
 
 Optional
 {: .label .label-grey }
 
 > Default: new `MemoryDB` instance
 
-> An instance of a ShareDB [database adapter]({% link adapters/database.md %}) that provides the data store for ShareDB
+> An instance of a ShareDB [database adapter]({{ site.baseurl }}{% link adapters/database.md %}) that provides the data store for ShareDB
 
 {: .warn }
 > The default option -- a new `MemoryDB` instance -- is a **non-persistent**, in-memory adapter and should **not** be used in production environments.
 
 {: .d-inline-block }
 
-`pubsub` -- [PubSub]({% link adapters/pub-sub.md %})
+`pubsub` -- [PubSub]({{ site.baseurl }}{% link adapters/pub-sub.md %})
 
 Optional
 {: .label .label-grey }
 
 > Default: new `MemoryPubSub` instance
 
-> An instance of a ShareDB [Pub/Sub adapter]({% link adapters/pub-sub.md %}) that provides a channel for notifying other ShareDB instances of changes to data.
+> An instance of a ShareDB [Pub/Sub adapter]({{ site.baseurl }}{% link adapters/pub-sub.md %}) that provides a channel for notifying other ShareDB instances of changes to data.
 
 {: .info }
 > The default option -- a new `MemoryPubSub` instance -- is an in-memory adapter.
@@ -55,17 +55,17 @@ Optional
 
 {: .d-inline-block }
 
-`milestoneDb` -- [MilestoneDB]({% link adapters/milestone.md %})
+`milestoneDb` -- [MilestoneDB]({{ site.baseurl }}{% link adapters/milestone.md %})
 
 Optional
 {: .label .label-grey }
 
 > Default: `null`
 
-> An instance of a ShareDB [milestone adapter]({% link adapters/milestone.md %}) that provides the data store for [milestone snapshots]({% link document-history.md %}#milestone-snapshots), which are historical snapshots of documents stored at a specified version interval.
+> An instance of a ShareDB [milestone adapter]({{ site.baseurl }}{% link adapters/milestone.md %}) that provides the data store for [milestone snapshots]({{ site.baseurl }}{% link document-history.md %}#milestone-snapshots), which are historical snapshots of documents stored at a specified version interval.
 
 {: .info }
-> If this option is omitted, milestone snapshots will **not** be enabled, but document history *may* still be accessed with a potential [performance penalty]({% link document-history.md %}#milestone-snapshots).
+> If this option is omitted, milestone snapshots will **not** be enabled, but document history *may* still be accessed with a potential [performance penalty]({{ site.baseurl }}{% link document-history.md %}#milestone-snapshots).
 
 {: .d-inline-block }
 
@@ -76,7 +76,7 @@ Optional
 
 > Default: `{}`
 
-> An object whose values are extra `DB` instances which can be [queried]({% link api/query.md %}). The keys are the names that can be passed into the query options `db` field
+> An object whose values are extra `DB` instances which can be [queried]({{ site.baseurl }}{% link api/query.md %}). The keys are the names that can be passed into the query options `db` field
 
 {: .d-inline-block }
 
@@ -87,7 +87,7 @@ Optional
 
 > Default: `false`
 
-> If set to `true`, any changes committed will *not* be published on [Pub/Sub]({% link pub-sub.md %})
+> If set to `true`, any changes committed will *not* be published on [Pub/Sub]({{ site.baseurl }}{% link pub-sub.md %})
 
 {: .d-inline-block }
 
@@ -109,19 +109,19 @@ Optional
 
 > Default: `false`
 
-> If set to `true`, enables [Presence]({% link presence.md %}) functionality
+> If set to `true`, enables [Presence]({{ site.baseurl }}{% link presence.md %}) functionality
 
 ## Properties
 
 ### `MIDDLEWARE_ACTIONS` -- Object
 
-> Map of available [middleware actions]({% link middleware/index.md %}#actions)
+> Map of available [middleware actions]({{ site.baseurl }}{% link middleware/index.md %}#actions)
 
 ## Methods
 
 ### connect()
 
-Connects to ShareDB and returns an instance of a [`Connection`]({% link api/connection.md %}) client for interacting with ShareDB. This is the server-side equivalent of `new Connection(socket)` in the browser.
+Connects to ShareDB and returns an instance of a [`Connection`]({{ site.baseurl }}{% link api/connection.md %}) client for interacting with ShareDB. This is the server-side equivalent of `new Connection(socket)` in the browser.
 
 ```js
 backend.connect([connection [, request]])
@@ -129,14 +129,14 @@ backend.connect([connection [, request]])
 
 {: .d-inline-block }
 
-`connection` -- [Connection]({% link api/connection.md %})
+`connection` -- [Connection]({{ site.baseurl }}{% link api/connection.md %})
 
 Optional
 {: .label .label-grey }
 
-> Default: a new [`Connection`]({% link api/connection.md %}) instance
+> Default: a new [`Connection`]({{ site.baseurl }}{% link api/connection.md %}) instance
 
-> A [`Connection`]({% link api/connection.md %}) instance to bind to the `Backend`
+> A [`Connection`]({{ site.baseurl }}{% link api/connection.md %}) instance to bind to the `Backend`
 
 {: .d-inline-block }
 
@@ -147,11 +147,11 @@ Optional
 
 > Default: `{}`
 
-> A connection context object that can contain information such as cookies or session data that will be made available in the [middleware]({% link middleware/index.md %}) on [`agent.custom`]({% link api/agent.md %}#custom)
+> A connection context object that can contain information such as cookies or session data that will be made available in the [middleware]({{ site.baseurl }}{% link middleware/index.md %}) on [`agent.custom`]({{ site.baseurl }}{% link api/agent.md %}#custom)
 
 Return value
 
-Returns a [`Connection`]({% link api/connection.md %})
+Returns a [`Connection`]({{ site.baseurl }}{% link api/connection.md %})
 
 ### listen()
 
@@ -163,7 +163,7 @@ backend.listen(stream [, request])
 
 `stream` -- [Stream](https://nodejs.org/api/stream.html)
 
-> A [`Stream`](https://nodejs.org/api/stream.html) (or `Stream`-like object) that will be used to communicate between the new [`Agent`]({% link api/agent.md %}) and the `Backend`
+> A [`Stream`](https://nodejs.org/api/stream.html) (or `Stream`-like object) that will be used to communicate between the new [`Agent`]({{ site.baseurl }}{% link api/agent.md %}) and the `Backend`
 
 {: .d-inline-block }
 
@@ -174,11 +174,11 @@ Optional
 
 > Default: `{}`
 
-> A connection context object that can contain information such as cookies or session data that will be made available in the [middleware]({% link middleware/index.md %}) on [`agent.custom`]({% link api/agent.md %}#custom)
+> A connection context object that can contain information such as cookies or session data that will be made available in the [middleware]({{ site.baseurl }}{% link middleware/index.md %}) on [`agent.custom`]({{ site.baseurl }}{% link api/agent.md %}#custom)
 
 Return value
 
-Returns an [`Agent`]({% link api/agent.md %}), which will also be available in the [middleware]({% link middleware/index.md %})
+Returns an [`Agent`]({{ site.baseurl }}{% link api/agent.md %}), which will also be available in the [middleware]({{ site.baseurl }}{% link middleware/index.md %})
 
 ### close()
 
@@ -203,7 +203,7 @@ Optional
 
 ### use()
 
-Registers [middleware]({% link middleware/index.md %}).
+Registers [middleware]({{ site.baseurl }}{% link middleware/index.md %}).
 
 ```js
 backend.use(action, middleware)
@@ -221,11 +221,11 @@ backend.use(action, middleware)
 > }
 > ```
 
-> A [middleware]({% link middleware/index.md %}) function
+> A [middleware]({{ site.baseurl }}{% link middleware/index.md %}) function
 
 addProjection()
 
-Adds a [projection]({% link projections.md %})
+Adds a [projection]({{ site.baseurl }}{% link projections.md %})
 
 ```js
 backend.addProjection(name, collection, fields)
@@ -248,7 +248,7 @@ backend.addProjection(name, collection, fields)
 
 ### addProjection()
 
-Defines a [projection]({% link projections.md %}).
+Defines a [projection]({{ site.baseurl }}{% link projections.md %}).
 
 ```js
 backend.addProjection(name, collection, fields)
@@ -277,13 +277,13 @@ Submits an operation to the `Backend`
 backend.submit(agent, index, id, op [, options [, callback]])
 ```
 
-`agent` -- [Agent]({% link api/agent.md %})
+`agent` -- [Agent]({{ site.baseurl }}{% link api/agent.md %})
 
-> An [`Agent`]({% link api/agent.md %}) instance to pass to the middleware
+> An [`Agent`]({{ site.baseurl }}{% link api/agent.md %}) instance to pass to the middleware
 
 `index` -- string
 
-> The name of the collection or [projection]({% link projections.md %})
+> The name of the collection or [projection]({{ site.baseurl }}{% link projections.md %})
 
 `id` -- string
 
@@ -302,7 +302,7 @@ Optional
 
 > Default: `{}`
 
-> Options passed through to the [database adapter]({% link adapters/database.md %})'s `commit` method. Any options that are valid there can be used here
+> Options passed through to the [database adapter]({{ site.baseurl }}{% link adapters/database.md %})'s `commit` method. Any options that are valid there can be used here
 
 {: .d-inline-block }
 
@@ -325,13 +325,13 @@ Fetches the ops for a document between the requested version numbers, where the 
 backend.getOps(agent, index, id, from, to [, options [, callback]])
 ```
 
-`agent` -- [Agent]({% link api/agent.md %})
+`agent` -- [Agent]({{ site.baseurl }}{% link api/agent.md %})
 
-> An [`Agent`]({% link api/agent.md %}) instance to pass to the middleware
+> An [`Agent`]({{ site.baseurl }}{% link api/agent.md %}) instance to pass to the middleware
 
 `index` -- string
 
-> The name of the collection or [projection]({% link projections.md %})
+> The name of the collection or [projection]({{ site.baseurl }}{% link projections.md %})
 
 `id` -- string
 
@@ -385,13 +385,13 @@ Fetches the ops for multiple documents in a collection between the requested ver
 backend.getOpsBulk(agent, index, fromMap, toMap [, options [, callback]])
 ```
 
-`agent` -- [Agent]({% link api/agent.md %})
+`agent` -- [Agent]({{ site.baseurl }}{% link api/agent.md %})
 
-> An [`Agent`]({% link api/agent.md %}) instance to pass to the middleware
+> An [`Agent`]({{ site.baseurl }}{% link api/agent.md %}) instance to pass to the middleware
 
 `index` -- string
 
-> The name of the collection or [projection]({% link projections.md %})
+> The name of the collection or [projection]({{ site.baseurl }}{% link projections.md %})
 
 `id` -- string
 
@@ -460,13 +460,13 @@ Fetch the current snapshot of a document
 backend.fetch(agent, index, id, [, options [, callback]])
 ```
 
-`agent` -- [Agent]({% link api/agent.md %})
+`agent` -- [Agent]({{ site.baseurl }}{% link api/agent.md %})
 
-> An [`Agent`]({% link api/agent.md %}) instance to pass to the middleware
+> An [`Agent`]({{ site.baseurl }}{% link api/agent.md %}) instance to pass to the middleware
 
 `index` -- string
 
-> The name of the collection or [projection]({% link projections.md %})
+> The name of the collection or [projection]({{ site.baseurl }}{% link projections.md %})
 
 `id` -- string
 
@@ -511,13 +511,13 @@ Fetch multiple document snapshots from a collection
 backend.fetchBulk(agent, index, ids, [, options [, callback]])
 ```
 
-`agent` -- [Agent]({% link api/agent.md %})
+`agent` -- [Agent]({{ site.baseurl }}{% link api/agent.md %})
 
-> An [`Agent`]({% link api/agent.md %}) instance to pass to the middleware
+> An [`Agent`]({{ site.baseurl }}{% link api/agent.md %}) instance to pass to the middleware
 
 `index` -- string
 
-> The name of the collection or [projection]({% link projections.md %})
+> The name of the collection or [projection]({{ site.baseurl }}{% link projections.md %})
 
 `ids` -- string[]
 
@@ -562,17 +562,17 @@ Fetch snapshots that match the provided query. In most cases, querying the backi
 backend.queryFetch(agent, index, query, [, options [, callback]])
 ```
 
-`agent` -- [Agent]({% link api/agent.md %})
+`agent` -- [Agent]({{ site.baseurl }}{% link api/agent.md %})
 
-> An [`Agent`]({% link api/agent.md %}) instance to pass to the middleware
+> An [`Agent`]({{ site.baseurl }}{% link api/agent.md %}) instance to pass to the middleware
 
 `index` -- string
 
-> The name of the collection or [projection]({% link projections.md %})
+> The name of the collection or [projection]({{ site.baseurl }}{% link projections.md %})
 
 `query` -- Object
 
-> A query object, whose format will depend on the [database adapter]({% link adapters/database.md %}) being used
+> A query object, whose format will depend on the [database adapter]({{ site.baseurl }}{% link adapters/database.md %}) being used
 
 {: .d-inline-block }
 

--- a/docs/api/connection.md
+++ b/docs/api/connection.md
@@ -12,18 +12,18 @@ parent: API
 
 ## Properties
 
-### `agent` -- [`Agent`]({% link api/agent.md %})
+### `agent` -- [`Agent`]({{ site.baseurl }}{% link api/agent.md %})
 
-> The [`Agent`]({% link api/agent.md %}) associated with this `Connection`.
+> The [`Agent`]({{ site.baseurl }}{% link api/agent.md %}) associated with this `Connection`.
 
 {: .warn }
-> This property is **only** populated if the `Connection` is running on the server, and was created through [`backend.connect()`]({% link api/backend.md %}#connect()).
+> This property is **only** populated if the `Connection` is running on the server, and was created through [`backend.connect()`]({{ site.baseurl }}{% link api/backend.md %}#connect()).
 
 ## Methods
 
 ### get()
 
-Get a [`Doc`]({% link api/doc.md %}) instance for the given `collection` and `id`.
+Get a [`Doc`]({{ site.baseurl }}{% link api/doc.md %}) instance for the given `collection` and `id`.
 
 ```js
 collection.get(collection, id)
@@ -42,7 +42,7 @@ Calling `get()` multiple times on the same `Connection` instance will return the
 
 Return value
 
-> A [`Doc`]({% link api/doc.md %}) instance
+> A [`Doc`]({{ site.baseurl }}{% link api/doc.md %}) instance
 
 ### createFetchQuery()
 
@@ -58,7 +58,7 @@ connection.createFetchQuery(collection, query [, options [, callback]])
 
 `query` -- Object
 
-> A query object, whose format will depend on the [database adapter]({% link adapters/database.md %}) being used
+> A query object, whose format will depend on the [database adapter]({{ site.baseurl }}{% link adapters/database.md %}) being used
 
 {: .d-inline-block }
 `options` -- Object
@@ -74,11 +74,11 @@ Optional
 
 > `options.*` -- any
 
-> > All other options are passed through to the [database adapter]({% link adapters/database.md %})
+> > All other options are passed through to the [database adapter]({{ site.baseurl }}{% link adapters/database.md %})
 
 Return value
 
-> A [`Query`]({% link api/query.md %}) instance
+> A [`Query`]({{ site.baseurl }}{% link api/query.md %}) instance
 
 ### createSubscribeQuery()
 
@@ -94,7 +94,7 @@ connection.createSubscribeQuery(collection, query [, options [, callback]])
 
 `query` -- Object
 
-> A query object, whose format will depend on the [database adapter]({% link adapters/database.md %}) being used
+> A query object, whose format will depend on the [database adapter]({{ site.baseurl }}{% link adapters/database.md %}) being used
 
 {: .d-inline-block }
 
@@ -111,11 +111,11 @@ Optional
 
 > `options.*` -- any
 
-> > All other options are passed through to the [database adapter]({% link adapters/database.md %})
+> > All other options are passed through to the [database adapter]({{ site.baseurl }}{% link adapters/database.md %})
 
 Return value
 
-> A [`Query`]({% link api/query.md %}) instance
+> A [`Query`]({{ site.baseurl }}{% link api/query.md %}) instance
 
 ### fetchSnapshot()
 
@@ -150,7 +150,7 @@ Optional
 > function(error, snapshot) { ... }
 > ```
 
-> A callback called with the requested [`Snapshot`]({% link api/snapshot.md %})
+> A callback called with the requested [`Snapshot`]({{ site.baseurl }}{% link api/snapshot.md %})
 
 ### fetchSnapshotByTimestamp()
 
@@ -185,11 +185,11 @@ Optional
 > function(error, snapshot) { ... }
 > ```
 
-> A callback called with the requested [`Snapshot`]({% link api/snapshot.md %})
+> A callback called with the requested [`Snapshot`]({{ site.baseurl }}{% link api/snapshot.md %})
 
 ### getPresence()
 
-Get a [`Presence`]({% link api/presence.md %}) instance that can be used to subscribe to presence information from other clients, and create instances of [`LocalPresence`]({% link api/local-presence.md %}).
+Get a [`Presence`]({{ site.baseurl }}{% link api/presence.md %}) instance that can be used to subscribe to presence information from other clients, and create instances of [`LocalPresence`]({{ site.baseurl }}{% link api/local-presence.md %}).
 
 ```js
 connection.getPresence(channel)
@@ -197,17 +197,17 @@ connection.getPresence(channel)
 
 `channel` -- string
 
-> The channel associated with this presence. All [`Presence`]({% link api/presence.md %}) instances subscribed to the same channel will receive the same notifications
+> The channel associated with this presence. All [`Presence`]({{ site.baseurl }}{% link api/presence.md %}) instances subscribed to the same channel will receive the same notifications
 
 Return value
 
-> A [`Presence`]({% link api/presence.md %}) instance for the given `channel`
+> A [`Presence`]({{ site.baseurl }}{% link api/presence.md %}) instance for the given `channel`
 
 ### getDocPresence()
 
-Get a special [`Presence`]({% link api/presence.md %}) instance tied to a given document.
+Get a special [`Presence`]({{ site.baseurl }}{% link api/presence.md %}) instance tied to a given document.
 
-This can be used to subscribe to presence information from other clients, and create instances of [`LocalPresence`]({% link api/local-presence.md %}).
+This can be used to subscribe to presence information from other clients, and create instances of [`LocalPresence`]({{ site.baseurl }}{% link api/local-presence.md %}).
 
 Presence updates are synchronized with ops to keep presence current, and avoid "flickering" -- where presence updates and ops arrive out-of-order.
 
@@ -216,7 +216,7 @@ connection.getDocPresence(collection, id)
 ```
 
 {: .warn }
-The document **must** be of a [type]({% link types/index.md %}) that supports [presence]({% link presence.md %}).
+The document **must** be of a [type]({{ site.baseurl }}{% link types/index.md %}) that supports [presence]({{ site.baseurl }}{% link presence.md %}).
 
 `collection` -- string
 
@@ -228,4 +228,4 @@ The document **must** be of a [type]({% link types/index.md %}) that supports [p
 
 Return value
 
-> A [`Presence`]({% link api/presence.md %}) instance tied to the given document
+> A [`Presence`]({{ site.baseurl }}{% link api/presence.md %}) instance tied to the given document

--- a/docs/api/doc.md
+++ b/docs/api/doc.md
@@ -16,13 +16,13 @@ copy:
 
 The `Doc` class is the client-side representation of a ShareDB document.
 
-A `Doc` instance can be obtained with [`connection.getDoc()`]({% link api/connection.md %}#getdoc).
+A `Doc` instance can be obtained with [`connection.getDoc()`]({{ site.baseurl }}{% link api/connection.md %}#getdoc).
 
 ## Properties
 
-### `type` -- [Type]({% link types/index.md %})
+### `type` -- [Type]({{ site.baseurl }}{% link types/index.md %})
 
-> The [type]({% link types/index.md %}) of the document
+> The [type]({{ site.baseurl }}{% link types/index.md %}) of the document
 
 {: .info }
 > If a document has been fetched, and its `type` remains unset, then the document has not yet been created.
@@ -134,7 +134,7 @@ Optional
 
 ### ingestSnapshot()
 
-Ingest [snapshot]({% link api/snapshot.md %}) data.
+Ingest [snapshot]({{ site.baseurl }}{% link api/snapshot.md %}) data.
 
 ```js
 doc.ingestSnapshot(snapshot [, callback])
@@ -144,12 +144,12 @@ doc.ingestSnapshot(snapshot [, callback])
 This method is generally called internally as a result of [`fetch()`](#fetch) or [`subscribe()`](#subscribe), and not directly from consumer code. Consumers *may* want to use this method to ingest data that was transferred to the client externally to the client's ShareDB connection.
 
 
-`snapshot` -- [Snapshot]({% link api/snapshot.md %})
+`snapshot` -- [Snapshot]({{ site.baseurl }}{% link api/snapshot.md %})
 
 > The snapshot to ingest
 
 {: .warn }
-> The snapshot **must** include its [`data`]({% link api/snapshot.md %}#data--object), [`v`]({% link api/snapshot.md %}#v--number) and [`type`]({% link api/snapshot.md %}#type--type) properties
+> The snapshot **must** include its [`data`]({{ site.baseurl }}{% link api/snapshot.md %}#data--object), [`v`]({{ site.baseurl }}{% link api/snapshot.md %}#v--number) and [`type`]({{ site.baseurl }}{% link api/snapshot.md %}#type--type) properties
 
 {: .d-inline-block }
 
@@ -166,7 +166,7 @@ Optional
 
 ### destroy()
 
-Unsubscribe and stop firing events. Also removes the document reference from its [`Connection`]({% link api/connection.md %}), allowing the `Doc` to be garbage-collected.
+Unsubscribe and stop firing events. Also removes the document reference from its [`Connection`]({{ site.baseurl }}{% link api/connection.md %}), allowing the `Doc` to be garbage-collected.
 
 ```js
 doc.destroy([callback])
@@ -195,11 +195,11 @@ doc.create(data [, type [, options [, callback]]])
 
 `data` -- Object
 
-> The document contents. The structure will depend on the document's [type]({% link types/index.md %})
+> The document contents. The structure will depend on the document's [type]({{ site.baseurl }}{% link types/index.md %})
 
-`type` -- [Type]({% link types/index.md %})
+`type` -- [Type]({{ site.baseurl }}{% link types/index.md %})
 
-> The document's [type]({% link types/index.md %})
+> The document's [type]({{ site.baseurl }}{% link types/index.md %})
 
 {: .d-inline-block }
 
@@ -239,7 +239,7 @@ doc.submitOp(op [, options [, callback]])
 
 `op` -- Object
 
-> The op to submit. The structure of `op` depends on the document's [type]({% link types/index.md %})
+> The op to submit. The structure of `op` depends on the document's [type]({{ site.baseurl }}{% link types/index.md %})
 
 {: .d-inline-block }
 
@@ -397,7 +397,7 @@ doc.on('op', function(op, source) { ... })
 ```
 
 {: .info }
-The difference between this event and [`'op batch'`](#op-batch) is that for [`json0`]({% link types/json0.md %}), the op will be shattered into its constituent parts.
+The difference between this event and [`'op batch'`](#op-batch) is that for [`json0`]({{ site.baseurl }}{% link types/json0.md %}), the op will be shattered into its constituent parts.
 <br/>
 For example, `[{p: ['list', 0], li: 'a'}, {p: ['list', 1], li: 'b'}]` would be split into two components: `[{p: ['list', 0], li: 'a'}]` and `[{p: ['list', 1], li: 'b'}]`.
 <br/>
@@ -467,6 +467,6 @@ An error occurred. This event will usually be emitted because of an asynchronous
 doc.on('error', function(error) { ... })
 ```
 
-`error` -- [ShareDBError]({% link api/sharedb-error.md %})
+`error` -- [ShareDBError]({{ site.baseurl }}{% link api/sharedb-error.md %})
 
 > The error that occurred

--- a/docs/api/local-presence.md
+++ b/docs/api/local-presence.md
@@ -10,9 +10,9 @@ parent: API
 1. TOC
 {:toc}
 
-`LocalPresence` represents the [presence]({% link presence.md %}) of the local client. For example, this might be the position of a caret in a text document; which field has been highlighted in a complex JSON object; etc.
+`LocalPresence` represents the [presence]({{ site.baseurl }}{% link presence.md %}) of the local client. For example, this might be the position of a caret in a text document; which field has been highlighted in a complex JSON object; etc.
 
-Local presence is created from a parent [`Presence`]({% link api/presence.md %}) instance using [`presence.create()`]({% link api/presence.md %}#create).
+Local presence is created from a parent [`Presence`]({{ site.baseurl }}{% link api/presence.md %}) instance using [`presence.create()`]({{ site.baseurl }}{% link api/presence.md %}#create).
 
 ## Methods
 
@@ -26,7 +26,7 @@ localPresence.submit(presence [, callback])
 
 `presence` -- Object
 
-> The presence object to broadcast. The structure of `presence` will depend on the [type]({% link types/index.md %})
+> The presence object to broadcast. The structure of `presence` will depend on the [type]({{ site.baseurl }}{% link types/index.md %})
 
 {: .info }
 > A value of `null` will be interpreted as the client no longer being present

--- a/docs/api/presence.md
+++ b/docs/api/presence.md
@@ -10,11 +10,11 @@ parent: API
 1. TOC
 {:toc}
 
-Representation of the [presence]({% link presence.md %}) data associated with a given channel.
+Representation of the [presence]({{ site.baseurl }}{% link presence.md %}) data associated with a given channel.
 
-A `Presence` instance can be obtained with [`connection.getPresence()`]({% link api/connection.md %}#getpresence) or [`connection.getDocPresence()`]({% link api/connection.md %}#getdocpresence).
+A `Presence` instance can be obtained with [`connection.getPresence()`]({{ site.baseurl }}{% link api/connection.md %}#getpresence) or [`connection.getDocPresence()`]({{ site.baseurl }}{% link api/connection.md %}#getdocpresence).
 
-If created with [`connection.getDocPresence()`]({% link api/connection.md %}#getdocpresence), this will represent the presence data associated with a given [`Doc`]({% link api/doc.md %}).
+If created with [`connection.getDocPresence()`]({{ site.baseurl }}{% link api/connection.md %}#getdocpresence), this will represent the presence data associated with a given [`Doc`]({{ site.baseurl }}{% link api/doc.md %}).
 
 ## Properties
 
@@ -24,7 +24,7 @@ If created with [`connection.getDocPresence()`]({% link api/connection.md %}#get
 
 ### `localPresences` -- Object
 
-> Map of local presence IDs to their [`LocalPresence`]({% link api/local-presence.md %}) instances
+> Map of local presence IDs to their [`LocalPresence`]({{ site.baseurl }}{% link api/local-presence.md %}) instances
 
 ## Methods
 
@@ -75,7 +75,7 @@ Optional
 
 ### create()
 
-Create an instance of [`LocalPresence`]({% link api/local-presence.md %}), which can be used to represent the client's presence. Many -- or none -- such local presences may exist on a `Presence` instance.
+Create an instance of [`LocalPresence`]({{ site.baseurl }}{% link api/local-presence.md %}), which can be used to represent the client's presence. Many -- or none -- such local presences may exist on a `Presence` instance.
 
 ```javascript
 presence.create([presenceId])
@@ -95,11 +95,11 @@ Optional
 
 Return value
 
-> A new [`LocalPresence`]({% link api/local-presence.md %}) instance
+> A new [`LocalPresence`]({{ site.baseurl }}{% link api/local-presence.md %}) instance
 
 ### destroy()
 
-Clear all [`LocalPresence`]({% link api/local-presence.md %}) instances associated with this `Presence`, setting them all to have a value of `null`, and sending the update to remote subscribers.
+Clear all [`LocalPresence`]({{ site.baseurl }}{% link api/local-presence.md %}) instances associated with this `Presence`, setting them all to have a value of `null`, and sending the update to remote subscribers.
 
 Also deletes this `Presence` instance for garbage-collection.
 
@@ -141,7 +141,7 @@ presence.on('receive', function(id, value) { ... });
 
 `value` -- Object
 
-> The presence value. The structure of this object will depend on the [type]({% link types/index.md %})
+> The presence value. The structure of this object will depend on the [type]({{ site.baseurl }}{% link types/index.md %})
 
 ### `'error'`
 
@@ -151,6 +151,6 @@ An error has occurred.
 presence.on('error', function(error) { ... })
 ```
 
-`error` -- [ShareDBError]({% link api/sharedb-error.md %})
+`error` -- [ShareDBError]({{ site.baseurl }}{% link api/sharedb-error.md %})
 
 > The error that occurred

--- a/docs/api/query.md
+++ b/docs/api/query.md
@@ -10,7 +10,7 @@ parent: API
 1. TOC
 {:toc}
 
-Representation of a query made through [`connection.createFetchQuery()`]({% link api/connection.md %}#createfetchquery) or [`connection.createSubscribeQuery()`]({% link api/connection.md %}#createsubscribequery).
+Representation of a query made through [`connection.createFetchQuery()`]({{ site.baseurl }}{% link api/connection.md %}#createfetchquery) or [`connection.createSubscribeQuery()`]({{ site.baseurl }}{% link api/connection.md %}#createsubscribequery).
 
 ## Properties
 
@@ -20,11 +20,11 @@ Representation of a query made through [`connection.createFetchQuery()`]({% link
 
 ### `results` -- Array
 
-> Query results, as an array of [`Doc`]({% link api/doc.md %}) instances
+> Query results, as an array of [`Doc`]({{ site.baseurl }}{% link api/doc.md %}) instances
 
 ### `extra` -- Object
 
-> Extra query results that are not an array of `Doc`s. Available for certain [database adapters]({% link adapters/database.md %}) and queries
+> Extra query results that are not an array of `Doc`s. Available for certain [database adapters]({{ site.baseurl }}{% link adapters/database.md %}) and queries
 
 ## Methods
 
@@ -55,7 +55,7 @@ Optional
 
 ### `'ready'`
 
-The initial query results were loaded from the server. Triggered on [`connection.createFetchQuery()`]({% link api/connection.md %}#createfetchquery) or [`connection.createSubscribeQuery()`]({% link api/connection.md %}#createsubscribequery).
+The initial query results were loaded from the server. Triggered on [`connection.createFetchQuery()`]({{ site.baseurl }}{% link api/connection.md %}#createfetchquery) or [`connection.createSubscribeQuery()`]({{ site.baseurl }}{% link api/connection.md %}#createsubscribequery).
 
 ```js
 query.on('ready', function() { ... })
@@ -71,7 +71,7 @@ query.on('changed', function(results) { ... })
 
 `results` -- Array
 
-> Query results, as an array of [`Doc`]({% link api/doc.md %}) instances
+> Query results, as an array of [`Doc`]({{ site.baseurl }}{% link api/doc.md %}) instances
 
 ### `'insert'`
 
@@ -83,7 +83,7 @@ query.on('insert', function(docs, index) { ... })
 
 `docs` -- Array
 
-> Array of inserted [`Doc`]({% link api/doc.md %})s
+> Array of inserted [`Doc`]({{ site.baseurl }}{% link api/doc.md %})s
 
 `index` -- number
 
@@ -99,7 +99,7 @@ query.on('move', function(docs, from, to) { ... })
 
 `docs` -- Array
 
-> Array of moved [`Doc`]({% link api/doc.md %})s
+> Array of moved [`Doc`]({{ site.baseurl }}{% link api/doc.md %})s
 
 `from` -- number
 
@@ -119,7 +119,7 @@ query.on('remove', function(docs, index) { ... })
 
 `docs` -- Array
 
-> Array of removed [`Doc`]({% link api/doc.md %})s
+> Array of removed [`Doc`]({{ site.baseurl }}{% link api/doc.md %})s
 
 `index` -- number
 
@@ -145,6 +145,6 @@ There was an error receiving updates to a subscription.
 query.on('error', function(error) { ... })
 ```
 
-`error` -- [ShareDBError]({% link api/sharedb-error.md %})
+`error` -- [ShareDBError]({{ site.baseurl }}{% link api/sharedb-error.md %})
 
 > The error that occurred

--- a/docs/api/sharedb-error.md
+++ b/docs/api/sharedb-error.md
@@ -53,7 +53,7 @@ Representation of an error, with a machine-parsable [code](#error-codes).
 
 ### `ERR_MAX_SUBMIT_RETRIES_EXCEEDED`
 
-> The number of retries defined by the [`maxSubmitRetries`]({% link api/backend.md %}#options) option has been exceeded by a submission.
+> The number of retries defined by the [`maxSubmitRetries`]({{ site.baseurl }}{% link api/backend.md %}#options) option has been exceeded by a submission.
 
 ### `ERR_DOC_ALREADY_CREATED`
 
@@ -69,9 +69,9 @@ Representation of an error, with a machine-parsable [code](#error-codes).
 
 ### `ERR_DOC_TYPE_NOT_RECOGNIZED`
 
-> The specified document [type]({% link types/index.md %}) has not been registered with ShareDB.
+> The specified document [type]({{ site.baseurl }}{% link types/index.md %}) has not been registered with ShareDB.
 
-> This error can usually be remedied by remembering to [register]({% link types/index.md %}#installing-other-types) any types you need.
+> This error can usually be remedied by remembering to [register]({{ site.baseurl }}{% link types/index.md %}#installing-other-types) any types you need.
 
 ### `ERR_DEFAULT_TYPE_MISMATCH`
 
@@ -95,4 +95,4 @@ Representation of an error, with a machine-parsable [code](#error-codes).
 
 ### `ERR_TYPE_CANNOT_BE_PROJECTED`
 
-> The document's type cannot be projected. [`json0`]({% link types/json0.md %}) is currently the only type that supports projections.
+> The document's type cannot be projected. [`json0`]({{ site.baseurl }}{% link types/json0.md %}) is currently the only type that supports projections.

--- a/docs/api/snapshot.md
+++ b/docs/api/snapshot.md
@@ -13,13 +13,13 @@ parent: API
 Represents a **read-only** ShareDB document at a particular version number.
 
 {: .info }
-Snapshots can **not** be used to manipulate the current version of the document stored in the database. That should be achieved by using a [`Doc`]({% link api/doc.md %}).
+Snapshots can **not** be used to manipulate the current version of the document stored in the database. That should be achieved by using a [`Doc`]({{ site.baseurl }}{% link api/doc.md %}).
 
 ## Properties
 
-### `type` -- [Type]({% link types/index.md %})
+### `type` -- [Type]({{ site.baseurl }}{% link types/index.md %})
 
-> The document [type]({% link types/index.md %})
+> The document [type]({{ site.baseurl }}{% link types/index.md %})
 
 {: .info }
 > Document types can change between versions if the document is deleted, and created again.

--- a/docs/document-history.md
+++ b/docs/document-history.md
@@ -10,8 +10,8 @@ Since -- by default -- ShareDB stores all of the submitted operations, these ope
 
 ShareDB exposes two methods for this:
 
- - [`connection.fetchSnapshot()`]({% link api/connection.md %}fetchsnapshot) -- fetches a snapshot by version number
- - [`connection.fetchSnapshotByTimestamp()`]({% link api/connection.md %}#fetchsnapshotbytimestamp) -- fetches a snapshot by UNIX timestamp
+ - [`connection.fetchSnapshot()`]({{ site.baseurl }}{% link api/connection.md %}fetchsnapshot) -- fetches a snapshot by version number
+ - [`connection.fetchSnapshotByTimestamp()`]({{ site.baseurl }}{% link api/connection.md %}#fetchsnapshotbytimestamp) -- fetches a snapshot by UNIX timestamp
 
 {: .info }
 ShareDB doesn't support "branching" a document. Any historical snapshots fetched will be read-only.
@@ -22,4 +22,4 @@ Since OT types are only optionally reversible, ShareDB rebuilds its historic sna
 
 Once documents reach a high version, rebuilding a document like this can get slow. In order to facilitate this, ShareDB supports Milestone Snapshots -- snapshots that are periodically saved, so that ShareDB can jump to the nearest snapshot, and rebuild from there.
 
-In order to benefit from this performance improvement, a [milestone adapter]({% link adapters/milestone.md %}) should be configured.
+In order to benefit from this performance improvement, a [milestone adapter]({{ site.baseurl }}{% link adapters/milestone.md %}) should be configured.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ npm install --save sharedb
 If your server and client have separate dependencies, ShareDB should be added as a dependency to **both** packages.
 
 <!-- TODO: Link to types -->
-You may also wish to install other [OT types]({% link types/index.md %}).
+You may also wish to install other [OT types]({{ site.baseurl }}{% link types/index.md %}).
 
 ## Examples
 

--- a/docs/middleware/index.md
+++ b/docs/middleware/index.md
@@ -14,18 +14,18 @@ copy:
     `op` -- Object
     > The submitted op
 
-    `snapshot` -- [`Snapshot`]({% link api/snapshot.md %})
+    `snapshot` -- [`Snapshot`]({{ site.baseurl }}{% link api/snapshot.md %})
     > The snapshot
 
     `extra` -- Object
     > `extra.source` -- Object
-    >> The submitted source when [`doc.submitSource`]({% link api/doc.md %}http://localhost:4000/api/doc#submitsource--boolean) is set to `true`
+    >> The submitted source when [`doc.submitSource`]({{ site.baseurl }}{% link api/doc.md %}http://localhost:4000/api/doc#submitsource--boolean) is set to `true`
 
     `saveMilestoneSnapshot` -- boolean
-    > Flag to control [saving a milestone snapshot]({% link adapters/milestone.md#requesting-snapshots %})
+    > Flag to control [saving a milestone snapshot]({{ site.baseurl }}{% link adapters/milestone.md#requesting-snapshots %})
 
     `suppressPublish` -- boolean
-    > Flag to prevent broadcasting over [pub/sub]({% link pub-sub.md %})
+    > Flag to prevent broadcasting over [pub/sub]({{ site.baseurl }}{% link pub-sub.md %})
 
     `retries` -- number
     > The number of times the op has attempted to submit
@@ -48,7 +48,7 @@ This can be particularly useful for authentication.
 
 ## Registering middleware
 
-Middleware is registered on the server with [`backend.use()`]({% link api/backend.md %}#use):
+Middleware is registered on the server with [`backend.use()`]({{ site.baseurl }}{% link api/backend.md %}#use):
 
 ```js
 backend.use(action, function(context, next) {
@@ -64,7 +64,7 @@ The `action` should be one of the values listed [below](#actions).
 
 ## Actions
 
-The actions represent different stages of information flow through the server. These hooks are also available on [`backend.MIDDLEWARE_ACTIONS`]({% link api/backend.md %}#middleware_actions--object).
+The actions represent different stages of information flow through the server. These hooks are also available on [`backend.MIDDLEWARE_ACTIONS`]({{ site.baseurl }}{% link api/backend.md %}#middleware_actions--object).
 
 All of the actions will have these `context` properties:
 
@@ -72,13 +72,13 @@ All of the actions will have these `context` properties:
 
 > The triggered middleware action
 
-`agent` -- [Agent]({% link api/agent.md %})
+`agent` -- [Agent]({{ site.baseurl }}{% link api/agent.md %})
 
-> The [`Agent`]({% link api/agent.md %}) communicating with the client
+> The [`Agent`]({{ site.baseurl }}{% link api/agent.md %}) communicating with the client
 
-`backend` -- [Backend]({% link api/backend.md %})
+`backend` -- [Backend]({{ site.baseurl }}{% link api/backend.md %})
 
-> The [`Backend`]({% link api/backend.md %}) handling the request
+> The [`Backend`]({{ site.baseurl }}{% link api/backend.md %}) handling the request
 
 ### `'connect'`
 
@@ -92,7 +92,7 @@ This action has these additional `context` properties:
 
 `req` -- Object
 
-> The `request` argument provided to [`backend.listen()`]({% link api/backend.md %}#listen)
+> The `request` argument provided to [`backend.listen()`]({{ site.baseurl }}{% link api/backend.md %}#listen)
 
 ### `'receive'`
 
@@ -130,7 +130,7 @@ This action has these additional `context` properties:
 
 `presence` -- Object
 
-> The presence object being sent. Its shape depends on its [type]({% link types/index.md %})
+> The presence object being sent. Its shape depends on its [type]({{ site.baseurl }}{% link types/index.md %})
 
 ### `'readSnapshots'`
 
@@ -142,9 +142,9 @@ This action has these additional `context` properties:
 
 > The collection the snapshots belong to
 
-`snapshots` -- [Snapshot[]]({% link api/snapshot.md %})
+`snapshots` -- [Snapshot[]]({{ site.baseurl }}{% link api/snapshot.md %})
 
-> The [`Snapshot`]({% link api/snapshot.md %})s being read
+> The [`Snapshot`]({{ site.baseurl }}{% link api/snapshot.md %})s being read
 
 `snapshotType` -- string
 

--- a/docs/presence.md
+++ b/docs/presence.md
@@ -14,14 +14,14 @@ ShareDB supports sharing "presence": transient information about a client's wher
 
 Presence can be used independently of a document (for example, sharing a mouse pointer position).
 
-In this case, clients just need to subscribe to a common channel using [`connection.getPresence()`]({% link api/connection.md %}#getpresence) to get a [`Presence`]({% link api/presence.md %}) instance:
+In this case, clients just need to subscribe to a common channel using [`connection.getPresence()`]({{ site.baseurl }}{% link api/connection.md %}#getpresence) to get a [`Presence`]({{ site.baseurl }}{% link api/presence.md %}) instance:
 
 ```js
 const presence = connection.getPresence('my-channel')
 presence.subscribe()
 ```
 
-In order to send presence information to other clients, a [`LocalPresence`]({% link api/local-presence.md %}) should be created. The presence object can take any arbitrary value
+In order to send presence information to other clients, a [`LocalPresence`]({{ site.baseurl }}{% link api/local-presence.md %}) should be created. The presence object can take any arbitrary value
 
 ```js
 const localPresence = presence.create()
@@ -34,23 +34,23 @@ Multiple local presences can be created from a single `presence` instance, which
 
 ### Typed presence
 
-Presence can be coupled to a particular document by getting a [`DocPresence`]({% link api/presence.md %}) instance with [`connection.getDocPresence()`]({% link api/doc.md %}#getdocpresence).
+Presence can be coupled to a particular document by getting a [`DocPresence`]({{ site.baseurl }}{% link api/presence.md %}) instance with [`connection.getDocPresence()`]({{ site.baseurl }}{% link api/doc.md %}#getdocpresence).
 
 The special thing about a `DocPresence` (as opposed to a `Presence`) instance is that `DocPresence` will automatically handle synchronisation issues. Since presence and ops are submitted independently of one another, they can arrive out-of-sync, which might make a text cursor jitter, for example. `DocPresence` will handle these cases, and make sure the correct presence is always applied to the correct version of a document.
 
-Support depends on the [type]({% link types/index.md %}) being used.
+Support depends on the [type]({{ site.baseurl }}{% link types/index.md %}) being used.
 
 {: .info }
 Currently, only `rich-text` supports presence information
 
-Clients subscribe to a particular [`Doc`]({% link api/doc.md %}) instead of a channel:
+Clients subscribe to a particular [`Doc`]({{ site.baseurl }}{% link api/doc.md %}) instead of a channel:
 
 ```js
 const presence = connection.getDocPresence(collection, id)
 presence.subscribe()
 ```
 
-The shape of the presence value will be defined by the [type]({% link types/index.md %}):
+The shape of the presence value will be defined by the [type]({{ site.baseurl }}{% link types/index.md %}):
 
 ```js
 const localPresence = presence.create()

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -6,10 +6,10 @@ layout: default
 
 # Projections
 
-Some [types]({% link types/index.md %}) support exposing a projection of a real collection, with a specified set of allowed fields.
+Some [types]({{ site.baseurl }}{% link types/index.md %}) support exposing a projection of a real collection, with a specified set of allowed fields.
 
 {: .info }
-Currently, only [`json0`]({% link types/json0.md %}) supports projections.
+Currently, only [`json0`]({{ site.baseurl }}{% link types/json0.md %}) supports projections.
 
 Once configured, the projected collection looks just like a real collection -- except documents only have the fields that have been specified.
 
@@ -17,7 +17,7 @@ Operations on the projected collection work, but only a small portion of the dat
 
 ## Usage
 
-Projections are configured using [`backend.addProjection()`]({% link api/backend.md %}#addprojection). For example, imagine we have a collection `users` with lots of information that should not be leaked. To add a projection `names`, which only has access to the `firstName` and `lastName` properties on a user:
+Projections are configured using [`backend.addProjection()`]({{ site.baseurl }}{% link api/backend.md %}#addprojection). For example, imagine we have a collection `users` with lots of information that should not be leaked. To add a projection `names`, which only has access to the `firstName` and `lastName` properties on a user:
 
 ```js
 backend.addProjection('names', 'users', {firstName: true, lastName: true})

--- a/docs/pub-sub.md
+++ b/docs/pub-sub.md
@@ -6,4 +6,4 @@ layout: default
 
 # Pub/Sub
 
-Pub/Sub is used to communicate between multiple ShareDB instances. To communicate with more than one ShareDB instance, a [pub/sub adapter]({% link adapters/pub-sub.md %}) should be configured.
+Pub/Sub is used to communicate between multiple ShareDB instances. To communicate with more than one ShareDB instance, a [pub/sub adapter]({{ site.baseurl }}{% link adapters/pub-sub.md %}) should be configured.

--- a/docs/types/index.md
+++ b/docs/types/index.md
@@ -15,7 +15,7 @@ ShareDB provides a realtime collaborative platform based on [Operational Transfo
 
 Transforming and handling ops is delegated to an underlying OT type.
 
-ShareDB ships with a single, default type -- [`json0`]({% link types/json0.md %}).
+ShareDB ships with a single, default type -- [`json0`]({{ site.baseurl }}{% link types/json0.md %}).
 
 ## Registering types
 
@@ -44,7 +44,7 @@ Client.types.register(richText.type)
 
 ## Using types
 
-A [registered](#registering-types) type can be used by specifying its name or URI when creating a [`Doc`]({% link api/doc.md %}):
+A [registered](#registering-types) type can be used by specifying its name or URI when creating a [`Doc`]({{ site.baseurl }}{% link api/doc.md %}):
 
 ```js
 doc.create([{insert: 'Lorem'}], 'http://sharejs.org/types/rich-text/v1')

--- a/docs/types/json0.md
+++ b/docs/types/json0.md
@@ -7,4 +7,4 @@ parent: OT Types
 
 # JSON0
 
-[`json0`](https://github.com/ottypes/json0) is ShareDB's default type. This means that if no other type is specified in [`doc.create()`]({% link api/doc.md %}), `json0` will be used by default.
+[`json0`](https://github.com/ottypes/json0) is ShareDB's default type. This means that if no other type is specified in [`doc.create()`]({{ site.baseurl }}{% link api/doc.md %}), `json0` will be used by default.


### PR DESCRIPTION
According to the [Jekyll docs][1]:

> Since Jekyll 4.0 , you don’t need to prepend `link` and `post_url`
> tags with `site.baseurl`

However, Github Pages is [stuck on v3][2], so we need to prepend all of
our links with `site.baseurl`.

Note that we could potentially just move to using relative paths
(rather than using the `link` tag), but the `link` tag offers some solid
benefits:

 - fails build if the linked page doesn't exist
 - keeps paths relative to the root, which makes updating links much
   easier (eg find-and-replacing a moved file)

[1]: https://jekyllrb.com/docs/liquid/tags/#links
[2]: https://github.com/github/pages-gem/issues/651