### PR TITLE
💥 Drop Node.js v10 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         node:
-        - 10
         - 12
         - 14
         - 16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Breaking changes
 
+* Drop Node.js v10 support
+
 ## v1.0-beta
 
 ### Breaking changes


### PR DESCRIPTION
Fixes https://github.com/share/sharedb/issues/483

Node.js v10 was [end-of-lifed][1] in April 2021. This change drops
support for testing against it in our build matrix.

[1]: https://nodejs.org/en/about/releases/