### PR TITLE
♻️ Refactor `ot.applyOps()`

### DIFF
--- a/lib/ot.js
+++ b/lib/ot.js
@@ -111,7 +111,7 @@ function applyOpEdit(snapshot, edit) {
   try {
     snapshot.data = type.apply(snapshot.data, edit);
   } catch (err) {
-    return err;
+    return new ShareDBError(ERROR_CODE.ERR_OT_OP_NOT_APPLIED, err.message);
   }
 }
 
@@ -160,34 +160,11 @@ exports.transform = function(type, op, appliedOp) {
  * @return an error object if applicable
  */
 exports.applyOps = function(snapshot, ops) {
-  var type = null;
-
-  if (snapshot.type) {
-    type = types[snapshot.type];
-    if (!type) return new ShareDBError(ERROR_CODE.ERR_DOC_TYPE_NOT_RECOGNIZED, 'Unknown type');
-  }
-
-  try {
-    for (var index = 0; index < ops.length; index++) {
-      var op = ops[index];
-
-      snapshot.v = op.v + 1;
-
-      if (op.create) {
-        type = types[op.create.type];
-        if (!type) return new ShareDBError(ERROR_CODE.ERR_DOC_TYPE_NOT_RECOGNIZED, 'Unknown type');
-        snapshot.data = type.create(op.create.data);
-        snapshot.type = type.uri;
-      } else if (op.del) {
-        snapshot.data = undefined;
-        type = null;
-        snapshot.type = null;
-      } else {
-        snapshot.data = type.apply(snapshot.data, op.op);
-      }
-    }
-  } catch (error) {
-    return new ShareDBError(ERROR_CODE.ERR_OT_OP_NOT_APPLIED, error.message);
+  for (var index = 0; index < ops.length; index++) {
+    var op = ops[index];
+    snapshot.v = op.v;
+    var error = exports.apply(snapshot, op);
+    if (error) return error;
   }
 };
 

--- a/test/ot.js
+++ b/test/ot.js
@@ -447,7 +447,12 @@ describe('ot', function() {
 
     it('returns an error if the snapshot has an unknown type', function() {
       var snapshot = {type: 'unknown-type', data: {}};
-      var ops = [];
+      var ops = [
+        {
+          v: 1,
+          op: [{p: ['title'], oi: 'Title'}]
+        }
+      ];
       var error = ot.applyOps(snapshot, ops);
       expect(error.code).to.equal(ERROR_CODE.ERR_DOC_TYPE_NOT_RECOGNIZED);
     });


### PR DESCRIPTION
At the moment, the `ot.applyOps()` duplicates a lot of logic from
`ot.apply()`.

This change refactors `applyOps()` into a simple loop wrapper, and
completely reuses all apply logic from `ot.apply()`.