### PR TITLE
🔧 Limit the files distributed in the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "sharedb-legacy": "npm:sharedb@=1.1.0",
     "sinon": "^7.5.0"
   },
+  "files": [
+    "lib/"
+  ],
   "scripts": {
     "docs:install": "cd docs && bundle install",
     "docs:build": "cd docs && bundle exec jekyll build",


### PR DESCRIPTION
Fixes https://github.com/share/sharedb/issues/459

This change adds the [`files`][1] property to our `package.json`, which
lets us define which files to publish as part of the distributed package
and reduce the size of our published package from ~2MB to ~100kB

# Before

```
npm notice 📦  sharedb@1.8.1
npm notice === Tarball Contents ===
npm notice 368B    test/.jshintrc
npm notice 1.2kB   docs/Gemfile
npm notice 1.1kB   LICENSE
npm notice 4.4kB   examples/leaderboard/static/leaderboard.css
npm notice 328B    examples/rich-text-presence/static/style.css
npm notice 444.9kB examples/counter-json1/demo.gif
npm notice 444.9kB examples/counter/demo.gif
npm notice 1.1MB   examples/leaderboard/demo.gif
npm notice 398B    docs/404.html
npm notice 343B    examples/counter-json1/static/index.html
npm notice 328B    examples/counter/static/index.html
npm notice 200B    examples/leaderboard/static/index.html
npm notice 562B    examples/rich-text-presence/static/index.html
npm notice 287B    examples/rich-text/static/index.html
npm notice 694B    examples/textarea/static/index.html
npm notice 1.7kB   .eslintrc.js
npm notice 28.3kB  lib/agent.js
npm notice 29.8kB  lib/backend.js
npm notice 5.6kB   test/backend.js
npm notice 2.9kB   test/BasicQueryableMemoryDB.js
npm notice 1.2kB   examples/counter-json1/client.js
npm notice 1.1kB   examples/counter/client.js
npm notice 2.8kB   examples/rich-text-presence/client.js
npm notice 1.1kB   examples/rich-text/client.js
npm notice 1.2kB   examples/textarea/client.js
npm notice 320B    examples/leaderboard/client/connection.js
npm notice 24.8kB  lib/client/connection.js
npm notice 10.3kB  test/client/connection.js
npm notice 2.0kB   test/db-memory.js
npm notice 31.7kB  test/db.js
npm notice 4.2kB   test/client/deserialized-type.js
npm notice 739B    lib/client/presence/doc-presence.js
npm notice 31.7kB  test/client/presence/doc-presence.js
npm notice 35.2kB  lib/client/doc.js
npm notice 17.3kB  test/client/doc.js
npm notice 255B    lib/emitter.js
npm notice 3.8kB   lib/error.js
npm notice 787B    test/error.js
npm notice 1.3kB   examples/leaderboard/server/index.js
npm notice 227B    lib/client/index.js
npm notice 3.4kB   lib/db/index.js
npm notice 691B    lib/index.js
npm notice 86B     lib/logger/index.js
npm notice 2.9kB   lib/milestone-db/index.js
npm notice 3.9kB   lib/pubsub/index.js
npm notice 3.6kB   lib/client/presence/local-doc-presence.js
npm notice 2.2kB   lib/client/presence/local-presence.js
npm notice 635B    lib/logger/logger.js
npm notice 1.2kB   test/logger.js
npm notice 6.5kB   lib/db/memory.js
npm notice 4.9kB   lib/milestone-db/memory.js
npm notice 1.2kB   lib/pubsub/memory.js
npm notice 15.2kB  test/middleware.js
npm notice 307B    test/milestone-db-memory.js
npm notice 21.4kB  test/milestone-db.js
npm notice 1.2kB   lib/milestone-db/no-op.js
npm notice 386B    test/client/number-type.js
npm notice 1.1kB   lib/op-stream.js
npm notice 7.4kB   lib/ot.js
npm notice 14.1kB  test/ot.js
npm notice 3.4kB   test/client/pending.js
npm notice 1.4kB   test/client/presence/presence-pauser.js
npm notice 994B    test/client/presence/presence-test-type.js
npm notice 5.3kB   lib/client/presence/presence.js
npm notice 14.9kB  test/client/presence/presence.js
npm notice 3.2kB   lib/projections.js
npm notice 12.5kB  test/client/projections.js
npm notice 9.5kB   test/projections.js
npm notice 2.4kB   test/pubsub-memory.js
npm notice 2.5kB   test/pubsub.js
npm notice 12.3kB  lib/query-emitter.js
npm notice 22.8kB  test/client/query-subscribe.js
npm notice 5.8kB   lib/client/query.js
npm notice 6.8kB   test/client/query.js
npm notice 3.8kB   lib/read-snapshots-request.js
npm notice 4.6kB   lib/client/presence/remote-doc-presence.js
npm notice 720B    lib/client/presence/remote-presence.js
npm notice 1.2kB   examples/counter-json1/server.js
npm notice 1.1kB   examples/counter/server.js
npm notice 1.3kB   examples/rich-text-presence/server.js
npm notice 1.2kB   examples/rich-text/server.js
npm notice 1.1kB   examples/textarea/server.js
npm notice 254B    test/setup.js
npm notice 1.4kB   lib/client/snapshot-request/snapshot-request.js
npm notice 725B    lib/client/snapshot-request/snapshot-timestamp-request.js
npm notice 16.9kB  test/client/snapshot-timestamp-request.js
npm notice 702B    lib/client/snapshot-request/snapshot-version-request.js
npm notice 13.9kB  test/client/snapshot-version-request.js
npm notice 173B    lib/snapshot.js
npm notice 1.7kB   lib/stream-socket.js
npm notice 2.9kB   test/client/submit-json1.js
npm notice 10.3kB  lib/submit-request.js
npm notice 43.0kB  test/client/submit.js
npm notice 34.1kB  test/client/subscribe.js
npm notice 242B    lib/types.js
npm notice 1.3kB   test/util-test.js
npm notice 2.4kB   lib/util.js
npm notice 1.5kB   test/util.js
npm notice 939B    examples/counter-json1/package.json
npm notice 830B    examples/counter/package.json
npm notice 1.1kB   examples/leaderboard/package.json
npm notice 891B    examples/rich-text-presence/package.json
npm notice 769B    examples/rich-text/package.json
npm notice 753B    examples/textarea/package.json
npm notice 1.1kB   package.json
npm notice 406B    examples/leaderboard/client/Body.jsx
npm notice 162B    examples/leaderboard/client/index.jsx
npm notice 1.6kB   examples/leaderboard/client/Leaderboard.jsx
npm notice 1.2kB   examples/leaderboard/client/Player.jsx
npm notice 704B    examples/leaderboard/client/PlayerList.jsx
npm notice 553B    examples/leaderboard/client/PlayerSelector.jsx
npm notice 7.5kB   docs/Gemfile.lock
npm notice 1.4kB   docs/api/agent.md
npm notice 14.2kB  docs/api/backend.md
npm notice 1.0kB   CHANGELOG.md
npm notice 5.3kB   docs/api/connection.md
npm notice 1.3kB   docs/adapters/database.md
npm notice 10.7kB  docs/api/doc.md
npm notice 1.3kB   docs/document-history.md
npm notice 2.9kB   docs/getting-started.md
npm notice 232B    docs/adapters/index.md
npm notice 75B     docs/api/index.md
npm notice 1.4kB   docs/index.md
npm notice 6.2kB   docs/middleware/index.md
npm notice 1.7kB   docs/types/index.md
npm notice 289B    docs/types/json0.md
npm notice 2.0kB   docs/api/local-presence.md
npm notice 1.8kB   docs/adapters/milestone.md
npm notice 3.6kB   docs/api/presence.md
npm notice 2.5kB   docs/presence.md
npm notice 1.2kB   docs/projections.md
npm notice 1.1kB   docs/adapters/pub-sub.md
npm notice 275B    docs/pub-sub.md
npm notice 6.5kB   docs/queries.md
npm notice 3.1kB   docs/api/query.md
npm notice 626B    examples/counter-json1/README.md
npm notice 611B    examples/counter/README.md
npm notice 760B    examples/leaderboard/README.md
npm notice 580B    examples/rich-text-presence/README.md
npm notice 580B    examples/rich-text/README.md
npm notice 541B    examples/textarea/README.md
npm notice 2.4kB   README.md
npm notice 4.4kB   docs/api/sharedb-error.md
npm notice 710B    docs/api/snapshot.md
npm notice 879B    docs/_sass/custom/custom.scss
npm notice 134B    scripts/test-sharedb-mongo.sh
npm notice 2.2kB   docs/_config.yml
npm notice 69B     .mocharc.yml
npm notice 392B    .github/workflows/docs.yml
npm notice 1.1kB   .github/workflows/test.yml
npm notice === Tarball Details ===
npm notice name:          sharedb
npm notice version:       1.8.1
npm notice package size:  1.8 MB
npm notice unpacked size: 2.6 MB
npm notice shasum:        b01bb9e9f5b793502832c5414ec481f1bf4ef59f
npm notice integrity:     sha512-ANf1TnfIesqeL[...]GwsM/kvdRiyxw==
npm notice total files:   150
```

# After

```
npm notice 📦  sharedb@1.8.1
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 28.3kB lib/agent.js
npm notice 29.8kB lib/backend.js
npm notice 24.8kB lib/client/connection.js
npm notice 739B   lib/client/presence/doc-presence.js
npm notice 35.2kB lib/client/doc.js
npm notice 255B   lib/emitter.js
npm notice 3.8kB  lib/error.js
npm notice 227B   lib/client/index.js
npm notice 3.4kB  lib/db/index.js
npm notice 691B   lib/index.js
npm notice 86B    lib/logger/index.js
npm notice 2.9kB  lib/milestone-db/index.js
npm notice 3.9kB  lib/pubsub/index.js
npm notice 3.6kB  lib/client/presence/local-doc-presence.js
npm notice 2.2kB  lib/client/presence/local-presence.js
npm notice 635B   lib/logger/logger.js
npm notice 6.5kB  lib/db/memory.js
npm notice 4.9kB  lib/milestone-db/memory.js
npm notice 1.2kB  lib/pubsub/memory.js
npm notice 1.2kB  lib/milestone-db/no-op.js
npm notice 1.1kB  lib/op-stream.js
npm notice 7.4kB  lib/ot.js
npm notice 5.3kB  lib/client/presence/presence.js
npm notice 3.2kB  lib/projections.js
npm notice 12.3kB lib/query-emitter.js
npm notice 5.8kB  lib/client/query.js
npm notice 3.8kB  lib/read-snapshots-request.js
npm notice 4.6kB  lib/client/presence/remote-doc-presence.js
npm notice 720B   lib/client/presence/remote-presence.js
npm notice 1.4kB  lib/client/snapshot-request/snapshot-request.js
npm notice 725B   lib/client/snapshot-request/snapshot-timestamp-request.js
npm notice 702B   lib/client/snapshot-request/snapshot-version-request.js
npm notice 173B   lib/snapshot.js
npm notice 1.7kB  lib/stream-socket.js
npm notice 10.3kB lib/submit-request.js
npm notice 242B   lib/types.js
npm notice 2.4kB  lib/util.js
npm notice 1.2kB  package.json
npm notice 1.0kB  CHANGELOG.md
npm notice 2.4kB  README.md
npm notice === Tarball Details ===
npm notice name:          sharedb
npm notice version:       1.8.1
npm notice package size:  55.9 kB
npm notice unpacked size: 221.8 kB
npm notice shasum:        95464893c49a2001c9e18ce4694d2795f55552b6
npm notice integrity:     sha512-Bd5jWtJ9Sd4zo[...]+lM+VOJNgZIHg==
npm notice total files:   41
```

[1]: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files