### PR TITLE
✨ Allow to preserve previous snapshot version that will be available in commit middleware

### DIFF
--- a/docs/middleware/actions.md
+++ b/docs/middleware/actions.md
@@ -18,6 +18,13 @@ copy:
     `snapshot` -- [`Snapshot`]({{ site.baseurl }}{% link api/snapshot.md %})
     > The snapshot
 
+    `preservePreapplySnapshot` -- boolean
+    > This flag can be set to true in any middleware action before `commit`. This will inform shareDb
+      to clone snapshot data and store it in the request object, so it is available in commit middleware as `preapplySnapshot`
+
+    `preapplySnapshot` -- [`Snapshot`]({{ site.baseurl }}{% link api/snapshot.md %})
+    > The snapshot captures the state prior to the application of operations. It is accessible exclusively during the `commit` action, and only when the `preservePreapplySnapshot` flag is set to `true`.
+
     `extra` -- Object
     > `extra.source` -- Object
     >> The submitted source when [`doc.submitSource`]({{ site.baseurl }}{% link api/doc.md %}http://localhost:4000/api/doc#submitsource--boolean) is set to `true`

--- a/lib/submit-request.js
+++ b/lib/submit-request.js
@@ -2,6 +2,7 @@ var ot = require('./ot');
 var projections = require('./projections');
 var ShareDBError = require('./error');
 var types = require('./types');
+var util = require('./util');
 
 var ERROR_CODE = ShareDBError.CODES;
 
@@ -42,6 +43,8 @@ function SubmitRequest(backend, agent, index, id, op, options) {
   this.ops = [];
   this.channels = null;
   this._fixupOps = [];
+  this.preservePreapplySnapshot = false;
+  this.preapplySnapshot = null;
 }
 module.exports = SubmitRequest;
 
@@ -179,6 +182,15 @@ SubmitRequest.prototype.apply = function(callback) {
   var request = this;
   this.backend.trigger(this.backend.MIDDLEWARE_ACTIONS.apply, this.agent, this, function(err) {
     if (err) return callback(err);
+
+    /**
+     * Middleware is able to opt in to store old snapshot
+     * which could be useful in cases where we want to compare the old snapshot
+     * (snapshot without the ops applied) and the new snapshot (with the ops applied)
+     */
+    if (request.preservePreapplySnapshot) {
+      request.preapplySnapshot = util.clone(request.snapshot);
+    }
 
     // Apply the submitted op to the snapshot
     err = ot.apply(request.snapshot, request.op);


### PR DESCRIPTION
Occasionally, it is necessary to reference the previous version of a snapshot to execute auxiliary operations within the commit middleware, for example:

Let's imagine we have this doc that describes user:
```typescript
{
  id: '123',
  emailConfirmed: false;
}
```
Now we would want to send notification to the admin whenever `emailConfirmed` changed from `false` to `true`

At the moment there is no simple way to check in the middlewares if something is changing, apart form trying to apply the ops manually in the `apply` middleware. Something like

```typescript
backend.use('apply', function(request, next) {
  const changedSnapshot = applyOps(clone(request.snapshot), request.op);
  if(
    request.snapshot.data.emailConfirmed === false &&
    request.snapshot.data.emailConfirmed === true
  ) {
    notifyAdmin();
  }
})
```

This approach has few drawbacks:
1. We need to apply ops twice once in this middleware and once in the sharedb itself.
2. It is quite difficult for app to make considerations and mimick the flow of `$fixOps`

Solution
---
Let's make it possible to opt-in for storing the pre-apply snapshot version in request by setting a `preservePreapplySnapshot` flag to `true` in any middleware that happens before apply. This will allow us to:
1. Have the old and new version of snapshot available in the `commit` middleware
2. We do not have much memory overhead as this is opt-in, so if user never needs it the snapshot would never be cloned.
3. We only need to apply ops once
4. The apply mechanism is using shareDb power house.