### PR TITLE
🔨 Fix example script builds on Windows

### DIFF
--- a/examples/counter-json1/package.json
+++ b/examples/counter-json1/package.json
@@ -4,7 +4,7 @@
   "description": "A simple client/server app using ShareDB (ottype json1) and WebSockets",
   "main": "server.js",
   "scripts": {
-    "build": "mkdir -p static/dist/ && ./node_modules/.bin/browserify client.js -o static/dist/bundle.js",
+    "build": "browserify client.js -o static/dist/bundle.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"
   },

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -4,7 +4,7 @@
   "description": "A simple client/server app using ShareDB and WebSockets",
   "main": "server.js",
   "scripts": {
-    "build": "mkdir -p static/dist/ && ./node_modules/.bin/browserify client.js -o static/dist/bundle.js",
+    "build": "browserify client.js -o static/dist/bundle.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"
   },

--- a/examples/leaderboard/package.json
+++ b/examples/leaderboard/package.json
@@ -4,7 +4,7 @@
   "description": "React Leaderboard backed by ShareDB",
   "main": "server.js",
   "scripts": {
-    "build": "mkdir -p static/dist/ && ./node_modules/.bin/browserify -t [ babelify --presets [ react ] ] client/index.jsx -o static/dist/bundle.js",
+    "build": "browserify -t [ babelify --presets [ react ] ] client/index.jsx -o static/dist/bundle.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server/index.js"
   },

--- a/examples/rich-text-presence/package.json
+++ b/examples/rich-text-presence/package.json
@@ -4,7 +4,7 @@
   "description": "An example of presence using ShareDB and Quill",
   "main": "server.js",
   "scripts": {
-    "build": "mkdir -p static/dist/ && ./node_modules/.bin/browserify client.js -o static/dist/bundle.js",
+    "build": "browserify client.js -o static/dist/bundle.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"
   },

--- a/examples/rich-text/package.json
+++ b/examples/rich-text/package.json
@@ -4,7 +4,7 @@
   "description": "A simple rich-text editor example based on Quill and ShareDB",
   "main": "server.js",
   "scripts": {
-    "build": "mkdir -p static/dist/ && ./node_modules/.bin/browserify client.js -o static/dist/bundle.js",
+    "build": "browserify client.js -o static/dist/bundle.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"
   },

--- a/examples/textarea/package.json
+++ b/examples/textarea/package.json
@@ -4,7 +4,7 @@
   "description": "A simple client/server app using ShareDB and WebSockets",
   "main": "server.js",
   "scripts": {
-    "build": "mkdir -p static/dist/ && ./node_modules/.bin/browserify client.js -o static/dist/bundle.js",
+    "build": "browserify client.js -o static/dist/bundle.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"
   },


### PR DESCRIPTION
Fixes https://github.com/share/sharedb/issues/466

Running the example `build` commands on windows doesn't work, because
`mkdir` [fails with the wrong slash type][1].

However, `browserify` will already [ensure the directory exists][2], so
we don't even need this command.

This change removes our call to `mkdir`, and also simplifies the call
to `browserify`, since `node_modules` is already on the PATH when run
with `npm run`.

[1]: https://stackoverflow.com/a/52863346/4003671
[2]: https://github.com/browserify/browserify/blob/0ec6e80ec48b67513718a392a6d09bd5569967d4/bin/cmd.js#L64