### PR TITLE
📝 Remove version reference from `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-_This README is for `sharedb@1.x`. For `sharedb@1.x-beta`, see [the 1.x-beta branch](https://github.com/share/sharedb/tree/1.x-beta). To upgrade, see [the upgrade guide](https://github.com/share/sharedb/wiki/Upgrading-to-sharedb@1.0.0-from-1.0.0-beta)._
-
 # ShareDB
 
   [![NPM Version](https://img.shields.io/npm/v/sharedb.svg)](https://npmjs.org/package/sharedb)


### PR DESCRIPTION
This statement in the `README` is now out-of-date (we're on v2).
`sharedb` has been out of beta since [November 2019][1], so we can
probably remove the link to the upgrade guide (which is linked in the
v1.0.0 release notes anyway).

[1]: https://github.com/share/sharedb/releases/tag/v1.0.0