### PR TITLE
🚨 Ignore docs when linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,30 +1,31 @@
 // The ESLint ecmaVersion argument is inconsistently used. Some rules will ignore it entirely, so if the rule has
 // been set, it will still error even if it's not applicable to that version number. Since Google sets these
 // rules, we have to turn them off ourselves.
-const DISABLED_ES6_OPTIONS = {
+var DISABLED_ES6_OPTIONS = {
   'no-var': 'off',
   'prefer-rest-params': 'off'
 };
 
-const SHAREDB_RULES = {
+var SHAREDB_RULES = {
   // Comma dangle is not supported in ES3
   'comma-dangle': ['error', 'never'],
   // We control our own objects and prototypes, so no need for this check
   'guard-for-in': 'off',
   // Google prescribes different indents for different cases. Let's just use 2 spaces everywhere. Note that we have
   // to override ESLint's default of 0 indents for this.
-  'indent': ['error', 2, {
-    'SwitchCase': 1
+  indent: ['error', 2, {
+    SwitchCase: 1
   }],
   // Less aggressive line length than Google, which is especially useful when we have a lot of callbacks in our code
   'max-len': ['error',
     {
       code: 120,
       tabWidth: 2,
-      ignoreUrls: true,
+      ignoreUrls: true
     }
   ],
-  // Google overrides the default ESLint behaviour here, which is slightly better for catching erroneously unused variables
+  // Google overrides the default ESLint behaviour here, which is slightly better for catching erroneously unused
+  // variables
   'no-unused-vars': ['error', {vars: 'all', args: 'after-used'}],
   // It's more readable to ensure we only have one statement per line
   'max-statements-per-line': ['error', {max: 1}],
@@ -46,4 +47,7 @@ module.exports = {
     DISABLED_ES6_OPTIONS,
     SHAREDB_RULES
   ),
+  ignorePatterns: [
+    '/docs/'
+  ]
 };

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "coveralls": "^3.0.7",
-    "eslint": "^6.5.1",
+    "eslint": "^7.32.0",
     "eslint-config-google": "^0.14.0",
-    "ot-json0-v2": "ottypes/json0",
     "lolex": "^5.1.1",
     "mocha": "^8.2.1",
     "nyc": "^14.1.1",
+    "ot-json0-v2": "ottypes/json0",
     "ot-json1": "^0.3.0",
     "sharedb-legacy": "npm:sharedb@=1.1.0",
     "sinon": "^7.5.0"


### PR DESCRIPTION
Fixes https://github.com/share/sharedb/issues/509

For some reason, the build has started linting our `/docs/` folder. It's
possible that this was an `eslint` bug, and that it should have always
been linted, since we just use our `.gitignore` file (and the JS in our
docs folder is ignored by its own, nested `.gitignore` file).

This change bumps our version of `eslint`, and adds the `/docs`/ folder
separately to be ignored by `eslint`.