### PR TITLE
✅ Make `getQuery` optional in `Db` test suite

### DIFF
--- a/test/client/query-subscribe.js
+++ b/test/client/query-subscribe.js
@@ -8,7 +8,6 @@ module.exports = function(options) {
 
   describe('client query subscribe', function() {
     before(function() {
-      if (!getQuery) return this.skip();
       this.matchAllDbQuery = getQuery({query: {}});
     });
 

--- a/test/client/query.js
+++ b/test/client/query.js
@@ -7,7 +7,6 @@ module.exports = function(options) {
 
   describe('client query', function() {
     before(function() {
-      if (!getQuery) return this.skip();
       this.matchAllDbQuery = getQuery({query: {}});
     });
 


### PR DESCRIPTION
Implementing queries is technically optional for database adapters.
This change updates our `Db` test suite to:

 - check if `getQuery` has been passed in the options
 - remove MongoDB-specific `getQuery` mapping