### PR TITLE
🐛 Fix inflight/pending callbacks execute in wrong order

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -295,7 +295,7 @@ Doc.prototype._handleFetch = function(error, snapshot) {
   var callbacks = this.pendingFetch;
   this.pendingFetch = [];
   var callback = this.inflightFetch.shift();
-  if (callback) callbacks.push(callback);
+  if (callback) callbacks.unshift(callback);
   if (callbacks.length) {
     callback = function(error) {
       util.callEach(callbacks, error);

--- a/test/client/doc.js
+++ b/test/client/doc.js
@@ -105,14 +105,20 @@ describe('Doc', function() {
       var connection = this.connection;
       var doc = connection.get('dogs', 'fido');
       doc.create({name: 'fido'});
-      var order = ""
-      doc.fetch(function() { order += "A" });
+      var order = '';
+      doc.fetch(function() {
+        order += 'A';
+      });
       doc.submitOp([{p: ['snacks'], oi: true}]);
-      doc.fetch(function() { order += "B" });
+      doc.fetch(function() {
+        order += 'B';
+      });
       doc.submitOp([{p: ['color'], oi: 'gray'}]);
-      doc.fetch(function() { order += "C" });
+      doc.fetch(function() {
+        order += 'C';
+      });
       doc.whenNothingPending(function() {
-        expect(order).to.eql("ABC");        
+        expect(order).to.eql('ABC');
         done();
       });
     });

--- a/test/client/doc.js
+++ b/test/client/doc.js
@@ -101,6 +101,21 @@ describe('Doc', function() {
       doc.fetch(finish);
       doc.fetch(finish);
     });
+    it('callbacks called in correct order when fetching and applying ops in quick succession', function(done) {
+      var connection = this.connection;
+      var doc = connection.get('dogs', 'fido');
+      doc.create({name: 'fido'});
+      var order = ""
+      doc.fetch(function() { order += "A" });
+      doc.submitOp([{p: ['snacks'], oi: true}]);
+      doc.fetch(function() { order += "B" });
+      doc.submitOp([{p: ['color'], oi: 'gray'}]);
+      doc.fetch(function() { order += "C" });
+      doc.whenNothingPending(function() {
+        expect(order).to.eql("ABC");        
+        done();
+      });
+    });
   });
 
   describe('when connection closed', function() {


### PR DESCRIPTION
I encountered a situation in ShareDB where my callbacks are often executed in the wrong order.

I tracked this down to incorrect behavior in the `doc.fetch()` method, which pushes the `inflightCallback` onto the back of the `callbacks` array. If there are already any `pendingCallbacks` in the array, then the `inflightCallback` will be executed AFTER all the `pendingCallbacks`.

This is obviously not the desired behavior. The `inflightCallback` should always be executed FIRST, before any of the `pendingCallbacks`.

I fixed the code and wrote a test demonstrating the fix. If you remove my bugfix and run the test, you'll see that it reliably fails.
