### PR TITLE
✅ Fix create resubmit test

### DIFF
--- a/test/client/submit.js
+++ b/test/client/submit.js
@@ -289,11 +289,15 @@ module.exports = function() {
             next();
           });
 
-          var doc = connection.get('dogs', 'fido');
-          doc.create({age: 3}, function(error) {
-            expect(doc.version).to.equal(1);
-            done(error);
+          var count = 0;
+          backend.use('reply', function(message, next) {
+            next();
+            if (message.reply.a === 'op') count++;
+            if (count === 2) done();
           });
+
+          var doc = connection.get('dogs', 'fido');
+          doc.create({age: 10}, errorHandler(done));
         });
 
         it('does not fail when resubmitting a create op on a doc that was deleted', function(done) {


### PR DESCRIPTION
One of our tests currently checks resubmitting a create op after reconnecting during submission.

However, since reconnection happens so quickly, this test case can cause two commit attempts in parallel.

We currently only wait for the first request to resolve, which means that the second request can continue into the next test, causing unexpected test failures.

This change waits for both acks to be sent before finishing the test.