### PR TITLE
📝 Add auxiliary links

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,6 +17,18 @@ title: ShareDB
 baseurl: "/sharedb" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
+aux_links:
+  "ShareDB on GitHub":
+    - "//github.com/share/sharedb"
+
+# Footer "Edit this page on GitHub" link text
+gh_edit_link: true # show or hide edit this page link
+gh_edit_link_text: "Edit this page on GitHub"
+gh_edit_repository: "https://github.com/share/sharedb" # the github URL for your repo
+gh_edit_branch: "master" # the branch that your docs is served from
+gh_edit_source: "docs" # the source that your files originate from
+gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
+
 # Build settings
 markdown: kramdown
 remote_theme: pmarsceill/just-the-docs


### PR DESCRIPTION
This change updates our [config][1] to:

 - add a link to the Github repo in the top-right corner
 - add a link to the current page in Github at the bottom of the page,
   encouraging viewers to edit the page

[1]: https://pmarsceill.github.io/just-the-docs/docs/configuration/