### PR TITLE
🐛 Fix error handling in `_fetchCreateOpVersion()`

### DIFF
--- a/lib/submit-request.js
+++ b/lib/submit-request.js
@@ -110,7 +110,7 @@ SubmitRequest.prototype.submit = function(callback) {
         // must get the past ops and check their src and seq values to
         // differentiate.
         request._fetchCreateOpVersion(function(error, version) {
-          if (err) return callback(err);
+          if (error) return callback(error);
           if (version == null) {
             callback(request.alreadyCreatedError());
           } else {


### PR DESCRIPTION
We're currently not returning errors from the database adapter if there are issues fetching the committed op, because of a code typo.

This change adds coverage for this case and fixes the bug.