### PR TITLE
📝 Add docs development scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ https://share.github.io/sharedb/
 
 ### Documentation
 
-The documentation is stored as Markdown files, but sometimes it can be useful to run these locally. The docs are served using [Jekyll](https://jekyllrb.com/), and require Ruby and [Bundler](https://bundler.io/).
+The documentation is stored as Markdown files, but sometimes it can be useful to run these locally. The docs are served using [Jekyll](https://jekyllrb.com/), and require Ruby >2.4.0 and [Bundler](https://bundler.io/):
+
+```bash
+gem install jekyll bundler
+```
 
 The docs can be built locally and served with live reload:
 

--- a/README.md
+++ b/README.md
@@ -46,3 +46,16 @@ https://share.github.io/sharedb/
 ### Leaderboard
 
 [<img src="examples/leaderboard/demo.gif" height="436">](examples/leaderboard)
+
+## Development
+
+### Documentation
+
+The documentation is stored as Markdown files, but sometimes it can be useful to run these locally. The docs are served using [Jekyll](https://jekyllrb.com/), and require Ruby and [Bundler](https://bundler.io/).
+
+The docs can be built locally and served with live reload:
+
+```bash
+npm run docs:install
+npm run docs:start
+```

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -31,3 +31,6 @@ gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
 # kramdown v2 ships without the gfm parser by default. If you're using
 # kramdown v1, comment out this line.
 gem "kramdown-parser-gfm"
+
+# Needed for Ruby 3: https://github.com/jekyll/jekyll/issues/8523
+gem "webrick", "~> 1.7"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -256,6 +256,7 @@ GEM
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     wdm (0.1.1)
+    webrick (1.7.0)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -268,6 +269,7 @@ DEPENDENCIES
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.0)
+  webrick (~> 1.7)
 
 BUNDLED WITH
    2.1.4

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "sinon": "^7.5.0"
   },
   "scripts": {
+    "docs:install": "cd docs && bundle install",
+    "docs:build": "cd docs && bundle exec jekyll build",
+    "docs:start": "cd docs && bundle exec jekyll serve --livereload",
     "test": "mocha",
     "test-cover": "nyc --temp-dir=coverage -r text -r lcov npm test",
     "lint": "./node_modules/.bin/eslint --ignore-path .gitignore '**/*.js'",


### PR DESCRIPTION
This change adds helper scripts to our `package.json` for working on the
documentation, as well as a brief overview in the `README`.