### PR TITLE
🐛 Fix `Presence.destroy()` race condition

### DIFF
--- a/lib/client/presence/presence.js
+++ b/lib/client/presence/presence.js
@@ -61,7 +61,9 @@ Presence.prototype.destroy = function(callback) {
       [
         function(next) {
           async.each(localIds, function(presenceId, next) {
-            presence.localPresences[presenceId].destroy(next);
+            var localPresence = presence.localPresences[presenceId];
+            if (!localPresence) return next();
+            localPresence.destroy(next);
           }, next);
         },
         function(next) {


### PR DESCRIPTION
There's currently a race condition that can throw uncaught errors when destroying both a `LocalPresence` *and* its parent `Presence` object.

If the `LocalPresence` destroys first, then - since the `Presence` [cached][1] its ID before the `Presence` unsubscribe - by the time the `Presence` tries to destroy its children, the `LocalPresence` is already gone, which throws when [trying to call `destroy()`][2].

This change adds a test for this race condition, and adds a fix, which just checks if the `LocalPresence` still exists on the parent before trying to destroy it.

[1]: https://github.com/share/sharedb/blob/91cae28a0065faf68749243ef36aadf54bf0645d/lib/client/presence/presence.js#L56
[2]: https://github.com/share/sharedb/blob/91cae28a0065faf68749243ef36aadf54bf0645d/lib/client/presence/presence.js#L64