### PR TITLE
🔒 Prevent sending `sendPresence` middleware errors to subscribers

### DIFF
--- a/docs/api/backend.md
+++ b/docs/api/backend.md
@@ -111,6 +111,21 @@ Optional
 
 > If set to `true`, enables [Presence]({{ site.baseurl }}{% link presence.md %}) functionality
 
+{: .d-inline-block }
+
+`errorHandler` -- Function
+
+Optional
+{: .label .label-grey }
+
+> ```js
+> function(error, context) {
+>   logger.error(error)
+> }
+> ```
+
+> Non-fatal ShareDB server errors will be passed to this handler. By default, ShareDB will log the error
+
 ## Properties
 
 ### `MIDDLEWARE_ACTIONS` -- Object

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -823,7 +823,9 @@ Agent.prototype._handlePresenceData = function(presence) {
   var agent = this;
   backend.trigger(backend.MIDDLEWARE_ACTIONS.sendPresence, this, context, function(error) {
     if (error) {
-      return agent.send({a: 'p', ch: presence.ch, id: presence.id, error: getReplyErrorObject(error)});
+      if (backend.doNotForwardSendPresenceErrorsToClient) backend.errorHandler(error, {agent: agent});
+      else agent.send({a: 'p', ch: presence.ch, id: presence.id, error: getReplyErrorObject(error)});
+      return;
     }
     agent.send(presence);
   });

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -14,6 +14,7 @@ var StreamSocket = require('./stream-socket');
 var SubmitRequest = require('./submit-request');
 var ReadSnapshotsRequest = require('./read-snapshots-request');
 var util = require('./util');
+var logger = require('./logger');
 
 var ERROR_CODE = ShareDBError.CODES;
 
@@ -34,6 +35,14 @@ function Backend(options) {
   this.suppressPublish = !!options.suppressPublish;
   this.maxSubmitRetries = options.maxSubmitRetries || null;
   this.presenceEnabled = !!options.presence;
+  this.doNotForwardSendPresenceErrorsToClient = !!options.doNotForwardSendPresenceErrorsToClient;
+  if (!this.doNotForwardSendPresenceErrorsToClient) {
+    logger.warn(
+      'Broadcasting "sendPresence" middleware errors to clients is deprecated ' +
+      'and will be removed in a future release. Disable this behaviour with:\n\n' +
+      'new Backend({doNotForwardSendPresenceErrorsToClient: true})\n\n'
+    );
+  }
 
   // Map from event name to a list of middleware
   this.middleware = {};
@@ -41,6 +50,13 @@ function Backend(options) {
   // The number of open agents for monitoring and testing memory leaks
   this.agentsCount = 0;
   this.remoteAgentsCount = 0;
+
+  this.errorHandler = typeof options.errorHandler === 'function' ?
+    options.errorHandler :
+    // eslint-disable-next-line no-unused-vars
+    function(error, context) {
+      logger.error(error);
+    };
 }
 module.exports = Backend;
 emitter.mixin(Backend);

--- a/test/backend.js
+++ b/test/backend.js
@@ -1,29 +1,51 @@
 var Backend = require('../lib/backend');
 var expect = require('chai').expect;
 var sinon = require('sinon');
+var logger = require('../lib/logger');
 
 describe('Backend', function() {
   var backend;
-  var agent = {
-    custom: {
-      foo: 'bar'
-    }
-  };
-  var fetchOptions = {
-    snapshotOptions: {
-      fizz: 'buzz'
-    }
-  };
-
-  beforeEach(function() {
-    backend = new Backend();
-  });
 
   afterEach(function(done) {
     backend.close(done);
   });
 
+  describe('options', function() {
+    describe('errorHandler', function() {
+      it('logs by default', function() {
+        backend = new Backend();
+        var error = new Error('foo');
+        sinon.spy(logger, 'error');
+        backend.errorHandler(error);
+        expect(logger.error.callCount).to.equal(1);
+      });
+
+      it('overrides with another function', function() {
+        var handler = sinon.spy();
+        backend = new Backend({errorHandler: handler});
+        var error = new Error('foo');
+        backend.errorHandler(error);
+        expect(handler.callCount).to.equal(1);
+      });
+    });
+  });
+
   describe('a simple document', function() {
+    var agent = {
+      custom: {
+        foo: 'bar'
+      }
+    };
+    var fetchOptions = {
+      snapshotOptions: {
+        fizz: 'buzz'
+      }
+    };
+
+    beforeEach(function() {
+      backend = new Backend();
+    });
+
     beforeEach(function(done) {
       var doc = backend.connect().get('books', '1984');
       doc.create({title: '1984'}, function(error) {


### PR DESCRIPTION
At the moment, if an error is passed in the `sendPresence` middleware,
this error is broadcast to any subscribed listeners.

Consumers may wish to use the `sendPresence` middleware to filter
messages being sent to particular clients (eg based on authentication or
other criteria). In these cases, no information at all should be
broadcast to subscribers, since this might be something of a security
risk - a malicious client can tell there's activity on a channel, even
if they don't know exactly what that activity is.

This change deprecates the current error behaviour, and adds a new flag
to opt-in to the new behaviour of emitting errors on `Backend` instead
of sending them down to clients. If consumers haven't actively opted in
for this behaviour, they will get a deprecation warning.