### PR TITLE
remote ops are transformed by ops submitted in `before op` event handler

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -624,6 +624,8 @@ Doc.prototype._otApply = function(op, source) {
       for (var i = 0; i < op.op.length; i++) {
         var component = op.op[i];
         var componentOp = {op: [component]};
+        // Apply the individual op component
+        this.emit('before op', componentOp.op, source, op.src);
         // Transform componentOp against any ops that have been submitted
         // sychronously inside of an op event handler since we began apply of
         // our operation
@@ -631,8 +633,6 @@ Doc.prototype._otApply = function(op, source) {
           var transformErr = transformX(this.applyStack[j], componentOp);
           if (transformErr) return this._hardRollback(transformErr);
         }
-        // Apply the individual op component
-        this.emit('before op', componentOp.op, source, op.src);
         this._setData(this.type.apply(this.data, componentOp.op));
         this.emit('op', componentOp.op, source, op.src);
       }

--- a/test/client/doc.js
+++ b/test/client/doc.js
@@ -222,7 +222,7 @@ describe('Doc', function() {
         if (source) {
           return;
         }
-        doc.off('before op', beforeOpHandler)
+        doc.off('before op', beforeOpHandler);
         doc.submitOp({p: ['list', 0], li: 2}, {source: true});
       }
       function opHandler(op, source) {

--- a/test/client/doc.js
+++ b/test/client/doc.js
@@ -215,43 +215,43 @@ describe('Doc', function() {
     });
 
     it('remote ops are transformed by ops submitted in `before op` event handlers', function(done) {
-      var doc = this.doc
+      var doc = this.doc;
       var doc2 = this.doc2;
       var doc3 = this.doc3;
-      doc2.submitOp({p:['list'], oi:[]}, function() {
+      doc2.submitOp({p: ['list'], oi: []}, function() {
         doc.fetch(function() {
-          var opFromBeforeOpEvent = 1
+          var opFromBeforeOpEvent = 1;
           doc.on('before op', function(op, source) {
             // console.log('\nbefore op @ doc', op, source ? 'local' : 'remote')
             if (source) {
-              return
+              return;
             }
             if (opFromBeforeOpEvent <= 0) {
-              return
+              return;
             }
-            opFromBeforeOpEvent--
-            doc.submitOp({p:['list', 0], li: 2}, {source: true})
-          })
+            opFromBeforeOpEvent--;
+            doc.submitOp({p: ['list', 0], li: 2}, {source: true});
+          });
 
-          var opFromOpEvent = 1
+          var opFromOpEvent = 1;
           doc.on('op', function(op, source) {
             // console.log('\nop @ doc', op, source ? 'local' : 'remote')
             if (source) {
-              return
+              return;
             }
             if (opFromOpEvent <= 0) {
-              return
+              return;
             }
-            opFromOpEvent--
-            doc.submitOp({p:['list', 0], li: 3}, {source: true})
-          })
+            opFromOpEvent--;
+            doc.submitOp({p: ['list', 0], li: 3}, {source: true});
+          });
           doc2.submitOp([{p: ['list', 0], li: 1}, {p: ['list', 1], li: 42}], function() {
-            doc.fetch()
-            verifyConsistency(doc, doc2, doc3, [], done)
-          })
-        })
-      })
-    })
+            doc.fetch();
+            verifyConsistency(doc, doc2, doc3, [], done);
+          });
+        });
+      });
+    });
 
     it('remote multi component ops are transformed by ops submitted in `op` event handlers', function(done) {
       var doc = this.doc;

--- a/test/client/doc.js
+++ b/test/client/doc.js
@@ -218,33 +218,24 @@ describe('Doc', function() {
       var doc = this.doc;
       var doc2 = this.doc2;
       var doc3 = this.doc3;
+      function beforeOpHandler(op, source) {
+        if (source) {
+          return;
+        }
+        doc.off('before op', beforeOpHandler)
+        doc.submitOp({p: ['list', 0], li: 2}, {source: true});
+      }
+      function opHandler(op, source) {
+        if (source) {
+          return;
+        }
+        doc.off('op', opHandler);
+        doc.submitOp({p: ['list', 0], li: 3}, {source: true});
+      }
       doc2.submitOp({p: ['list'], oi: []}, function() {
         doc.fetch(function() {
-          var opFromBeforeOpEvent = 1;
-          doc.on('before op', function(op, source) {
-            // console.log('\nbefore op @ doc', op, source ? 'local' : 'remote')
-            if (source) {
-              return;
-            }
-            if (opFromBeforeOpEvent <= 0) {
-              return;
-            }
-            opFromBeforeOpEvent--;
-            doc.submitOp({p: ['list', 0], li: 2}, {source: true});
-          });
-
-          var opFromOpEvent = 1;
-          doc.on('op', function(op, source) {
-            // console.log('\nop @ doc', op, source ? 'local' : 'remote')
-            if (source) {
-              return;
-            }
-            if (opFromOpEvent <= 0) {
-              return;
-            }
-            opFromOpEvent--;
-            doc.submitOp({p: ['list', 0], li: 3}, {source: true});
-          });
+          doc.on('before op', beforeOpHandler);
+          doc.on('op', opHandler);
           doc2.submitOp([{p: ['list', 0], li: 1}, {p: ['list', 1], li: 42}], function() {
             doc.fetch();
             verifyConsistency(doc, doc2, doc3, [], done);

--- a/test/client/doc.js
+++ b/test/client/doc.js
@@ -218,10 +218,10 @@ describe('Doc', function() {
       var doc = this.doc
       var doc2 = this.doc2;
       var doc3 = this.doc3;
-      doc2.submitOp({p:['list'], oi:[]}, () => {
-        doc.fetch(() => {
+      doc2.submitOp({p:['list'], oi:[]}, function() {
+        doc.fetch(function() {
           var opFromBeforeOpEvent = 1
-          doc.on('before op', (op, source) => {
+          doc.on('before op', function(op, source) {
             // console.log('\nbefore op @ doc', op, source ? 'local' : 'remote')
             if (source) {
               return
@@ -234,7 +234,7 @@ describe('Doc', function() {
           })
 
           var opFromOpEvent = 1
-          doc.on('op', (op, source) => {
+          doc.on('op', function(op, source) {
             // console.log('\nop @ doc', op, source ? 'local' : 'remote')
             if (source) {
               return
@@ -245,7 +245,7 @@ describe('Doc', function() {
             opFromOpEvent--
             doc.submitOp({p:['list', 0], li: 3}, {source: true})
           })
-          doc2.submitOp([{p: ['list', 0], li: 1}, {p: ['list', 1], li: 42}], () => {
+          doc2.submitOp([{p: ['list', 0], li: 1}, {p: ['list', 1], li: 42}], function() {
             doc.fetch()
             verifyConsistency(doc, doc2, doc3, [], done)
           })


### PR DESCRIPTION
as discussed in https://github.com/share/sharedb/issues/474#issuecomment-1020742910 and https://github.com/share/sharedb/issues/474#issuecomment-1021021414, remote ops should be transformed by ops submitted in `before op` event handler.