### PR TITLE
Fixing Custom Agent Context Missing From getOps/getOpsBulk

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -304,6 +304,8 @@ Backend.prototype._getSnapshotsFromMap = function(ids, snapshotMap) {
 
 Backend.prototype._getSanitizedOps = function(agent, projection, collection, id, from, to, opsOptions, callback) {
   var backend = this;
+  if (!opsOptions) opsOptions = {};
+  if (agent) opsOptions.agentCustom = agent.custom;
   backend.db.getOps(collection, id, from, to, opsOptions, function(err, ops) {
     if (err) return callback(err);
     backend._sanitizeOps(agent, projection, collection, id, ops, function(err) {
@@ -315,6 +317,8 @@ Backend.prototype._getSanitizedOps = function(agent, projection, collection, id,
 
 Backend.prototype._getSanitizedOpsBulk = function(agent, projection, collection, fromMap, toMap, opsOptions, callback) {
   var backend = this;
+  if (!opsOptions) opsOptions = {};
+  if (agent) opsOptions.agentCustom = agent.custom;
   backend.db.getOpsBulk(collection, fromMap, toMap, opsOptions, function(err, opsMap) {
     if (err) return callback(err);
     backend._sanitizeOpsBulk(agent, projection, collection, opsMap, function(err) {

--- a/test/backend.js
+++ b/test/backend.js
@@ -61,7 +61,7 @@ describe('Backend', function() {
           opsOptions: {metadata: true}
         };
         var getOpsSpy = sinon.spy(backend.db, 'getOps');
-        backend.getOps(agent, 'books', '1984', 0, null, options, function(error, ops) {
+        backend.getOps(agent, 'books', '1984', 0, null, options, function(error) {
           if (error) return done(error);
           expect(getOpsSpy.getCall(0).args[4]).to.deep.equal({
             agentCustom: agent.custom,
@@ -75,12 +75,12 @@ describe('Backend', function() {
     describe('getOpsBulk', function() {
       it('fetches all the ops', function(done) {
         backend.getOpsBulk(agent, 'books', {
-          '1984': 0,
+          1984: 0
         }, {
-          '1984': null,
+          1984: null
         }, null, function(error, opsPerDoc) {
           if (error) return done(error);
-          const ops = opsPerDoc['1984'];
+          var ops = opsPerDoc['1984'];
           expect(ops).to.have.length(2);
           expect(ops[0].create.data).to.eql({title: '1984'});
           expect(ops[1].op).to.eql([{p: ['author'], oi: 'George Orwell'}]);
@@ -93,12 +93,12 @@ describe('Backend', function() {
           opsOptions: {metadata: true}
         };
         backend.getOpsBulk(agent, 'books', {
-          '1984': 0,
+          1984: 0
         }, {
-          '1984': null,
+          1984: null
         }, options, function(error, opsPerDoc) {
           if (error) return done(error);
-          const ops = opsPerDoc['1984'];
+          var ops = opsPerDoc['1984'];
           expect(ops).to.have.length(2);
           expect(ops[0].m).to.be.ok;
           expect(ops[1].m).to.be.ok;
@@ -112,10 +112,10 @@ describe('Backend', function() {
         };
         var getOpsBulkSpy = sinon.spy(backend.db, 'getOpsBulk');
         backend.getOpsBulk(agent, 'books', {
-          '1984': 0,
+          1984: 0
         }, {
-          '1984': null,
-        }, options, function(error, opsPerDoc) {
+          1984: null
+        }, options, function(error) {
           if (error) return done(error);
           expect(getOpsBulkSpy.getCall(0).args[3]).to.deep.equal({
             agentCustom: agent.custom,

--- a/test/backend.js
+++ b/test/backend.js
@@ -55,6 +55,75 @@ describe('Backend', function() {
           done();
         });
       });
+
+      it('passes agent.custom and snapshot options to db', function(done) {
+        var options = {
+          opsOptions: {metadata: true}
+        };
+        var getOpsSpy = sinon.spy(backend.db, 'getOps');
+        backend.getOps(agent, 'books', '1984', 0, null, options, function(error, ops) {
+          if (error) return done(error);
+          expect(getOpsSpy.getCall(0).args[4]).to.deep.equal({
+            agentCustom: agent.custom,
+            metadata: true
+          });
+          done();
+        });
+      });
+    });
+
+    describe('getOpsBulk', function() {
+      it('fetches all the ops', function(done) {
+        backend.getOpsBulk(agent, 'books', {
+          '1984': 0,
+        }, {
+          '1984': null,
+        }, null, function(error, opsPerDoc) {
+          if (error) return done(error);
+          const ops = opsPerDoc['1984'];
+          expect(ops).to.have.length(2);
+          expect(ops[0].create.data).to.eql({title: '1984'});
+          expect(ops[1].op).to.eql([{p: ['author'], oi: 'George Orwell'}]);
+          done();
+        });
+      });
+
+      it('fetches the ops with metadata', function(done) {
+        var options = {
+          opsOptions: {metadata: true}
+        };
+        backend.getOpsBulk(agent, 'books', {
+          '1984': 0,
+        }, {
+          '1984': null,
+        }, options, function(error, opsPerDoc) {
+          if (error) return done(error);
+          const ops = opsPerDoc['1984'];
+          expect(ops).to.have.length(2);
+          expect(ops[0].m).to.be.ok;
+          expect(ops[1].m).to.be.ok;
+          done();
+        });
+      });
+
+      it('passes agent.custom and snapshot options to db', function(done) {
+        var options = {
+          opsOptions: {metadata: true}
+        };
+        var getOpsBulkSpy = sinon.spy(backend.db, 'getOpsBulk');
+        backend.getOpsBulk(agent, 'books', {
+          '1984': 0,
+        }, {
+          '1984': null,
+        }, options, function(error, opsPerDoc) {
+          if (error) return done(error);
+          expect(getOpsBulkSpy.getCall(0).args[3]).to.deep.equal({
+            agentCustom: agent.custom,
+            metadata: true
+          });
+          done();
+        });
+      });
     });
 
     describe('fetch', function() {


### PR DESCRIPTION
This is required for downstream middleware.

Tests done and passing.