### PR TITLE
🐛 Fix `closed` check when handling `querySubscribe()`

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -569,7 +569,7 @@ Agent.prototype._querySubscribe = function(queryId, collection, query, options, 
   }
   this.backend.querySubscribe(this, collection, query, options, function(err, emitter, results, extra) {
     if (err) return finish(err);
-    if (this.closed) return emitter.destroy();
+    if (agent.closed) return emitter.destroy();
 
     agent._subscribeToQuery(emitter, queryId, collection, query);
     // No results are returned when ids are passed in as an option. Instead,


### PR DESCRIPTION
The `Agent` attempts to check if it's been closed when getting the response for a query subscribe.

However, it incorrectly tries to access `this` inside a `function`, which doesn't give the correct value, and in `strict mode`, will actually result in an error, since `this` will be `undefined`.

This change adds a test for this case and fixes it.