### PR TITLE
Only display sendPresence error deprecation if presence is enabled

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -36,7 +36,7 @@ function Backend(options) {
   this.maxSubmitRetries = options.maxSubmitRetries || null;
   this.presenceEnabled = !!options.presence;
   this.doNotForwardSendPresenceErrorsToClient = !!options.doNotForwardSendPresenceErrorsToClient;
-  if (!this.doNotForwardSendPresenceErrorsToClient) {
+  if (this.presenceEnabled && !this.doNotForwardSendPresenceErrorsToClient) {
     logger.warn(
       'Broadcasting "sendPresence" middleware errors to clients is deprecated ' +
       'and will be removed in a future release. Disable this behaviour with:\n\n' +


### PR DESCRIPTION
https://github.com/share/sharedb/pull/524 added a deprecation notice about presence error handling for all constructed backends without a new opt-in flag:

> Broadcasting "sendPresence" middleware errors to clients is deprecated and will be removed in a future release. Disable this behaviour with:
> new Backend({doNotForwardSendPresenceErrorsToClient: true})

Since the warning is irrelevant for backends with the default of no presence, this PR updates the notice to only display for backends that were constructed with the option `presence: true`.