### PR TITLE
🥅 Improve presence error message

### DIFF
--- a/lib/client/presence/local-doc-presence.js
+++ b/lib/client/presence/local-doc-presence.js
@@ -1,5 +1,6 @@
 var LocalPresence = require('./local-presence');
 var ShareDBError = require('../../error');
+var util = require('../../util');
 var ERROR_CODE = ShareDBError.CODES;
 
 module.exports = LocalDocPresence;
@@ -77,7 +78,7 @@ LocalDocPresence.prototype._transformAgainstOp = function(op, source) {
   var presence = this;
   this._pendingMessages.forEach(function(message) {
     try {
-      message.p = presence._doc.type.transformPresence(message.p, op, source);
+      message.p = presence._transformPresence(message.p, op, source);
     } catch (error) {
       var callback = presence._getCallback(message.pv);
       presence._callbackOrEmit(error, callback);
@@ -85,7 +86,7 @@ LocalDocPresence.prototype._transformAgainstOp = function(op, source) {
   });
 
   try {
-    this.value = this._doc.type.transformPresence(this.value, op, source);
+    this.value = this._transformPresence(this.value, op, source);
   } catch (error) {
     this.emit('error', error);
   }
@@ -111,4 +112,15 @@ LocalDocPresence.prototype._message = function() {
   message.v = null;
   message.t = null;
   return message;
+};
+
+LocalDocPresence.prototype._transformPresence = function(value, op, source) {
+  var type = this._doc.type;
+  if (!util.supportsPresence(type)) {
+    throw new ShareDBError(
+      ERROR_CODE.ERR_TYPE_DOES_NOT_SUPPORT_PRESENCE,
+      'Type does not support presence: ' + type.name
+    );
+  }
+  return type.transformPresence(value, op, source);
 };


### PR DESCRIPTION
At the moment, if a consumer tries to listen for presence on a type that
does not support presence, they'll get an error along the lines of:

```
TypeError: this._doc.type.transformPresence is not a function
    at LocalDocPresence._transformAgainstOp
```

This can be a bit confusing for consumers who assume their type supports
presence.

This change wraps that method in a function that will check if the type
supports presence. If not, then we throw a more descriptive error,
explaining that the type does not support presence.