### PR TITLE
💥 Drop Node v10 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         node:
-        - 10
         - 12
         - 14
         - 16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.0
+
+### Breaking changes
+
+* Drop Node.js v10 support
+
 ## v1.0-beta
 
 ### Breaking changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharedb",
-  "version": "1.9.2",
+  "version": "2.0.0",
   "description": "JSON OT database backend",
   "main": "lib/index.js",
   "dependencies": {


### PR DESCRIPTION
Fixes https://github.com/share/sharedb/issues/483

This is a **BREAKING CHANGE** which drops official Node.js v10 support,
which has been [end-of-lifed][1].

[1]: https://nodejs.org/en/about/releases/