### PR TITLE
Vite example

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,18 +34,13 @@ var SHAREDB_RULES = {
   // as-needed quote props are easier to write
   'quote-props': ['error', 'as-needed'],
   'require-jsdoc': 'off',
-  'valid-jsdoc': 'off',
-
-  // Required after upgrade to ecmaVersion: 6
-  'no-invalid-this': 'off'
+  'valid-jsdoc': 'off'
 };
 
 module.exports = {
   extends: 'google',
   parserOptions: {
-    // Support ES6 imports and exports
-    ecmaVersion: 6,
-    sourceType: 'module'
+    ecmaVersion: 3
   },
   rules: Object.assign(
     {},
@@ -54,5 +49,17 @@ module.exports = {
   ),
   ignorePatterns: [
     '/docs/'
+  ],
+  overrides: [
+    {
+      files: ['examples/counter-json1-vite/*.js'],
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      rules: {
+        quotes: ['error', 'single']
+      }
+    }
   ]
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,13 +34,18 @@ var SHAREDB_RULES = {
   // as-needed quote props are easier to write
   'quote-props': ['error', 'as-needed'],
   'require-jsdoc': 'off',
-  'valid-jsdoc': 'off'
+  'valid-jsdoc': 'off',
+
+  // Required after upgrade to ecmaVersion: 6
+  'no-invalid-this': 'off'
 };
 
 module.exports = {
   extends: 'google',
   parserOptions: {
-    ecmaVersion: 3
+    // Support ES6 imports and exports
+    ecmaVersion: 6,
+    sourceType: 'module'
   },
   rules: Object.assign(
     {},

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ jspm_packages
 
 # Don't commit generated JS bundles
 examples/**/static/dist/bundle.js
+examples/**/dist

--- a/examples/counter-json1-vite/.gitignore
+++ b/examples/counter-json1-vite/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/examples/counter-json1-vite/index.html
+++ b/examples/counter-json1-vite/index.html
@@ -7,7 +7,7 @@
   <body>
     <div style="font-family: Helvetica Neue, Helvetica, Arial, sans-serif; font-size: 36px;">
       You clicked <span id="num-clicks"></span> times.
-      <button style="font-size: 36px;" onclick="increment()">+1</button>
+      <button style="font-size: 36px;" class="increment">+1</button>
     </div>
     <script type="module" src="/main.js"></script>
   </body>

--- a/examples/counter-json1-vite/index.html
+++ b/examples/counter-json1-vite/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>ShareDB Counter (ottype json1 with Vite)</title>
+  </head>
+  <body>
+    <div style="font-family: Helvetica Neue, Helvetica, Arial, sans-serif; font-size: 36px;">
+      You clicked <span id="num-clicks"></span> times.
+      <button style="font-size: 36px;" onclick="increment()">+1</button>
+    </div>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/examples/counter-json1-vite/main.js
+++ b/examples/counter-json1-vite/main.js
@@ -1,9 +1,9 @@
 import ReconnectingWebSocket from 'reconnecting-websocket';
-import json1 from 'ot-json1';
+import { json1 } from 'sharedb-client-browser/dist/ot-json1-umd.cjs';
 import sharedb from 'sharedb-client-browser/dist/sharedb-client-umd.cjs';
 
 // Open WebSocket connection to ShareDB server
-var socket = new ReconnectingWebSocket('ws://' + window.location.host);
+var socket = new ReconnectingWebSocket('ws://' + window.location.host + '/ws');
 sharedb.types.register(json1.type);
 var connection = new sharedb.Connection(socket);
 

--- a/examples/counter-json1-vite/main.js
+++ b/examples/counter-json1-vite/main.js
@@ -1,6 +1,6 @@
 import ReconnectingWebSocket from 'reconnecting-websocket';
-import sharedb from 'sharedb/lib/client';
 import json1 from 'ot-json1';
+import sharedb from 'sharedb-client-browser/dist/sharedb-client-umd.cjs';
 
 // Open WebSocket connection to ShareDB server
 var socket = new ReconnectingWebSocket('ws://' + window.location.host);
@@ -29,5 +29,5 @@ function increment() {
   doc.submitOp(['numClicks', {ena: 1}]);
 }
 
-// Expose to index.html
-global.increment = increment;
+var button = document.querySelector('button.increment');
+button.addEventListener('click', increment);

--- a/examples/counter-json1-vite/main.js
+++ b/examples/counter-json1-vite/main.js
@@ -1,0 +1,33 @@
+import ReconnectingWebSocket from 'reconnecting-websocket';
+import sharedb from 'sharedb/lib/client';
+import json1 from 'ot-json1';
+
+// Open WebSocket connection to ShareDB server
+var socket = new ReconnectingWebSocket('ws://' + window.location.host);
+sharedb.types.register(json1.type);
+var connection = new sharedb.Connection(socket);
+
+// Create local Doc instance mapped to 'examples' collection document with id 'counter'
+var doc = connection.get('examples', 'counter');
+
+// Get initial value of document and subscribe to changes
+doc.subscribe(showNumbers);
+// When document changes (by this client or any other, or the server),
+// update the number on the page
+doc.on('op', showNumbers);
+
+function showNumbers() {
+  document.querySelector('#num-clicks').textContent = doc.data.numClicks;
+};
+
+// When clicking on the '+1' button, change the number in the local
+// document and sync the change to the server and other connected
+// clients
+function increment() {
+  // Increment `doc.data.numClicks`. See
+  // https://github.com/ottypes/json1/blob/master/spec.md for list of valid operations.
+  doc.submitOp(['numClicks', {ena: 1}]);
+}
+
+// Expose to index.html
+global.increment = increment;

--- a/examples/counter-json1-vite/main.js
+++ b/examples/counter-json1-vite/main.js
@@ -1,5 +1,5 @@
 import ReconnectingWebSocket from 'reconnecting-websocket';
-import { json1 } from 'sharedb-client-browser/dist/ot-json1-umd.cjs';
+import {json1} from 'sharedb-client-browser/dist/ot-json1-umd.cjs';
 import sharedb from 'sharedb-client-browser/dist/sharedb-client-umd.cjs';
 
 // Open WebSocket connection to ShareDB server

--- a/examples/counter-json1-vite/package.json
+++ b/examples/counter-json1-vite/package.json
@@ -15,6 +15,7 @@
     "ot-json1": "^1.0.2",
     "reconnecting-websocket": "^4.4.0",
     "sharedb": "^3.2.4",
+    "sharedb-client-browser": "^4.2.0",
     "ws": "^8.12.1"
   },
   "devDependencies": {

--- a/examples/counter-json1-vite/package.json
+++ b/examples/counter-json1-vite/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "counter-json1-vite",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "@teamwork/websocket-json-stream": "^2.0.0",
+    "express": "^4.18.2",
+    "ot-json1": "^1.0.2",
+    "reconnecting-websocket": "^4.4.0",
+    "sharedb": "^3.2.4",
+    "ws": "^8.12.1"
+  },
+  "devDependencies": {
+    "vite": "^4.1.4"
+  }
+}

--- a/examples/counter-json1-vite/package.json
+++ b/examples/counter-json1-vite/package.json
@@ -14,11 +14,11 @@
     "express": "^4.18.2",
     "ot-json1": "^1.0.2",
     "reconnecting-websocket": "^4.4.0",
-    "sharedb": "^3.2.4",
-    "sharedb-client-browser": "^4.2.0",
-    "ws": "^8.12.1"
+    "sharedb": "^3.3.1",
+    "sharedb-client-browser": "^4.2.1",
+    "ws": "^8.13.0"
   },
   "devDependencies": {
-    "vite": "^4.1.4"
+    "vite": "^4.2.1"
   }
 }

--- a/examples/counter-json1-vite/server.js
+++ b/examples/counter-json1-vite/server.js
@@ -30,7 +30,7 @@ function startServer() {
   var server = http.createServer(app);
 
   // Connect any incoming WebSocket connection to ShareDB
-  var wss = new WebSocketServer({server: server, path:'/ws'});
+  var wss = new WebSocketServer({server: server, path: '/ws'});
   wss.on('connection', function(ws) {
     var stream = new WebSocketJSONStream(ws);
     backend.listen(stream);

--- a/examples/counter-json1-vite/server.js
+++ b/examples/counter-json1-vite/server.js
@@ -1,0 +1,41 @@
+import http from 'http';
+import express from 'express';
+import ShareDB from 'sharedb';
+import { WebSocketServer } from 'ws';
+import WebSocketJSONStream from '@teamwork/websocket-json-stream';
+import json1 from 'ot-json1';
+
+ShareDB.types.register(json1.type);
+var backend = new ShareDB();
+createDoc(startServer);
+
+// Create initial document then fire callback
+function createDoc(callback) {
+  var connection = backend.connect();
+  var doc = connection.get('examples', 'counter');
+  doc.fetch(function(err) {
+    if (err) throw err;
+    if (doc.type === null) {
+      doc.create({numClicks: 0}, json1.type.uri, callback);
+      return;
+    }
+    callback();
+  });
+}
+
+function startServer() {
+  // Create a web server to serve files and listen to WebSocket connections
+  var app = express();
+  app.use(express.static('dist'));
+  var server = http.createServer(app);
+
+  // Connect any incoming WebSocket connection to ShareDB
+  var wss = new WebSocketServer({server: server});
+  wss.on('connection', function(ws) {
+    var stream = new WebSocketJSONStream(ws);
+    backend.listen(stream);
+  });
+
+  server.listen(8080);
+  console.log('Listening on http://localhost:8080');
+}

--- a/examples/counter-json1-vite/server.js
+++ b/examples/counter-json1-vite/server.js
@@ -30,7 +30,7 @@ function startServer() {
   var server = http.createServer(app);
 
   // Connect any incoming WebSocket connection to ShareDB
-  var wss = new WebSocketServer({server: server});
+  var wss = new WebSocketServer({server: server, path:'/ws'});
   wss.on('connection', function(ws) {
     var stream = new WebSocketJSONStream(ws);
     backend.listen(stream);

--- a/examples/counter-json1-vite/server.js
+++ b/examples/counter-json1-vite/server.js
@@ -1,7 +1,7 @@
 import http from 'http';
 import express from 'express';
 import ShareDB from 'sharedb';
-import { WebSocketServer } from 'ws';
+import {WebSocketServer} from 'ws';
 import WebSocketJSONStream from '@teamwork/websocket-json-stream';
 import json1 from 'ot-json1';
 

--- a/examples/counter-json1-vite/vite.config.js
+++ b/examples/counter-json1-vite/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import {defineConfig} from 'vite';
 
 export default defineConfig({
   server: {
@@ -6,8 +6,8 @@ export default defineConfig({
       // Proxy websockets to ws://localhost:8080 for `npm run dev`
       '/ws': {
         target: 'ws://localhost:8080',
-        ws: true,
-      },
-    },
-  },
-})
+        ws: true
+      }
+    }
+  }
+});

--- a/examples/counter-json1-vite/vite.config.js
+++ b/examples/counter-json1-vite/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    proxy: {
+      // Proxy websockets to ws://localhost:8080 for `npm run dev`
+      '/ws': {
+        target: 'ws://localhost:8080',
+        ws: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
Towards #593 by cloning the `counter-json1` example and attempting to adapt it to use Vite.

Desired workflows:

 * In dev, `npm start` to start the server, then in another terminal/tab `npm run dev` to load the front end with hot reloading enabled (still need to set up the WebSocket proxy for this, but there are blockers in the way of getting to this point)
 * In prod `npm run build` followed by `npm start`, like in the other examples.