### PR TITLE
Upgrade rich-text-presence example to Quill 2.0.2

### DIFF
--- a/examples/rich-text-presence/client.js
+++ b/examples/rich-text-presence/client.js
@@ -1,10 +1,10 @@
-var ReconnectingWebSocket = require('reconnecting-websocket');
-var sharedb = require('sharedb/lib/client');
-var richText = require('rich-text');
-var Quill = require('quill');
-var QuillCursors = require('quill-cursors');
-var tinycolor = require('tinycolor2');
-var ObjectID = require('bson-objectid');
+import ReconnectingWebSocket from 'reconnecting-websocket';
+import sharedb from 'sharedb/lib/client';
+import richText from 'rich-text';
+import Quill from 'quill';
+import QuillCursors from 'quill-cursors';
+import tinycolor from 'tinycolor2';
+import ObjectID from 'bson-objectid';
 
 sharedb.types.register(richText.type);
 Quill.register('modules/cursors', QuillCursors);
@@ -36,9 +36,12 @@ doc.subscribe(function(err) {
 });
 
 function initialiseQuill(doc) {
-  var quill = new Quill('#editor', {
-    theme: 'bubble',
-    modules: {cursors: true}
+    var quill = new Quill('#editor', {
+    theme: 'snow',
+    modules: {
+      cursors: true,
+      toolbar: true,
+    }
   });
   var cursors = quill.getModule('cursors');
 

--- a/examples/rich-text-presence/package.json
+++ b/examples/rich-text-presence/package.json
@@ -4,7 +4,7 @@
   "description": "An example of presence using ShareDB and Quill",
   "main": "server.js",
   "scripts": {
-    "build": "browserify client.js -o static/dist/bundle.js",
+    "build": "webpack --mode development",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"
   },
@@ -18,7 +18,7 @@
     "@teamwork/websocket-json-stream": "^2.0.0",
     "bson-objectid": "^2.0.4",
     "express": "^4.18.2",
-    "quill": "^1.3.7",
+    "quill": "^2.0.2",
     "quill-cursors": "^4.0.2",
     "reconnecting-websocket": "^4.4.0",
     "rich-text": "^4.1.0",
@@ -27,6 +27,7 @@
     "ws": "^8.12.1"
   },
   "devDependencies": {
-    "browserify": "^17.0.0"
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4"
   }
 }

--- a/examples/rich-text-presence/static/index.html
+++ b/examples/rich-text-presence/static/index.html
@@ -3,6 +3,7 @@
 <title>ShareDB Rich Text</title>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
 <link href="quill.bubble.css" rel="stylesheet">
+<link href="quill.snow.css" rel="stylesheet">
 <link href="style.css" rel="stylesheet">
 
 <div class="controls">

--- a/examples/rich-text-presence/webpack.config.js
+++ b/examples/rich-text-presence/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+module.exports = {
+  entry: './client.js',
+  output: {
+    path: path.resolve(__dirname, 'static/dist'),
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env']
+          }
+        }
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['.js']
+  },
+  mode: 'development'
+};


### PR DESCRIPTION
This pull request includes several updates to the `examples/rich-text-presence` project, specifically to support Quill 2.0.2 and modernizing the build process, updating dependencies, and improving the user interface. 

<img width="1145" alt="Screenshot 2024-10-06 at 5 57 10 AM" src="https://github.com/user-attachments/assets/97c04d9e-59e4-4395-9ac3-d8fa103aeb92">

Watch: [Demo](https://youtu.be/MiY4gNmPgLM)

The most important changes are summarized below:

### Modernization of Build Process:

* **Switch from Browserify to Webpack**: Updated the build script in `package.json` to use Webpack for module bundling, replacing Browserify. Added `webpack` and `webpack-cli` to `devDependencies`, and included a new `webpack.config.js` file for configuration. (`examples/rich-text-presence/package.json`, `examples/rich-text-presence/webpack.config.js`) [[1]](diffhunk://#diff-cc061bdd1d3ab694acb7b87b415dd0bd9bae4a557e19fd8607ab3b460f365cefL7-R7) [[2]](diffhunk://#diff-cc061bdd1d3ab694acb7b87b415dd0bd9bae4a557e19fd8607ab3b460f365cefL30-R31) [[3]](diffhunk://#diff-9d13c7e216896b6195ad4033d3c9845535b693bb3e752d795985a398c8176134R1-R27)

### Dependency Updates:

* **Upgrade Quill**: Updated the `quill` dependency from version `^1.3.7` to `^2.0.2` in `package.json`. (`examples/rich-text-presence/package.json`)

### Codebase Improvements:

* **Migration to ES6 Imports**: Replaced CommonJS `require` statements with ES6 `import` statements in `client.js` for better compatibility with modern JavaScript standards. (`examples/rich-text-presence/client.js`)

### User Interface Enhancements:

* **Change Quill Theme**: Modified the Quill editor initialization to use the `snow` theme instead of `bubble` and added a toolbar module for enhanced editing capabilities. Correspondingly, added the `quill.snow.css` stylesheet in `index.html`. (`examples/rich-text-presence/client.js`, `examples/rich-text-presence/static/index.html`) [[1]](diffhunk://#diff-d96b540509d1513659730abe2bc2a5d7968a4db66cf78f5636ac82c731d35d3eL40-R44) [[2]](diffhunk://#diff-3a1605139ce24a58e1a03e24d9552471eccb33422507e10dbabaf56e40bd1479R6)