### PR TITLE
🥅 Normalize `json0` `lm`

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -836,7 +836,7 @@ Backend.prototype._fetchSnapshotByTimestamp = function(collection, id, timestamp
 
 Backend.prototype._buildSnapshotFromOps = function(id, startingSnapshot, ops, callback) {
   var snapshot = startingSnapshot || new Snapshot(id, 0, null, undefined, null);
-  var error = ot.applyOps(snapshot, ops, {_normalizeJson0Paths: true});
+  var error = ot.applyOps(snapshot, ops, {_normalizeLegacyJson0Ops: true});
   callback(error, snapshot);
 };
 

--- a/lib/ot.js
+++ b/lib/ot.js
@@ -164,7 +164,7 @@ exports.applyOps = function(snapshot, ops, options) {
   options = options || {};
   for (var index = 0; index < ops.length; index++) {
     var op = ops[index];
-    if (options._normalizeJson0Paths) normalizeJson0Paths(snapshot, op);
+    if (options._normalizeLegacyJson0Ops) normalizeLegacyJson0Ops(snapshot, op);
     snapshot.v = op.v;
     var error = exports.apply(snapshot, op);
     if (error) return error;
@@ -205,15 +205,17 @@ exports.transformPresence = function(presence, op, isOwnOp) {
  * json0 had a breaking change in https://github.com/ottypes/json0/pull/40
  * The change added stricter type checking, which breaks fetchSnapshot()
  * when trying to rebuild a snapshot from old, committed ops that didn't
- * have this stricter validation. This method fixes up the op paths to
+ * have this stricter validation. This method fixes up legacy ops to
  * pass the stricter validation
  */
-function normalizeJson0Paths(snapshot, json0Op) {
+function normalizeLegacyJson0Ops(snapshot, json0Op) {
   if (snapshot.type !== types.defaultType.uri) return;
   var components = json0Op.op;
   if (!components) return;
   for (var i = 0; i < components.length; i++) {
-    var path = components[i].p;
+    var component = components[i];
+    if (typeof component.lm === 'string') component.lm = +component.lm;
+    var path = component.p;
     var element = snapshot.data;
     for (var j = 0; j < path.length; j++) {
       var key = path[j];


### PR DESCRIPTION
We recently [added a shim][1] to let consumers bump to a breaking
version of `json0`.

This shim normalized the `json0` path to allow older, less strict ops to
be applied using the stricter version of `json0`.

However, that change also included [stricter checking for `lm`][2].
This change updates our shim to also allow for these older ops. We also
rename our internal methods to be more reflective of the fact that we're
normalizing ops (rather than just their paths).

[1]: https://github.com/share/sharedb/pull/496
[2]: https://github.com/ottypes/json0/pull/40/files#diff-188db14d4925d79e94b18d68782b7df264ff95d95a26812b5b2c07c90f5640afR222-R223