### PR TITLE
➖ Remove `lolex`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "coveralls": "^3.1.1",
     "eslint": "^7.32.0",
     "eslint-config-google": "^0.14.0",
-    "lolex": "^5.1.2",
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "ot-json0-v2": "https://github.com/ottypes/json0#90a3ae26364c4fa3b19b6df34dad46707a704421",

--- a/test/client/snapshot-timestamp-request.js
+++ b/test/client/snapshot-timestamp-request.js
@@ -1,6 +1,5 @@
 var Backend = require('../../lib/backend');
 var expect = require('chai').expect;
-var lolex = require('lolex');
 var MemoryDb = require('../../lib/db/memory');
 var MemoryMilestoneDb = require('../../lib/milestone-db/memory');
 var sinon = require('sinon');
@@ -18,7 +17,7 @@ describe('SnapshotTimestampRequest', function() {
   var ONE_DAY = 1000 * 60 * 60 * 24;
 
   beforeEach(function() {
-    clock = lolex.install({now: day1});
+    clock = sinon.useFakeTimers(day1);
     backend = new Backend();
   });
 


### PR DESCRIPTION
`sinon` has ships with its own fake timers, so let's just use those.