### PR TITLE
🔧 Re-include `test/` folder in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "sinon": "^7.5.0"
   },
   "files": [
-    "lib/"
+    "lib/",
+    "test/"
   ],
   "scripts": {
     "docs:install": "cd docs && bundle install",


### PR DESCRIPTION
We recently updated `package.json` to only include `lib/` in our
published package in https://github.com/share/sharedb/pull/469

However, the driver libraries run tests from `test/`, which are no
longer included in the package, which has broken downstream builds.

This change re-includes the `test/` directory to fix those builds.

This approximately doubles our package size. If we're concerned about
this, in future we should consider breaking out a separate testing
library (which may also make our library inter-dependency, and testing
strategy a bit more transparent).