### PR TITLE
📝 Update Presence example

### DIFF
--- a/examples/rich-text-presence/client.js
+++ b/examples/rich-text-presence/client.js
@@ -56,7 +56,11 @@ function initialiseQuill(doc) {
   });
   var localPresence = presence.create(presenceId);
 
-  quill.on('selection-change', function(range) {
+  quill.on('selection-change', function(range, oldRange, source) {
+    // We only need to send updates if the user moves the cursor
+    // themselves. Cursor updates as a result of text changes will
+    // automatically be handled by the remote client.
+    if (source !== 'user') return;
     // Ignore blurring, so that we can see lots of users in the
     // same window. In real use, you may want to clear the cursor.
     if (!range) return;


### PR DESCRIPTION
This change updates the Presence example to only send Presence updates
when the user actively changes their selection.

Remote clients automatically update Presence when new ops are applied,
so there's no need to send this information.