### PR TITLE
📈 Add `presence.broadcast` `timing` event

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -776,6 +776,7 @@ Agent.prototype._broadcastPresence = function(presence, callback) {
     presence: presence,
     collection: presence.c
   };
+  var start = Date.now();
   backend.trigger(backend.MIDDLEWARE_ACTIONS.receivePresence, this, context, function(error) {
     if (error) return callback(error);
     backend.transformPresenceToLatestVersion(agent, presence, function(error, presence) {
@@ -783,6 +784,7 @@ Agent.prototype._broadcastPresence = function(presence, callback) {
       var channel = agent._getPresenceChannel(presence.ch);
       agent.backend.pubsub.publish([channel], presence, function(error) {
         if (error) return callback(error);
+        backend.emit('timing', 'presence.broadcast', Date.now() - start, context);
         callback(null, presence);
       });
     });


### PR DESCRIPTION
This change adds a `presence.broadcast` `timing` event, which can be used to monitor Presence broadcast performance.