### PR TITLE
👷‍♀️ Specify `bundler` version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,6 @@ jobs:
       with:
         ruby-version: '2.7'
     - name: Install
-      run: cd docs && gem install bundler && bundle install
+      run: cd docs && gem install bundler -v 2.4.22 && bundle install
     - name: Build
       run: cd docs && bundle exec jekyll build


### PR DESCRIPTION
The docs build currently fails with:

```
Run cd docs && gem install bundler && bundle install
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
```

This change follows the advice of the error message, and specifies the version of bundler to install, since we [can't bump Ruby][1].

[1]: https://pages.github.com/versions/