### PR TITLE
✅ Allow deleting ops in `MemoryDb`

### DIFF
--- a/lib/db/memory.js
+++ b/lib/db/memory.js
@@ -84,16 +84,30 @@ MemoryDB.prototype.getOps = function(collection, id, from, to, options, callback
   if (typeof callback !== 'function') throw new Error('Callback required');
   util.nextTick(function() {
     var opLog = db._getOpLogSync(collection, id);
-    if (to == null) {
-      to = opLog.length;
+    if (!from) from = 0;
+    if (to == null) to = opLog.length;
+    var ops = clone(opLog.slice(from, to).filter(Boolean));
+    if (ops.length < to - from) {
+      return callback(new Error('Missing ops'));
     }
-    var ops = clone(opLog.slice(from, to));
     if (!includeMetadata) {
       for (var i = 0; i < ops.length; i++) {
         delete ops[i].m;
       }
     }
     callback(null, ops);
+  });
+};
+
+MemoryDB.prototype.deleteOps = function(collection, id, from, to, options, callback) {
+  if (typeof callback !== 'function') throw new Error('Callback required');
+  var db = this;
+  util.nextTick(function() {
+    var opLog = db._getOpLogSync(collection, id);
+    if (!from) from = 0;
+    if (to == null) to = opLog.length;
+    for (var i = from; i < to; i++) opLog[i] = null;
+    callback(null);
   });
 };
 

--- a/test/client/snapshot-version-request.js
+++ b/test/client/snapshot-version-request.js
@@ -145,7 +145,18 @@ describe('SnapshotVersionRequest', function() {
 
     it('errors if asking for a version that does not exist', function(done) {
       backend.connect().fetchSnapshot('books', 'don-quixote', 4, function(error, snapshot) {
-        expect(error.code).to.equal('ERR_OP_VERSION_NEWER_THAN_CURRENT_SNAPSHOT');
+        expect(error).to.be.ok;
+        expect(snapshot).to.equal(undefined);
+        done();
+      });
+    });
+
+    it('errors if asking for a version that does not exist if the DB adapter does not error', function(done) {
+      sinon.stub(MemoryDb.prototype, 'getOps').callsFake(function(collection, id, from, to, options, callback) {
+        callback(null, []);
+      });
+      backend.connect().fetchSnapshot('books', 'don-quixote', 4, function(error, snapshot) {
+        expect(error).to.be.ok;
         expect(snapshot).to.equal(undefined);
         done();
       });

--- a/test/db-memory.js
+++ b/test/db-memory.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
+var Backend = require('../lib/backend');
 var DB = require('../lib/db');
 var BasicQueryableMemoryDB = require('./BasicQueryableMemoryDB');
+var async = require('async');
 
 describe('DB base class', function() {
   it('can call db.close() without callback', function() {
@@ -54,17 +56,83 @@ describe('DB base class', function() {
   });
 });
 
-// Run all the DB-based tests against the BasicQueryableMemoryDB.
-require('./db')({
-  create: function(options, callback) {
-    if (typeof options === 'function') {
-      callback = options;
-      options = null;
+describe('MemoryDB', function() {
+  // Run all the DB-based tests against the BasicQueryableMemoryDB.
+  require('./db')({
+    create: function(options, callback) {
+      if (typeof options === 'function') {
+        callback = options;
+        options = null;
+      }
+      var db = new BasicQueryableMemoryDB(options);
+      callback(null, db);
+    },
+    getQuery: function(options) {
+      return {filter: options.query, sort: options.sort};
     }
-    var db = new BasicQueryableMemoryDB(options);
-    callback(null, db);
-  },
-  getQuery: function(options) {
-    return {filter: options.query, sort: options.sort};
-  }
+  });
+
+  describe('deleteOps', function() {
+    describe('with some ops', function() {
+      var backend;
+      var db;
+      var connection;
+      var doc;
+
+      beforeEach(function(done) {
+        backend = new Backend();
+        db = backend.db;
+        connection = backend.connect();
+        doc = connection.get('dogs', 'fido');
+
+        async.waterfall([
+          doc.create.bind(doc, {name: 'Fido'}),
+          doc.submitOp.bind(doc, [{p: ['tricks'], oi: ['fetch']}]),
+          db.getOps.bind(db, 'dogs', 'fido', null, null, null),
+          function(ops, next) {
+            expect(ops).to.have.length(2);
+            next();
+          }
+        ], done);
+      });
+
+      it('deletes all ops', function(done) {
+        async.waterfall([
+          db.deleteOps.bind(db, 'dogs', 'fido', null, null, null),
+          function(next) {
+            db.getOps('dogs', 'fido', null, null, null, function(error) {
+              expect(error.message).to.equal('Missing ops');
+              next();
+            });
+          }
+        ], done);
+      });
+
+      it('deletes some ops', function(done) {
+        async.waterfall([
+          db.deleteOps.bind(db, 'dogs', 'fido', 0, 1, null),
+          db.getOps.bind(db, 'dogs', 'fido', 1, 2, null),
+          function(ops, next) {
+            expect(ops).to.have.length(1);
+            expect(ops[0].op).to.eql([{p: ['tricks'], oi: ['fetch']}]);
+            db.getOps('dogs', 'fido', 0, 1, null, function(error) {
+              expect(error.message).to.equal('Missing ops');
+              next();
+            });
+          }
+        ], done);
+      });
+
+      it('submits more ops after deleting ops', function(done) {
+        async.series([
+          db.deleteOps.bind(db, 'dogs', 'fido', null, null, null),
+          doc.submitOp.bind(doc, [{p: ['tricks', 1], li: 'sit'}]),
+          function(next) {
+            expect(doc.data.tricks).to.eql(['fetch', 'sit']);
+            next();
+          }
+        ], done);
+      });
+    });
+  });
 });


### PR DESCRIPTION
It can be useful to delete ops from `MemoryDb` to test how a system will act with TTLed ops.

This change:

 - adds a `MemoryDb.deleteOps()` helper method
 - adapts `MemoryDb.getOps()` to filter out deleted ops, and check that the correct number of ops are being returned, and error if not (similar to [`sharedb-mongo`][1])

[1]: https://github.com/share/sharedb-mongo/blob/0013d15df717ac8af32aa7847ed64bca96be7f66/index.js#L550