### PR TITLE
Remove extra = in sharedb-legacy devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ot-json0-v2": "https://github.com/ottypes/json0#90a3ae26364c4fa3b19b6df34dad46707a704421",
     "ot-json1": "^1.0.2",
     "rich-text": "^4.1.0",
-    "sharedb-legacy": "npm:sharedb@=1.1.0",
+    "sharedb-legacy": "npm:sharedb@1.1.0",
     "sinon": "^15.2.0",
     "sinon-chai": "^3.7.0"
   },


### PR DESCRIPTION
In the latest Node 18.17.1 with NPM 6, sharedb fails to install with an "Invalid URL" error.

I traced it back to an attempted parsing of `"npm:sharedb@=1.1.0"`, which is the specifier for the sharedb-legacy devDependency.

According to [node-semver](https://github.com/npm/node-semver#versions):
> A leading `"="` or `"v"` character is stripped off and ignored.

It seems something in the combination of latest Node 18 with NPM 6 isn't stripping the `=`.

Node 18 by default comes with NPM 9, which is why sharedb's CI didn't break. However, NPM 6 is still supported since NPM 7 made some notable breaking changes, and the `=` somehow breaks things even when sharedb is installed as a dependency.

Since the `=` is meaningless in the specifier, removing it fixes the issue and shouldn't affect anything.

<details>
<summary>Click to see full NPM stack trace</summary>

```
5579 verbose stack TypeError [ERR_INVALID_URL]: Invalid URL
5579 verbose stack     at new NodeError (node:internal/errors:405:5)
5579 verbose stack     at Url.parse (node:url:445:17)
5579 verbose stack     at Object.urlParse [as parse] (node:url:167:13)
5579 verbose stack     at fixupUnqualifiedGist (/usr/local/lib/node_modules/npm/node_modules/hosted-git-info/index.js:99:20)
5579 verbose stack     at fromUrl (/usr/local/lib/node_modules/npm/node_modules/hosted-git-info/index.js:40:13)
5579 verbose stack     at module.exports.fromUrl (/usr/local/lib/node_modules/npm/node_modules/hosted-git-info/index.js:32:18)
5579 verbose stack     at Object.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/normalize-package-data/lib/fixer.js:150:36)
5579 verbose stack     at Array.forEach (<anonymous>)
5579 verbose stack     at Object.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/normalize-package-data/lib/fixer.js:144:31)
5579 verbose stack     at Array.forEach (<anonymous>)
5579 verbose stack     at Object.fixDependencies (/usr/local/lib/node_modules/npm/node_modules/normalize-package-data/lib/fixer.js:137:41)
5579 verbose stack     at /usr/local/lib/node_modules/npm/node_modules/normalize-package-data/lib/normalize.js:32:38
5579 verbose stack     at Array.forEach (<anonymous>)
5579 verbose stack     at normalize (/usr/local/lib/node_modules/npm/node_modules/normalize-package-data/lib/normalize.js:31:15)
5579 verbose stack     at new Manifest (/usr/local/lib/node_modules/npm/node_modules/pacote/lib/finalize-manifest.js:116:3)
5579 verbose stack     at /usr/local/lib/node_modules/npm/node_modules/pacote/lib/finalize-manifest.js:52:13
```
</details>
