### PR TITLE
👷‍♀️ Move to `ruby/setup-ruby` action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: '2.7'
     - name: Install
       run: cd docs && gem install bundler && bundle install
     - name: Build


### PR DESCRIPTION
The [`actions/setup-ruby`][1] action has been deprecated and advises moving to [`ruby/setup-ruby`][2]

[1]: https://github.com/actions/setup-ruby
[2]: https://github.com/ruby/setup-ruby