### PR TITLE
🏷️ Mark `presence.subscribe()` options as internal

### DIFF
--- a/lib/client/presence/presence.js
+++ b/lib/client/presence/presence.js
@@ -90,7 +90,7 @@ Presence.prototype._sendSubscriptionAction = function(wantSubscribe, options, ca
   }
   options = options || {};
   wantSubscribe = !!wantSubscribe;
-  if (!options.force && wantSubscribe === this.wantSubscribe) {
+  if (!options._force && wantSubscribe === this.wantSubscribe) {
     if (!callback) return;
     if (wantSubscribe === this.subscribed) return util.nextTick(callback);
     if (Object.keys(this._subscriptionCallbacksBySeq).length) {

--- a/lib/client/presence/remote-doc-presence.js
+++ b/lib/client/presence/remote-doc-presence.js
@@ -107,7 +107,7 @@ RemoteDocPresence.prototype._catchUpStalePresence = function() {
     this._doc.fetch();
     // We're already subscribed, but we send another subscribe message
     // to force presence updates from other clients
-    this.presence.subscribe({force: true});
+    this.presence.subscribe({_force: true});
     return false;
   }
 


### PR DESCRIPTION
Add a prefix to the `force` option to mark it as internal, so we can remove it later if needed.