### PR TITLE
Fall back to doing a _hardRollback when `op.type.invert` fails

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -948,7 +948,13 @@ Doc.prototype._rollback = function(err) {
   var op = this.inflightOp;
 
   if ('op' in op && op.type.invert) {
-    op.op = op.type.invert(op.op);
+    try {
+      op.op = op.type.invert(op.op);
+    } catch (error) {
+      // If the op doesn't support `.invert()`, we just reload the doc
+      // instead of trying to locally revert it.
+      return this._hardRollback(err);
+    }
 
     // Transform the undo operation by any pending ops.
     for (var i = 0; i < this.pendingOps.length; i++) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "nyc": "^14.1.1",
     "ot-json0-v2": "ottypes/json0",
     "ot-json1": "^0.3.0",
+    "rich-text": "^4.1.0",
     "sharedb-legacy": "npm:sharedb@=1.1.0",
     "sinon": "^7.5.0"
   },

--- a/test/client/doc.js
+++ b/test/client/doc.js
@@ -1,6 +1,9 @@
 var Backend = require('../../lib/backend');
 var expect = require('chai').expect;
 var async = require('async');
+var json0 = require('ot-json0').type;
+var richText = require('rich-text').type;
+var ShareDBError = require('../../lib/error');
 var errorHandler = require('../util').errorHandler;
 
 describe('Doc', function() {
@@ -406,6 +409,43 @@ describe('Doc', function() {
         }
       ], done);
     });
+
+    it('rolls the doc back even if the op is not invertible', function(done) {
+      var backend = this.backend;
+
+      async.series([
+        function(next) {
+          // Register the rich text type, which can't be inverted
+          json0.registerSubtype(richText);
+
+          var validOp = {p: ['richName'], oi: {ops: [{insert: 'Scooby\n'}]}};
+          doc.submitOp(validOp, function(error) {
+            expect(error).to.not.exist;
+            next();
+          });
+        },
+        function(next) {
+          // Make the server reject this insertion
+          backend.use('submit', function(_context, backendNext) {
+            backendNext(new ShareDBError(ShareDBError.CODES.ERR_UNKNOWN_ERROR, 'Custom unknown error'));
+          });
+          var nonInvertibleOp = {p: ['richName'], t: 'rich-text', o: [{insert: 'e'}]};
+
+          // The server error should get all the way back to our handler
+          doc.submitOp(nonInvertibleOp, function(error) {
+            expect(error.message).to.eql('Custom unknown error');
+            next();
+          });
+        },
+        doc.whenNothingPending.bind(doc),
+        function(next) {
+          // The doc should have been reverted successfully
+          expect(doc.data).to.eql({name: 'Scooby', richName: {ops: [{insert: 'Scooby\n'}]}});
+          next();
+        }
+      ], done);
+    });
+
 
     it('rescues an irreversible op collision', function(done) {
       // This test case attempts to reconstruct the following corner case, with


### PR DESCRIPTION
## Motivation

When we had rollbacks due to conflicts on our server, the rollback would fail when the rejected ops were `rich-text` ops, which aren't invertible due to the error in #442.

This fix is a less breaking change than what's proposed in #442, #443, and #451, and can potentially close those issues. Unlike those changes, this change:

1. Doesn't require any changes in libraries to support it
2. Only changes the behaviour in cases that are totally broken today

Closes #442.

## Fix

When the ops fail to invert, just fall back to a hard rollback (refetching the data from the server)

## Testing

Added automated test for this case that failed before, but passes now.