### PR TITLE
🐛 Fix legacy json0 op normalization for ops with multiple components

### DIFF
--- a/lib/ot.js
+++ b/lib/ot.js
@@ -221,11 +221,18 @@ function normalizeLegacyJson0Ops(snapshot, json0Op) {
   if (snapshot.type !== types.defaultType.uri) return;
   var components = json0Op.op;
   if (!components) return;
+  var data = snapshot.data;
+
+  // type.apply() makes no guarantees about mutating the original data, so
+  // we need to clone. However, we only need to apply() if we have multiple
+  // components, so avoid cloning if we don't have to.
+  if (components.length > 1) data = util.clone(data);
+
   for (var i = 0; i < components.length; i++) {
     var component = components[i];
     if (typeof component.lm === 'string') component.lm = +component.lm;
     var path = component.p;
-    var element = snapshot.data;
+    var element = data;
     for (var j = 0; j < path.length; j++) {
       var key = path[j];
       // https://github.com/ottypes/json0/blob/73db17e86adc5d801951d1a69453b01382e66c7d/lib/json0.js#L21
@@ -234,5 +241,10 @@ function normalizeLegacyJson0Ops(snapshot, json0Op) {
       else if (element.constructor === Object) path[j] = key.toString();
       element = element[key];
     }
+
+    // Apply to update the snapshot, so we can correctly check the path for
+    // the next component. We don't need to do this on the final iteration,
+    // since there's no more ops.
+    if (i < components.length - 1) data = types.defaultType.apply(data, [component]);
   }
 }

--- a/test/client/snapshot-version-request.js
+++ b/test/client/snapshot-version-request.js
@@ -496,4 +496,50 @@ describe('SnapshotVersionRequest', function() {
       });
     });
   });
+
+  describe('invalid json0v2 path with multiple components', function() {
+    beforeEach(function(done) {
+      var doc = backend.connect().get('series', 'his-dark-materials');
+      async.series([
+        doc.create.bind(doc, [{}]),
+        doc.submitOp.bind(doc, [
+          {p: ['0', 'title'], oi: ''},
+          {p: ['0', 'title', 0], si: 'Northern Lights'}
+        ])
+      ], done);
+    });
+
+    describe('json0v1', function() {
+      it('fetches v2 with json0v1', function(done) {
+        backend.connect().fetchSnapshot('series', 'his-dark-materials', 2, function(error, snapshot) {
+          if (error) return done(error);
+          expect(snapshot.data).to.eql([{title: 'Northern Lights'}]);
+          done();
+        });
+      });
+    });
+
+    describe('json0v2', function() {
+      var defaultType;
+
+      beforeEach(function() {
+        defaultType = types.defaultType;
+        types.defaultType = json0v2;
+        types.register(json0v2);
+      });
+
+      afterEach(function() {
+        types.defaultType = defaultType;
+        types.register(defaultType);
+      });
+
+      it('fetches v2 with json0v2', function(done) {
+        backend.connect().fetchSnapshot('series', 'his-dark-materials', 2, function(error, snapshot) {
+          if (error) return done(error);
+          expect(snapshot.data).to.eql([{title: 'Northern Lights'}]);
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
We added some code for backwards-compatibility with breaking `json0`
changes in https://github.com/share/sharedb/pull/496

However, this code doesn't correctly handle ops with multiple components
since later components can be affected by earlier components.

For example, consider this op:

```js
[
  {p: ['path'], oi: ''},
  {p: ['path', 0], si: 'foo'},
]
```

Assuming an empty starting document `{}`, then if we **don't** update
the snapshot between op components, then the second component will
attempt to access an invalid path (since `path` doesn't yet exist on the
document).

This change fixes this case by calling `defaultType.apply()` between op
components, so that later components can correctly check their paths.

This unfortunately duplicates some work (since normally the op
components are iterated [within `json0` itself][1], so we can't insert
logic into this loop). However, the work duplication is limited to:

 - fetching historic snapshots - there is no impact on "live" documents
 - `json0` ops with multiple components

[1]: https://github.com/ottypes/json0/blob/90a3ae26364c4fa3b19b6df34dad46707a704421/lib/json0.js#L145