### PR TITLE
Fix "Cannot read properties of null (reading 'callback')" error occured in Doc.prototype._handleSubscribe

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -311,7 +311,7 @@ Doc.prototype._handleSubscribe = function(error, snapshot) {
   this.inflightSubscribe = null;
   var callbacks = this.pendingFetch;
   this.pendingFetch = [];
-  if (request.callback) callbacks.push(request.callback);
+  if (request && request.callback) callbacks.push(request.callback);
   var callback;
   if (callbacks.length) {
     callback = function(error) {
@@ -319,7 +319,7 @@ Doc.prototype._handleSubscribe = function(error, snapshot) {
     };
   }
   if (error) return this._emitResponseError(error, callback);
-  this.subscribed = request.wantSubscribe;
+  this.subscribed = request && request.wantSubscribe;
   if (this.subscribed) this.ingestSnapshot(snapshot, callback);
   else if (callback) callback();
   this._emitNothingPending();


### PR DESCRIPTION
There is a "Cannot read properties of null (reading 'callback')" error in our logging system when using this library in our project. The error occured in method: Doc.prototype._handleSubscribe. When this method called variable `request` would be null.
Add two checkings to fix it.