### PR TITLE
✅ Unique ID per test in `submit` tests

### DIFF
--- a/test/client/submit.js
+++ b/test/client/submit.js
@@ -14,8 +14,15 @@ types.register(richText.type);
 
 module.exports = function() {
   describe('client submit', function() {
+    var id;
+    var idCount = 0;
+
+    beforeEach(function() {
+      id = 'dog-' + idCount++;
+    });
+
     it('can fetch an uncreated doc', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       expect(doc.data).equal(undefined);
       expect(doc.version).equal(null);
       doc.fetch(function(err) {
@@ -27,7 +34,7 @@ module.exports = function() {
     });
 
     it('can fetch then create a new doc', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.fetch(function(err) {
         if (err) return done(err);
         doc.create({age: 3}, function(err) {
@@ -40,7 +47,7 @@ module.exports = function() {
     });
 
     it('can create a new doc without fetching', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         expect(doc.data).eql({age: 3});
@@ -55,7 +62,7 @@ module.exports = function() {
         foo: 'bar'
       };
       var getSnapshotSpy = sinon.spy(this.backend.db, 'getSnapshot');
-      connection.get('dogs', 'fido').create({age: 3}, function(err) {
+      connection.get('dogs', id).create({age: 3}, function(err) {
         if (err) return done(err);
         expect(getSnapshotSpy.firstCall.args[3]).to.haveOwnProperty('agentCustom').that.deep.equals({foo: 'bar'});
         done();
@@ -63,7 +70,7 @@ module.exports = function() {
     });
 
     it('can create then delete then create a doc', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         expect(doc.data).eql({age: 3});
@@ -85,7 +92,7 @@ module.exports = function() {
     });
 
     it('can create then submit an op', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc.submitOp({p: ['age'], na: 2}, function(err) {
@@ -98,7 +105,7 @@ module.exports = function() {
     });
 
     it('can create then submit an op sync', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3});
       expect(doc.data).eql({age: 3});
       expect(doc.version).eql(null);
@@ -109,7 +116,7 @@ module.exports = function() {
     });
 
     it('submitting an op from a future version fails', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc.version++;
@@ -121,7 +128,7 @@ module.exports = function() {
     });
 
     it('cannot submit op on an uncreated doc', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.submitOp({p: ['age'], na: 2}, function(err) {
         expect(err).instanceOf(Error);
         done();
@@ -129,7 +136,7 @@ module.exports = function() {
     });
 
     it('cannot delete an uncreated doc', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.del(function(err) {
         expect(err).instanceOf(Error);
         done();
@@ -137,7 +144,7 @@ module.exports = function() {
     });
 
     it('ops submitted sync get composed', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3});
       doc.submitOp({p: ['age'], na: 2});
       doc.submitOp({p: ['age'], na: 2}, function(err) {
@@ -164,7 +171,7 @@ module.exports = function() {
     });
 
     it('does not compose ops when doc.preventCompose is true', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.preventCompose = true;
       doc.create({age: 3});
       doc.submitOp({p: ['age'], na: 2});
@@ -185,7 +192,7 @@ module.exports = function() {
     });
 
     it('resumes composing after doc.preventCompose is set back to false', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.preventCompose = true;
       doc.create({age: 3});
       doc.submitOp({p: ['age'], na: 2});
@@ -237,7 +244,7 @@ module.exports = function() {
 
       function runCreateTests() {
         it('can create a new doc then fetch', function(done) {
-          var doc = this.backend.connect().get('dogs', 'fido');
+          var doc = this.backend.connect().get('dogs', id);
           doc.create({age: 3}, function(err) {
             if (err) return done(err);
             doc.fetch(function(err) {
@@ -250,7 +257,7 @@ module.exports = function() {
         });
 
         it('calling create on the same doc twice fails', function(done) {
-          var doc = this.backend.connect().get('dogs', 'fido');
+          var doc = this.backend.connect().get('dogs', id);
           doc.create({age: 3}, function(err) {
             if (err) return done(err);
             doc.create({age: 4}, function(err) {
@@ -263,8 +270,8 @@ module.exports = function() {
         });
 
         it('trying to create an already created doc without fetching fails and fetches', function(done) {
-          var doc = this.backend.connect().get('dogs', 'fido');
-          var doc2 = this.backend.connect().get('dogs', 'fido');
+          var doc = this.backend.connect().get('dogs', id);
+          var doc2 = this.backend.connect().get('dogs', id);
           doc.create({age: 3}, function(err) {
             if (err) return done(err);
             doc2.create({age: 4}, function(err) {
@@ -296,7 +303,7 @@ module.exports = function() {
             if (count === 2) done();
           });
 
-          var doc = connection.get('dogs', 'fido');
+          var doc = connection.get('dogs', id);
           doc.create({age: 10}, errorHandler(done));
         });
 
@@ -304,8 +311,8 @@ module.exports = function() {
           var backend = this.backend;
           var connection1 = backend.connect();
           var connection2 = backend.connect();
-          var doc1 = connection1.get('dogs', 'fido');
-          var doc2 = connection2.get('dogs', 'fido');
+          var doc1 = connection1.get('dogs', id);
+          var doc2 = connection2.get('dogs', id);
 
           async.series([
             doc1.create.bind(doc1, {age: 3}),
@@ -332,8 +339,8 @@ module.exports = function() {
     });
 
     it('server fetches and transforms by already committed op', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.fetch(function(err) {
@@ -355,8 +362,8 @@ module.exports = function() {
       this.backend.db.getOpsToSnapshot = function(collection, id, from, snapshot, options, callback) {
         callback(null, []);
       };
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.fetch(function(err) {
@@ -380,8 +387,8 @@ module.exports = function() {
           callback(null, ops);
         });
       };
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.fetch(function(err) {
@@ -411,7 +418,7 @@ module.exports = function() {
 
     it('resends create when disconnected before ack', function(done) {
       var backend = this.backend;
-      var doc = backend.connect().get('dogs', 'fido');
+      var doc = backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         expect(doc.version).equal(1);
@@ -423,13 +430,13 @@ module.exports = function() {
 
     it('resent create on top of deleted doc gets proper starting version', function(done) {
       var backend = this.backend;
-      var doc = backend.connect().get('dogs', 'fido');
+      var doc = backend.connect().get('dogs', id);
       doc.create({age: 4}, function(err) {
         if (err) return done(err);
         doc.del(function(err) {
           if (err) return done(err);
 
-          var doc2 = backend.connect().get('dogs', 'fido');
+          var doc2 = backend.connect().get('dogs', id);
           doc2.create({age: 3}, function(err) {
             if (err) return done(err);
             expect(doc2.version).equal(3);
@@ -443,7 +450,7 @@ module.exports = function() {
 
     it('resends delete when disconnected before ack', function(done) {
       var backend = this.backend;
-      var doc = backend.connect().get('dogs', 'fido');
+      var doc = backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc.del(function(err) {
@@ -458,7 +465,7 @@ module.exports = function() {
 
     it('op submitted during inflight create does not compose and gets flushed', function(done) {
       this.backend.connect(null, null, function(connection) {
-        var doc = connection.get('dogs', 'fido');
+        var doc = connection.get('dogs', id);
         doc.create({age: 3});
         // Submit an op after message is sent but before server has a chance to reply
         process.nextTick(function() {
@@ -473,8 +480,8 @@ module.exports = function() {
     });
 
     it('can commit then fetch in a new connection to get the same data', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.fetch(function(err) {
@@ -490,8 +497,8 @@ module.exports = function() {
     });
 
     it('an op submitted concurrently is transformed by the first', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.fetch(function(err) {
@@ -526,8 +533,8 @@ module.exports = function() {
     });
 
     it('second of two concurrent creates is rejected', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       var count = 0;
       doc.create({age: 3}, function(err) {
         count++;
@@ -558,8 +565,8 @@ module.exports = function() {
     });
 
     it('concurrent delete operations transform', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.fetch(function(err) {
@@ -595,8 +602,8 @@ module.exports = function() {
 
     it('submits retry below the backend.maxSubmitRetries threshold', function(done) {
       this.backend.maxSubmitRetries = 10;
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.fetch(function(err) {
@@ -616,8 +623,8 @@ module.exports = function() {
     it('submits fail above the backend.maxSubmitRetries threshold', function(done) {
       var backend = this.backend;
       this.backend.maxSubmitRetries = 0;
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.fetch(function(err) {
@@ -657,8 +664,8 @@ module.exports = function() {
     });
 
     it('pending delete transforms incoming ops', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.fetch(function(err) {
@@ -684,8 +691,8 @@ module.exports = function() {
     });
 
     it('pending delete transforms incoming delete', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.fetch(function(err) {
@@ -711,8 +718,8 @@ module.exports = function() {
     });
 
     it('submitting op after delete returns error', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.fetch(function(err) {
@@ -731,8 +738,8 @@ module.exports = function() {
     });
 
     it('transforming pending op by server delete returns error', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.fetch(function(err) {
@@ -753,8 +760,8 @@ module.exports = function() {
     });
 
     it('transforming pending op by server create returns error', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc.del(function(err) {
@@ -778,8 +785,8 @@ module.exports = function() {
     });
 
     it('second client can create following delete', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc.del(function(err) {
@@ -795,28 +802,28 @@ module.exports = function() {
     });
 
     it('doc.pause() prevents ops from being sent', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.pause();
       doc.create({age: 3}, done);
       done();
     });
 
     it('can call doc.resume() without pausing', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.resume();
       doc.create({age: 3}, done);
     });
 
     it('doc.resume() resumes sending ops after pause', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.pause();
       doc.create({age: 3}, done);
       doc.resume();
     });
 
     it('pending ops are transformed by ops from other clients', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc2.fetch(function(err) {
@@ -871,7 +878,7 @@ module.exports = function() {
     });
 
     it('snapshot fetch does not revert the version of deleted doc without pending ops', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       this.backend.use('readSnapshots', function(request, next) {
         doc.create({age: 3});
         doc.del(next);
@@ -884,7 +891,7 @@ module.exports = function() {
     });
 
     it('snapshot fetch does not revert the version of deleted doc with pending ops', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       this.backend.use('readSnapshots', function(request, next) {
         doc.create({age: 3}, function(err) {
           if (err) return done(err);
@@ -906,8 +913,8 @@ module.exports = function() {
       var backend = this.backend;
       backend.connect(null, null, function(connection1) {
         backend.connect(null, null, function(connection2) {
-          var doc = connection1.get('dogs', 'fido');
-          var doc2 = connection2.get('dogs', 'fido');
+          var doc = connection1.get('dogs', id);
+          var doc2 = connection2.get('dogs', id);
           doc.create({name: 'kido'}, function(err) {
             if (err) return done(err);
             doc2.fetch(function(err) {
@@ -944,7 +951,7 @@ module.exports = function() {
       this.backend.use('submit', function(request, next) {
         next({message: 'Custom error'});
       });
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         expect(err.message).equal('Custom error');
         expect(doc.version).equal(0);
@@ -959,7 +966,7 @@ module.exports = function() {
       this.backend.use('submit', function(request, next) {
         next({message: 'Custom error'});
       });
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3});
       expect(doc.version).equal(null);
       expect(doc.data).eql({age: 3});
@@ -978,7 +985,7 @@ module.exports = function() {
         if (submitCount === 1) return next({message: 'Custom error'});
         next();
       });
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       async.parallel([
         function(cb) {
           doc.create({age: 3}, function(err) {
@@ -1015,7 +1022,7 @@ module.exports = function() {
       });
 
       var connection = this.backend.connect();
-      var doc = connection.get('dogs', 'fido');
+      var doc = connection.get('dogs', id);
       doc.preventCompose = true;
 
       doc.create({age: 3}, function(error) {
@@ -1031,7 +1038,7 @@ module.exports = function() {
       this.backend.use('submit', function(request, next) {
         next(request.rejectedError());
       });
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         expect(doc.version).equal(0);
@@ -1046,7 +1053,7 @@ module.exports = function() {
       this.backend.use('submit', function(request, next) {
         next(request.rejectedError());
       });
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3});
       expect(doc.version).equal(null);
       expect(doc.data).eql({age: 3});
@@ -1067,7 +1074,7 @@ module.exports = function() {
         });
 
         var connection = this.backend.connect();
-        var doc = connection.get('dogs', 'fido');
+        var doc = connection.get('dogs', id);
         doc.preventCompose = true;
 
         doc.create({age: 3});
@@ -1085,7 +1092,7 @@ module.exports = function() {
         if ('op' in request.op) return next({message: 'Custom error'});
         next();
       });
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc.submitOp({p: ['age'], na: 1}, function(err) {
@@ -1104,7 +1111,7 @@ module.exports = function() {
         if ('op' in request.op) return next({message: 'Custom error'});
         next();
       });
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc.submitOp({p: ['age'], na: 1});
@@ -1126,7 +1133,7 @@ module.exports = function() {
         if (submitCount === 2) return next({message: 'Custom error'});
         next();
       });
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         async.parallel([
@@ -1160,7 +1167,7 @@ module.exports = function() {
         if ('op' in request.op) return next(request.rejectedError());
         next();
       });
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc.submitOp({p: ['age'], na: 1}, function(err) {
@@ -1183,7 +1190,7 @@ module.exports = function() {
         }
         next();
       });
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.preventCompose = true;
 
       doc.create({age: 3}, function(err) {
@@ -1213,7 +1220,7 @@ module.exports = function() {
           }
           next();
         });
-        var doc = this.backend.connect().get('dogs', 'fido');
+        var doc = this.backend.connect().get('dogs', id);
         doc.preventCompose = true;
 
         doc.create({ops: [{insert: 'Scrappy'}]}, 'rich-text', function(err) {
@@ -1238,7 +1245,7 @@ module.exports = function() {
         if ('op' in request.op) return next(request.rejectedError());
         next();
       });
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc.submitOp({p: ['age'], na: 1});
@@ -1257,8 +1264,8 @@ module.exports = function() {
         if (request.op) delete request.op.op;
         next();
       });
-      var doc = this.backend.connect().get('dogs', 'fido');
-      var doc2 = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
+      var doc2 = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc.submitOp({p: ['age'], na: 1}, function(err) {
@@ -1278,7 +1285,7 @@ module.exports = function() {
     });
 
     it('submitting an invalid op message returns error', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create({age: 3}, function(err) {
         if (err) return done(err);
         doc._submit({}, null, function(err) {
@@ -1289,7 +1296,7 @@ module.exports = function() {
     });
 
     it('allows snapshot and op to be a non-object', function(done) {
-      var doc = this.backend.connect().get('dogs', 'fido');
+      var doc = this.backend.connect().get('dogs', id);
       doc.create(5, numberType.type.uri, function(err) {
         if (err) return done(err);
         expect(doc.data).to.equal(5);
@@ -1303,7 +1310,7 @@ module.exports = function() {
 
     describe('type.deserialize', function() {
       it('can create a new doc', function(done) {
-        var doc = this.backend.connect().get('dogs', 'fido');
+        var doc = this.backend.connect().get('dogs', id);
         doc.create([3], deserializedType.type.uri, function(err) {
           if (err) return done(err);
           expect(doc.data).instanceOf(deserializedType.Node);
@@ -1315,10 +1322,10 @@ module.exports = function() {
 
       it('is stored serialized in backend', function(done) {
         var db = this.backend.db;
-        var doc = this.backend.connect().get('dogs', 'fido');
+        var doc = this.backend.connect().get('dogs', id);
         doc.create([3], deserializedType.type.uri, function(err) {
           if (err) return done(err);
-          db.getSnapshot('dogs', 'fido', null, null, function(err, snapshot) {
+          db.getSnapshot('dogs', id, null, null, function(err, snapshot) {
             if (err) return done(err);
             expect(snapshot.data).eql([3]);
             done();
@@ -1327,8 +1334,8 @@ module.exports = function() {
       });
 
       it('deserializes on fetch', function(done) {
-        var doc = this.backend.connect().get('dogs', 'fido');
-        var doc2 = this.backend.connect().get('dogs', 'fido');
+        var doc = this.backend.connect().get('dogs', id);
+        var doc2 = this.backend.connect().get('dogs', id);
         doc.create([3], deserializedType.type.uri, function(err) {
           if (err) return done(err);
           doc2.fetch(function(err) {
@@ -1342,7 +1349,7 @@ module.exports = function() {
       });
 
       it('can create then submit an op', function(done) {
-        var doc = this.backend.connect().get('dogs', 'fido');
+        var doc = this.backend.connect().get('dogs', id);
         doc.create([3], deserializedType.type.uri, function(err) {
           if (err) return done(err);
           doc.submitOp({insert: 0, value: 2}, function(err) {
@@ -1356,8 +1363,8 @@ module.exports = function() {
       });
 
       it('server fetches and transforms by already committed op', function(done) {
-        var doc = this.backend.connect().get('dogs', 'fido');
-        var doc2 = this.backend.connect().get('dogs', 'fido');
+        var doc = this.backend.connect().get('dogs', id);
+        var doc2 = this.backend.connect().get('dogs', id);
         doc.create([3], deserializedType.type.uri, function(err) {
           if (err) return done(err);
           doc2.fetch(function(err) {
@@ -1380,7 +1387,7 @@ module.exports = function() {
 
     describe('type.createDeserialized', function() {
       it('can create a new doc', function(done) {
-        var doc = this.backend.connect().get('dogs', 'fido');
+        var doc = this.backend.connect().get('dogs', id);
         doc.create([3], deserializedType.type2.uri, function(err) {
           if (err) return done(err);
           expect(doc.data).instanceOf(deserializedType.Node);
@@ -1391,7 +1398,7 @@ module.exports = function() {
       });
 
       it('can create a new doc from deserialized form', function(done) {
-        var doc = this.backend.connect().get('dogs', 'fido');
+        var doc = this.backend.connect().get('dogs', id);
         doc.create(new deserializedType.Node(3), deserializedType.type2.uri, function(err) {
           if (err) return done(err);
           expect(doc.data).instanceOf(deserializedType.Node);
@@ -1408,9 +1415,9 @@ module.exports = function() {
 
       beforeEach(function(done) {
         var connection = this.backend.connect();
-        doc = connection.get('dogs', 'fido');
+        doc = connection.get('dogs', id);
         var remoteConnection = this.backend.connect();
-        remoteDoc = remoteConnection.get('dogs', 'fido');
+        remoteDoc = remoteConnection.get('dogs', id);
 
         async.series([
           doc.create.bind(doc, {name: 'fido'}),


### PR DESCRIPTION
We've had some issues with state from one test bleeding into another.

This happens because all of our `submit.js` tests use the same collection and ID.

This change makes them instead use sequential IDs for each test, which should give each test better isolation from other tests.