### PR TITLE
🔥 Remove duplicate this.type = null assigment

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -61,6 +61,7 @@ function Doc(connection, collection, id) {
   this.id = id;
 
   this.version = null;
+  // The OT type of this document. An uncreated document has type `null`
   this.type = null;
   this.data = undefined;
 
@@ -92,9 +93,6 @@ function Doc(connection, collection, id) {
   //
   // This is a list of {[create:{...}], [del:true], [op:...], callbacks:[...]}
   this.pendingOps = [];
-
-  // The OT type of this document. An uncreated document has type `null`
-  this.type = null;
 
   // The applyStack enables us to track any ops submitted while we are
   // applying an op incrementally. This value is an array when we are


### PR DESCRIPTION
At the moment in constructor we call
```js
this.type = null
```
twice. Let's remove one of the calls