### PR TITLE
👷‍♀️ Update Node.js build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       matrix:
         node:
-        - 16
         - 18
         - 20
+        - 22
     services:
       mongodb:
         image: mongo:4.4


### PR DESCRIPTION
Drop Node.js v16 support, and add v22 support in-line with the Node.js [release schedule][1].

[1]: https://github.com/nodejs/release#release-schedule