### PR TITLE
♻️ Try loading `'inherits'` library if `'util'` is missing

### DIFF
--- a/lib/op-stream.js
+++ b/lib/op-stream.js
@@ -1,4 +1,3 @@
-var inherits = require('util').inherits;
 var Readable = require('stream').Readable;
 var util = require('./util');
 
@@ -10,7 +9,7 @@ function OpStream() {
 }
 module.exports = OpStream;
 
-inherits(OpStream, Readable);
+util.inherits(OpStream, Readable);
 
 // This function is for notifying us that the stream is empty and needs data.
 // For now, we'll just ignore the signal and assume the reader reads as fast

--- a/lib/stream-socket.js
+++ b/lib/stream-socket.js
@@ -1,5 +1,4 @@
 var Duplex = require('stream').Duplex;
-var inherits = require('util').inherits;
 var logger = require('./logger');
 var util = require('./util');
 
@@ -47,7 +46,7 @@ function ServerStream(socket) {
     socket.close('stopped');
   });
 }
-inherits(ServerStream, Duplex);
+util.inherits(ServerStream, Duplex);
 
 ServerStream.prototype.isServer = true;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -113,3 +113,15 @@ Object.getOwnPropertyNames(Object.prototype).forEach(function(prop) {
 exports.isDangerousProperty = function(propName) {
   return propName === '__proto__' || objectProtoPropNames[propName];
 };
+
+try {
+  var util = require('util');
+  if (typeof util.inherits !== 'function') throw new Error('Could not find util.inherits()');
+  exports.inherits = util.inherits;
+} catch (e) {
+  try {
+    exports.inherits = require('inherits');
+  } catch (e) {
+    throw new Error('If running sharedb in a browser, please install the "inherits" or "util" package');
+  }
+}


### PR DESCRIPTION
When running ShareDB in a browser environment, we have to polyfill the `util` library.

However, we only use the `inherits` part of that library.

This change will attempt to fall back to the browser-friendly [`inherits` library][1] if `util` can't be found, allowing for lighter polyfilling.

[1]: https://github.com/isaacs/inherits