### PR TITLE
🐛 Prevent local presence transformation when presence created late

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -114,6 +114,10 @@ function Doc(connection, collection, id) {
   // ops are still received. Should be toggled through the pause() and
   // resume() methods to correctly flush on resume.
   this.paused = false;
+
+  // Internal counter that gets incremented every time doc.data is updated.
+  // Used as a cheap way to check if doc.data has changed.
+  this._dataStateVersion = 0;
 }
 emitter.mixin(Doc);
 
@@ -156,11 +160,16 @@ Doc.prototype._setType = function(newType) {
   } else if (newType === null) {
     this.type = newType;
     // If we removed the type from the object, also remove its data
-    this.data = undefined;
+    this._setData(undefined);
   } else {
     var err = new ShareDBError(ERROR_CODE.ERR_DOC_TYPE_NOT_RECOGNIZED, 'Missing type ' + newType);
     return this.emit('error', err);
   }
+};
+
+Doc.prototype._setData = function(data) {
+  this.data = data;
+  this._dataStateVersion++;
 };
 
 // Ingest snapshot data. This data must include a version, snapshot and type.
@@ -218,9 +227,11 @@ Doc.prototype.ingestSnapshot = function(snapshot, callback) {
   this.version = snapshot.v;
   var type = (snapshot.type === undefined) ? types.defaultType : snapshot.type;
   this._setType(type);
-  this.data = (this.type && this.type.deserialize) ?
-    this.type.deserialize(snapshot.data) :
-    snapshot.data;
+  this._setData(
+    (this.type && this.type.deserialize) ?
+      this.type.deserialize(snapshot.data) :
+      snapshot.data
+  );
   this.emit('load');
   callback && callback();
 };
@@ -622,7 +633,7 @@ Doc.prototype._otApply = function(op, source) {
         }
         // Apply the individual op component
         this.emit('before op', componentOp.op, source, op.src);
-        this.data = this.type.apply(this.data, componentOp.op);
+        this._setData(this.type.apply(this.data, componentOp.op));
         this.emit('op', componentOp.op, source, op.src);
       }
       this.emit('op batch', op.op, source);
@@ -635,7 +646,7 @@ Doc.prototype._otApply = function(op, source) {
     // the snapshot before it gets changed
     this.emit('before op', op.op, source, op.src);
     // Apply the operation to the local data, mutating it in place
-    this.data = this.type.apply(this.data, op.op);
+    this._setData(this.type.apply(this.data, op.op));
     // Emit an 'op' event once the local data includes the changes from the
     // op. For locally submitted ops, this will be synchronously with
     // submission and before the server or other clients have received the op.
@@ -648,11 +659,15 @@ Doc.prototype._otApply = function(op, source) {
 
   if (op.create) {
     this._setType(op.create.type);
-    this.data = (this.type.deserialize) ?
-      (this.type.createDeserialized) ?
-        this.type.createDeserialized(op.create.data) :
-        this.type.deserialize(this.type.create(op.create.data)) :
-      this.type.create(op.create.data);
+    if (this.type.deserialize) {
+      if (this.type.createDeserialized) {
+        this._setData(this.type.createDeserialized(op.create.data));
+      } else {
+        this._setData(this.type.deserialize(this.type.create(op.create.data)));
+      }
+    } else {
+      this._setData(this.type.create(op.create.data));
+    }
     this.emit('create', source);
     return;
   }

--- a/lib/client/presence/local-doc-presence.js
+++ b/lib/client/presence/local-doc-presence.js
@@ -12,6 +12,7 @@ function LocalDocPresence(presence, presenceId) {
 
   this._doc = this.connection.get(this.collection, this.id);
   this._isSending = false;
+  this._docDataVersionByPresenceVersion = {};
 
   this._opHandler = this._transformAgainstOp.bind(this);
   this._createOrDelHandler = this._handleCreateOrDel.bind(this);
@@ -35,6 +36,9 @@ LocalDocPresence.prototype.submit = function(value, callback) {
     return this._callbackOrEmit(error, callback);
   };
 
+  // Record the current data state version to check if we need to transform
+  // the presence later
+  this._docDataVersionByPresenceVersion[this.presenceVersion] = this._doc._dataStateVersion;
   LocalPresence.prototype.submit.call(this, value, callback);
 };
 
@@ -63,6 +67,7 @@ LocalDocPresence.prototype._sendPending = function() {
     });
 
     presence._pendingMessages = [];
+    presence._docDataVersionByPresenceVersion = {};
   });
 };
 
@@ -76,9 +81,18 @@ LocalDocPresence.prototype._registerWithDoc = function() {
 
 LocalDocPresence.prototype._transformAgainstOp = function(op, source) {
   var presence = this;
+  var docDataVersion = this._doc._dataStateVersion;
+
   this._pendingMessages.forEach(function(message) {
+    // Check if the presence needs transforming against the op - this is to check against
+    // edge cases where presence is submitted from an 'op' event
+    var messageDocDataVersion = presence._docDataVersionByPresenceVersion[message.pv];
+    if (messageDocDataVersion >= docDataVersion) return;
     try {
       message.p = presence._transformPresence(message.p, op, source);
+      // Ensure the presence's data version is kept consistent to deal with "deep" op
+      // submissions
+      presence._docDataVersionByPresenceVersion[message.pv] = docDataVersion;
     } catch (error) {
       var callback = presence._getCallback(message.pv);
       presence._callbackOrEmit(error, callback);
@@ -103,6 +117,7 @@ LocalDocPresence.prototype._handleCreateOrDel = function() {
 LocalDocPresence.prototype._handleLoad = function() {
   this.value = null;
   this._pendingMessages = [];
+  this._docDataVersionByPresenceVersion = {};
 };
 
 LocalDocPresence.prototype._message = function() {


### PR DESCRIPTION
This change fixes a presence edge case:

 1. Register a `doc.on('op')` listener which submits presence
 2. Create the `LocalPresence` _after_ registering this listener
 3. Submit an op
 4. The presence being submitted is transformed against the submitted op
    when it shouldn't be

This happens because the `LocalPresence` handles its transformation
logic in the `'op'` event. If the `LocalPresence` is created after
another handler that submits presence, then its listener is bound late,
and is only triggered after the handler that submits the op.

The result is that the `LocalPresence` will try to transform the
presence, even though the presence is already consistent with the doc's
state.

We could in theory try to prepend the `LocalPresence` listener, but we'd
still be vulnerable to the same bug if consumers _also_ prepend
listeners, and we just move the problem to another place.

Instead, this change fixes the issue by tracking the state of `doc.data`
when the presence is submitted.

However, since `doc.version` is only incremented when an op is
[acknowledged][1], we can't use this to track our document state. To
address this, this change adds a new `_dataStateVersion` internal
variable, which is incremented every time `doc.data` is changed. This
allows us to compare the state of our local `doc.data` over time and
we can use this to check if our presence needs transformation or not.

[1]: https://github.com/share/sharedb/blob/a1a33852531432baeb3cb948ca36500bdbc60fa4/lib/client/doc.js#L947-L948