### PR TITLE
🐛 Allow getting a `Doc` while it's being destroyed

### DIFF
--- a/lib/client/connection.js
+++ b/lib/client/connection.js
@@ -521,6 +521,7 @@ Connection.prototype.get = function(collection, id) {
     this.emit('doc', doc);
   }
 
+  doc._wantsDestroy = false;
   return doc;
 };
 
@@ -531,7 +532,9 @@ Connection.prototype.get = function(collection, id) {
  * @private
  */
 Connection.prototype._destroyDoc = function(doc) {
+  if (!doc._wantsDestroy) return;
   util.digAndRemove(this.collections, doc.collection, doc.id);
+  doc.emit('destroy');
 };
 
 Connection.prototype._addDoc = function(doc) {

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -76,6 +76,8 @@ function Doc(connection, collection, id) {
   // Whether to re-establish the subscription on reconnect
   this.wantSubscribe = false;
 
+  this._wantsDestroy = false;
+
   // The op that is currently roundtripping to the server, or null.
   //
   // When the connection reconnects, the inflight op is resubmitted.
@@ -122,6 +124,7 @@ function Doc(connection, collection, id) {
 emitter.mixin(Doc);
 
 Doc.prototype.destroy = function(callback) {
+  this._wantsDestroy = true;
   var doc = this;
   doc.whenNothingPending(function() {
     if (doc.wantSubscribe) {
@@ -131,12 +134,10 @@ Doc.prototype.destroy = function(callback) {
           return doc.emit('error', err);
         }
         doc.connection._destroyDoc(doc);
-        doc.emit('destroy');
         if (callback) callback();
       });
     } else {
       doc.connection._destroyDoc(doc);
-      doc.emit('destroy');
       if (callback) callback();
     }
   });

--- a/test/client/doc.js
+++ b/test/client/doc.js
@@ -43,8 +43,28 @@ describe('Doc', function() {
       if (err) return done(err);
       var doc2 = connection.get('dogs', 'fido');
       expect(doc).not.equal(doc2);
-      expect(doc).eql(doc2);
       done();
+    });
+  });
+
+  it('destroying then getting synchronously does not destroy the new doc', function(done) {
+    var connection = this.connection;
+    var doc = connection.get('dogs', 'fido');
+    var doc2;
+
+    doc.create({name: 'fido'}, function(error) {
+      if (error) return done(error);
+
+      doc.destroy(function(error) {
+        if (error) return done(error);
+        var doc3 = connection.get('dogs', 'fido');
+        async.parallel([
+          doc2.submitOp.bind(doc2, [{p: ['snacks'], oi: true}]),
+          doc3.submitOp.bind(doc3, [{p: ['color'], oi: 'gray'}])
+        ], done);
+      });
+
+      doc2 = connection.get('dogs', 'fido');
     });
   });
 


### PR DESCRIPTION
There's currently an edge case involving trying to get a doc in the middle of being destroyed. For example, consider these synchronous calls:

```js
var doc = connection.get('collection', 'id')
doc.destroy()
var newDoc = connection.get('collection', 'id')
```

Since `Doc` objects are singletons, the above code is effectively the same as:

```js
var doc = connection.get('collection', 'id')
doc.destroy()
var newDoc = doc
```

In other words, our "new" doc is actually already being destroyed, and will soon be removed from the `Connection` cache.

One of the ways this could cause a bug is that the `doc` cannot be found in order to trigger callbacks when receiving responses from the server. `Connection` already tries to handle this case with [`_addDoc()`][1], but this could be problematic for a couple of reasons:

 1. If we add new functionality to `Connection` we may forget to add a call to `_addDoc()`
 2. This is susceptible to having multiple different instances of a `Doc` continuously trying to replace one another on the `Connection` cache

We can reach multiple `Doc`s trying to replace one another with the following edge case:

 1. Get a `Doc`
 2. Destroy it
 3. Synchronously get the same `Doc` (returning the instance in the process of being destroyed)
 4. Wait for the `destroy()` to finish (ie the `Doc` has been removed from the `Connection` cache)
 5. Get the `Doc` again - we now have a fresh, different instance
 6. Try to submit ops on both docs at the same time
 7. Depending on which one goes last, that one will be the `Doc` stored on the `Connection`, and will incorrectly receive both server responses

This change attempts to address this edge case by adding a private `_wantsDestroy` to our `Doc` instances, which is:

  - `false` on construction
  - set to `true` when calling `destroy()`
  - reset to `false` if calling `connection.get()`

We then check this flag when performing the `destroy()` tidy-up, and avoid tidying up if we have since reset the flag.

The end result of this is that any calls to `connection.get()` before `destroy()` has resolved will return the same singleton `Doc` instance, and prevent tidy-up.

[1]: https://github.com/share/sharedb/blob/5176283e2d1c9dc263f1fa3c2bc6a93c1afe2ad3/lib/client/connection.js#L452-L453