### PR TITLE
📝 Update docs around `reconnecting-websocket`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,7 +71,11 @@ Try running the [working example](https://github.com/share/sharedb/tree/master/e
 var ReconnectingWebSocket = require('reconnecting-websocket')
 var Connection = require('sharedb/lib/client').Connection
 
-var socket = new ReconnectingWebSocket('ws://localhost:8080')
+var socket = new ReconnectingWebSocket('ws://localhost:8080', [], {
+  // ShareDB handles dropped messages, and buffering them while the socket
+  // is closed has undefined behavior
+  maxEnqueuedMessages: 0
+})
 var connection = new Connection(socket)
 
 var doc = connection.get('doc-collection', 'doc-id')

--- a/examples/counter-json1-vite/main.js
+++ b/examples/counter-json1-vite/main.js
@@ -3,7 +3,11 @@ import {json1} from 'sharedb-client-browser/dist/ot-json1-umd.cjs';
 import sharedb from 'sharedb-client-browser/dist/sharedb-client-umd.cjs';
 
 // Open WebSocket connection to ShareDB server
-var socket = new ReconnectingWebSocket('ws://' + window.location.host + '/ws');
+var socket = new ReconnectingWebSocket('ws://' + window.location.host + '/ws', [], {
+  // ShareDB handles dropped messages, and buffering them while the socket
+  // is closed has undefined behavior
+  maxEnqueuedMessages: 0
+});
 sharedb.types.register(json1.type);
 var connection = new sharedb.Connection(socket);
 

--- a/examples/counter-json1/client.js
+++ b/examples/counter-json1/client.js
@@ -3,7 +3,11 @@ var sharedb = require('sharedb/lib/client');
 var json1 = require('ot-json1');
 
 // Open WebSocket connection to ShareDB server
-var socket = new ReconnectingWebSocket('ws://' + window.location.host);
+var socket = new ReconnectingWebSocket('ws://' + window.location.host, [], {
+  // ShareDB handles dropped messages, and buffering them while the socket
+  // is closed has undefined behavior
+  maxEnqueuedMessages: 0
+});
 sharedb.types.register(json1.type);
 var connection = new sharedb.Connection(socket);
 

--- a/examples/counter/client.js
+++ b/examples/counter/client.js
@@ -2,7 +2,11 @@ var ReconnectingWebSocket = require('reconnecting-websocket');
 var sharedb = require('sharedb/lib/client');
 
 // Open WebSocket connection to ShareDB server
-var socket = new ReconnectingWebSocket('ws://' + window.location.host);
+var socket = new ReconnectingWebSocket('ws://' + window.location.host, [], {
+  // ShareDB handles dropped messages, and buffering them while the socket
+  // is closed has undefined behavior
+  maxEnqueuedMessages: 0
+});
 var connection = new sharedb.Connection(socket);
 
 // Create local Doc instance mapped to 'examples' collection document with id 'counter'

--- a/examples/leaderboard/client/connection.js
+++ b/examples/leaderboard/client/connection.js
@@ -2,6 +2,10 @@ var ReconnectingWebSocket = require('reconnecting-websocket');
 var sharedb = require('sharedb/lib/client');
 
 // Expose a singleton WebSocket connection to ShareDB server
-var socket = new ReconnectingWebSocket('ws://' + window.location.host);
+var socket = new ReconnectingWebSocket('ws://' + window.location.host, [], {
+  // ShareDB handles dropped messages, and buffering them while the socket
+  // is closed has undefined behavior
+  maxEnqueuedMessages: 0
+});
 var connection = new sharedb.Connection(socket);
 module.exports = connection;

--- a/examples/rich-text-presence/client.js
+++ b/examples/rich-text-presence/client.js
@@ -22,7 +22,11 @@ var collection = 'examples';
 var id = 'richtext';
 var presenceId = new ObjectID().toString();
 
-var socket = new ReconnectingWebSocket('ws://' + window.location.host);
+var socket = new ReconnectingWebSocket('ws://' + window.location.host, [], {
+  // ShareDB handles dropped messages, and buffering them while the socket
+  // is closed has undefined behavior
+  maxEnqueuedMessages: 0
+});
 var connection = new sharedb.Connection(socket);
 var doc = connection.get(collection, id);
 

--- a/examples/rich-text/client.js
+++ b/examples/rich-text/client.js
@@ -5,7 +5,11 @@ var Quill = require('quill');
 sharedb.types.register(richText.type);
 
 // Open WebSocket connection to ShareDB server
-var socket = new ReconnectingWebSocket('ws://' + window.location.host);
+var socket = new ReconnectingWebSocket('ws://' + window.location.host, [], {
+  // ShareDB handles dropped messages, and buffering them while the socket
+  // is closed has undefined behavior
+  maxEnqueuedMessages: 0
+});
 var connection = new sharedb.Connection(socket);
 
 // For testing reconnection
@@ -13,7 +17,11 @@ window.disconnect = function() {
   connection.close();
 };
 window.connect = function() {
-  var socket = new ReconnectingWebSocket('ws://' + window.location.host);
+  var socket = new ReconnectingWebSocket('ws://' + window.location.host, [], {
+    // ShareDB handles dropped messages, and buffering them while the socket
+    // is closed has undefined behavior
+    maxEnqueuedMessages: 0
+  });
   connection.bindToSocket(socket);
 };
 

--- a/examples/textarea/client.js
+++ b/examples/textarea/client.js
@@ -3,7 +3,11 @@ var StringBinding = require('sharedb-string-binding');
 
 // Open WebSocket connection to ShareDB server
 var ReconnectingWebSocket = require('reconnecting-websocket');
-var socket = new ReconnectingWebSocket('ws://' + window.location.host);
+var socket = new ReconnectingWebSocket('ws://' + window.location.host, [], {
+  // ShareDB handles dropped messages, and buffering them while the socket
+  // is closed has undefined behavior
+  maxEnqueuedMessages: 0
+});
 var connection = new sharedb.Connection(socket);
 
 var element = document.querySelector('textarea');


### PR DESCRIPTION
In our docs, we recommend using [`reconnecting-websocket`][1] to handle websocket reconnection.

However, [by default][2] that library will [buffer][3] messages when its underlying socket is closed, which can lead to [undefined behaviour][4] when ShareDB reconnects, since it works under the assumption that all messages sent as the socket is closing have been lost (eg pushing inflight ops back onto the pending queue, etc.).

This change updates our documentation and our examples to set `{maxEnqueuedMessages: 0}`, which disables this buffering, and should help to avoid ShareDB reaching undefined states when reconnecting using this library.

[1]: https://www.npmjs.com/package/reconnecting-websocket
[2]: https://github.com/pladaria/reconnecting-websocket/blob/05a2f7cb0e31f15dff5ff35ad53d07b1bec5e197/reconnecting-websocket.ts#L46
[3]: https://github.com/pladaria/reconnecting-websocket/blob/05a2f7cb0e31f15dff5ff35ad53d07b1bec5e197/reconnecting-websocket.ts#L260
[4]: https://github.com/share/sharedb/issues/605