### PR TITLE
📝 Update `Snapshot` documentation

### DIFF
--- a/docs/api/snapshot.md
+++ b/docs/api/snapshot.md
@@ -17,9 +17,9 @@ Snapshots can **not** be used to manipulate the current version of the document 
 
 ## Properties
 
-### `type` -- [Type]({{ site.baseurl }}{% link types/index.md %})
+### `type` -- string
 
-> The document [type]({{ site.baseurl }}{% link types/index.md %})
+> The URI of the document [type]({{ site.baseurl }}{% link types/index.md %})
 
 {: .info }
 > Document types can change between versions if the document is deleted, and created again.


### PR DESCRIPTION
`Snapshot.type` should be marked as a `string`, since it's a
serializable form of a `Doc`, and the serializable form of a type is its
URI.

The `snapshot.type` is assumed to be a URI at many points in the code:

 - https://github.com/share/sharedb/blob/e29936ca2dffd187b3fcfa3ca1b7e83becb6a2dc/lib/projections.js#L82
 - https://github.com/share/sharedb/blob/99ea28e003bdba4e7fcba7c45e70d47f30ea96f5/lib/ot.js#L80
 - https://github.com/share/sharedb/blob/e29936ca2dffd187b3fcfa3ca1b7e83becb6a2dc/lib/agent.js#L562-L563