### PR TITLE
[Docs] Indicate create*Query options.results is a Doc[]

### DIFF
--- a/docs/api/connection.md
+++ b/docs/api/connection.md
@@ -70,7 +70,7 @@ Optional
 
 > `options.results` -- [`Doc`]({{ site.baseurl }}{% link api/doc.md %})[]
 
-> > Prior query results, if available, such as from server rendering
+> > Prior query results, if available, such as from server rendering. This should be an array of Doc instances, as obtained from  `connection.get(collection, id)`. If the docs' data is already available, invoke [`ingestSnapshot`]({{ site.baseurl }}{% link api/doc.md %}#ingestsnapshot) for each Doc instance beforehand to avoid re-transferring the data from the server.
 
 > `options.*` -- any
 
@@ -107,7 +107,7 @@ Optional
 
 > `options.results` -- [`Doc`]({{ site.baseurl }}{% link api/doc.md %})[]
 
-> > Prior query results, if available, such as from server rendering
+> > Prior query results, if available, such as from server rendering. This should be an array of Doc instances, as obtained from `connection.get(collection, id)`. If the docs' data is already available, invoke [`ingestSnapshot`]({{ site.baseurl }}{% link api/doc.md %}#ingestsnapshot) for each Doc instance beforehand to avoid re-transferring the data from the server.
 
 > `options.*` -- any
 

--- a/docs/api/connection.md
+++ b/docs/api/connection.md
@@ -68,7 +68,7 @@ Optional
 
 > Default: `{}`
 
-> `options.results` -- Object[]
+> `options.results` -- [`Doc`]({{ site.baseurl }}{% link api/doc.md %})[]
 
 > > Prior query results, if available, such as from server rendering
 
@@ -105,7 +105,7 @@ Optional
 
 > Default: `{}`
 
-> `options.results` -- Object[]
+> `options.results` -- [`Doc`]({{ site.baseurl }}{% link api/doc.md %})[]
 
 > > Prior query results, if available, such as from server rendering
 


### PR DESCRIPTION
The `Connection`'s `createFetchQuery` and `createSubscribeQuery` take an optional existing result array as `options.results`.

It should be an array of Doc instances:
https://github.com/share/sharedb/blob/1cca122c63329665ebfdeceb1984921badb0cf4d/lib/client/connection.js#L563-L567

This PR updates the docs to indicate the specific type, instead of `Object[]`.