### PR TITLE
✨ Add `receivePresence` middleware hook

### DIFF
--- a/docs/middleware/actions.md
+++ b/docs/middleware/actions.md
@@ -99,6 +99,20 @@ This action has these additional `context` properties:
 
 > The reply about to be sent
 
+## `'receivePresence'`
+
+Presence information has just been received from a client. The presence has not yet been transformed against any ops it has missed.
+
+This action has these additional `context` properties:
+
+`collection` -- string
+
+> The collection the presence is associated with
+
+`presence` -- Object
+
+> The presence object that was received. Its shape depends on its [type]({{ site.baseurl }}{% link types/index.md %})
+
 ## `'sendPresence'`
 
 Presence information is about to be sent to a client.

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -736,17 +736,25 @@ Agent.prototype._src = function() {
 
 Agent.prototype._broadcastPresence = function(presence, callback) {
   var agent = this;
+  var backend = this.backend;
   var requests = this.presenceRequests[presence.ch] || (this.presenceRequests[presence.ch] = {});
   var previousRequest = requests[presence.id];
   if (!previousRequest || previousRequest.pv < presence.pv) {
     this.presenceRequests[presence.ch][presence.id] = presence;
   }
-  this.backend.transformPresenceToLatestVersion(this, presence, function(error, presence) {
+  var context = {
+    presence: presence,
+    collection: presence.c
+  };
+  backend.trigger(backend.MIDDLEWARE_ACTIONS.receivePresence, this, context, function(error) {
     if (error) return callback(error);
-    var channel = agent._getPresenceChannel(presence.ch);
-    agent.backend.pubsub.publish([channel], presence, function(error) {
+    backend.transformPresenceToLatestVersion(agent, presence, function(error, presence) {
       if (error) return callback(error);
-      callback(null, presence);
+      var channel = agent._getPresenceChannel(presence.ch);
+      agent.backend.pubsub.publish([channel], presence, function(error) {
+        if (error) return callback(error);
+        callback(null, presence);
+      });
     });
   });
 };

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -68,6 +68,8 @@ Backend.prototype.MIDDLEWARE_ACTIONS = {
   // by design, changing existing reply properties can cause weird bugs, since
   // the rest of ShareDB would be unaware of those changes.
   reply: 'reply',
+  // The server received presence information
+  receivePresence: 'receivePresence',
   // About to send presence information to a client
   sendPresence: 'sendPresence',
   // An operation is about to be submitted to the database


### PR DESCRIPTION
At the moment, we have a [`sendPresence`][1] middleware hook, which is
triggered just before a presence update is about to be sent to a client.

This existing hook is useful for determining if a client should receive
an update or not on the server.

However, it doesn't let us *stop* clients from broadcasting to other
clients, which we may want to do for authentication reasons, for
example.

This change adds a new `receivePresence` middleware hook, which is
triggered when the server receives a presence message from a client,
before the presence has been transformed against any ops.

Passing an error to this middleware hook will return an error message to
the broadcasting client (as opposed to `sendPresence`, which will send
an error down to any subscribed clients).

[1]: https://github.com/share/sharedb/blob/07f8bd98e5cdae37e925d4c0c709a1c3cbbca5e0/lib/agent.js#L816