### PR TITLE
🥅 Remove agent truthiness checks

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -392,7 +392,7 @@ Backend.prototype.fetch = function(agent, index, id, options, callback) {
     id: id
   };
   var snapshotOptions = (options && options.snapshotOptions) || {};
-  if (agent) snapshotOptions.agentCustom = agent.custom;
+  snapshotOptions.agentCustom = agent.custom;
   backend.db.getSnapshot(collection, id, fields, snapshotOptions, function(err, snapshot) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);
@@ -440,7 +440,7 @@ Backend.prototype.fetchBulk = function(agent, index, ids, options, callback) {
     ids: ids
   };
   var snapshotOptions = (options && options.snapshotOptions) || {};
-  if (agent) snapshotOptions.agentCustom = agent.custom;
+  snapshotOptions.agentCustom = agent.custom;
   backend.db.getSnapshotBulk(collection, ids, fields, snapshotOptions, function(err, snapshotMap) {
     if (err) return callback(err);
     var snapshotProjection = backend._getSnapshotProjection(backend.db, projection);

--- a/lib/query-emitter.js
+++ b/lib/query-emitter.js
@@ -261,7 +261,7 @@ QueryEmitter.prototype.queryPollDoc = function(id, callback) {
       var index = emitter.ids.push(id) - 1;
 
       var snapshotOptions = {};
-      if (emitter.agent) snapshotOptions.agentCustom = emitter.agent.custom;
+      snapshotOptions.agentCustom = emitter.agent.custom;
 
       // We can get the result to send to the client async, since there is a
       // delay in sending to the client anyway

--- a/lib/submit-request.js
+++ b/lib/submit-request.js
@@ -54,7 +54,7 @@ SubmitRequest.prototype.submit = function(callback) {
   var fields = {$submit: true};
 
   var snapshotOptions = {};
-  if (request.agent) snapshotOptions.agentCustom = request.agent.custom;
+  snapshotOptions.agentCustom = request.agent.custom;
   backend.db.getSnapshot(collection, id, fields, snapshotOptions, function(err, snapshot) {
     if (err) return callback(err);
 

--- a/test/backend.js
+++ b/test/backend.js
@@ -34,7 +34,7 @@ describe('Backend', function() {
 
     describe('getOps', function() {
       it('fetches all the ops', function(done) {
-        backend.getOps(null, 'books', '1984', 0, null, function(error, ops) {
+        backend.getOps(agent, 'books', '1984', 0, null, function(error, ops) {
           if (error) return done(error);
           expect(ops).to.have.length(2);
           expect(ops[0].create.data).to.eql({title: '1984'});
@@ -47,7 +47,7 @@ describe('Backend', function() {
         var options = {
           opsOptions: {metadata: true}
         };
-        backend.getOps(null, 'books', '1984', 0, null, options, function(error, ops) {
+        backend.getOps(agent, 'books', '1984', 0, null, options, function(error, ops) {
           if (error) return done(error);
           expect(ops).to.have.length(2);
           expect(ops[0].m).to.be.ok;
@@ -59,7 +59,7 @@ describe('Backend', function() {
 
     describe('fetch', function() {
       it('fetches the document', function(done) {
-        backend.fetch(null, 'books', '1984', function(error, doc) {
+        backend.fetch(agent, 'books', '1984', function(error, doc) {
           if (error) return done(error);
           expect(doc.data).to.eql({
             title: '1984',
@@ -73,7 +73,7 @@ describe('Backend', function() {
         var options = {
           snapshotOptions: {metadata: true}
         };
-        backend.fetch(null, 'books', '1984', options, function(error, doc) {
+        backend.fetch(agent, 'books', '1984', options, function(error, doc) {
           if (error) return done(error);
           expect(doc.m).to.be.ok;
           done();
@@ -109,7 +109,7 @@ describe('Backend', function() {
 
     describe('subscribe', function() {
       it('subscribes to the document', function(done) {
-        backend.subscribe(null, 'books', '1984', null, function(error, stream, snapshot) {
+        backend.subscribe(agent, 'books', '1984', null, function(error, stream, snapshot) {
           if (error) return done(error);
           expect(stream.open).to.equal(true);
           expect(snapshot.data).to.eql({
@@ -121,7 +121,7 @@ describe('Backend', function() {
             expect(data.op).to.eql(op.op);
             done();
           });
-          backend.submit(null, 'books', '1984', op, null, function(error) {
+          backend.submit(agent, 'books', '1984', op, null, function(error) {
             if (error) return done(error);
           });
         });
@@ -131,7 +131,7 @@ describe('Backend', function() {
         var options = {
           opsOptions: {metadata: true}
         };
-        backend.subscribe(null, 'books', '1984', null, options, function(error) {
+        backend.subscribe(agent, 'books', '1984', null, options, function(error) {
           expect(error.code).to.equal('ERR_DATABASE_METHOD_NOT_IMPLEMENTED');
           done();
         });
@@ -155,7 +155,7 @@ describe('Backend', function() {
         });
 
         var op = {op: {p: ['publicationYear'], oi: 1949}};
-        backend.submit(null, 'books', '1984', op, null, function(error) {
+        backend.submit(agent, 'books', '1984', op, null, function(error) {
           if (error) done(error);
         });
       });
@@ -172,7 +172,7 @@ describe('Backend', function() {
         });
 
         var op = {op: {p: ['publicationYear'], oi: 1949}};
-        backend.submit(null, 'books', '1984', op, null, function() {
+        backend.submit(agent, 'books', '1984', op, null, function() {
           // Swallow the error
         });
       });

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -226,7 +226,9 @@ describe('middleware', function() {
         });
         var op = {create: {type: types.defaultType.uri}};
         var options = {testOption: true};
-        this.backend.submit(null, 'dogs', 'fido', op, options, doneAfter);
+        var connection = this.backend.connect();
+        var agent = connection.agent;
+        this.backend.submit(agent, 'dogs', 'fido', op, options, doneAfter);
       });
     });
   });


### PR DESCRIPTION
Fixes https://github.com/share/sharedb/issues/454

We recently made [a change][1], which added checks for if `agent` was
provided to certain backend methods. This added unofficial support for
a falsy `agent`, which we don't really want to support.

This change removes these checks, and fixes the tests that fail because
they pass in a `null` agent.

Note that we discussed adding a formal assertion, but this pattern
didn't fix with the existing methods, which all operate under the
assumption that its arguments are present.

[1]: https://github.com/share/sharedb/pull/446