### PR TITLE
Add detail for ingestSnapshot docs

### DIFF
--- a/docs/api/doc.md
+++ b/docs/api/doc.md
@@ -141,7 +141,7 @@ doc.ingestSnapshot(snapshot [, callback])
 ```
 
 {: .warn }
-This method is generally called internally as a result of [`fetch()`](#fetch) or [`subscribe()`](#subscribe), and not directly from consumer code. Consumers *may* want to use this method to ingest data that was transferred to the client externally to the client's ShareDB connection.
+This method is generally called internally as a result of [`fetch()`](#fetch) or [`subscribe()`](#subscribe), and not directly from consumer code. Consumers *may* want to use this method to ingest data that was transferred to the client externally to the client's ShareDB connection. To generate a snapshot from a fetched `Doc`, you can do the following: `const snapshot = { v: doc.version, data: doc.data, type: doc.type }`.
 
 
 `snapshot` -- [Snapshot]({{ site.baseurl }}{% link api/snapshot.md %})


### PR DESCRIPTION
Greetings,

I was attempting to use `ingestSnapshot` by generating the snapshot on the server and sending it to the client, and I realized that the best documentation for how to create that actual `snapshot` object were found in the comments thread of this issue: https://github.com/share/sharedb/issues/254

I tried to find in the codebase where the `snapshot` object is constructed by looking into the `doc.fetch` internals, but could not find it. So I figured I would contribute this small documentation change.