### PR TITLE
✅ Try to fix flaky Milestone DB tests

### DIFF
--- a/test/milestone-db.js
+++ b/test/milestone-db.js
@@ -576,8 +576,10 @@ module.exports = function(options) {
       });
 
       it('only stores even-numbered versions', function(done) {
-        db.on('save', function(collection, snapshot) {
-          if (snapshot.v !== 4) return;
+        var snapshotCount = 0;
+        db.on('save', function() {
+          snapshotCount++;
+          if (snapshotCount < 2) return;
 
           async.waterfall([
             db.getMilestoneSnapshot.bind(db, 'books', 'catcher-in-the-rye', 1),
@@ -619,8 +621,10 @@ module.exports = function(options) {
           callback();
         });
 
-        db.on('save', function(collection, snapshot) {
-          if (snapshot.v !== 4) return;
+        var snapshotCount = 0;
+        db.on('save', function() {
+          snapshotCount++;
+          if (snapshotCount < 2) return;
 
           async.waterfall([
             db.getMilestoneSnapshot.bind(db, 'books', 'catcher-in-the-rye', 1),


### PR DESCRIPTION
At the moment we sometimes get some flaky Milestone Mongo test [failures][1].

This potentially happens because milestone snapshots are saved as a [fire-and-forget request][2], which means that we technically make no guarantee about the order that snapshots are written to the database.

Since this is the case, the affected tests may write the v4 snapshot before the others, and then fail assertions about earlier snapshots.

This change tweaks these tests to count the snapshots instead, which should be more robust to this race condition.

[1]: https://github.com/share/sharedb-milestone-mongo/actions/runs/4545270938/jobs/8012439274
[2]: https://github.com/share/sharedb/blob/404cde5568bf88d8de12186a90ba6bc168920e23/lib/submit-request.js#L223