### PR TITLE
 🐛 Wrong error when submitting presence during hard rollback.

### DIFF
--- a/lib/client/presence/local-doc-presence.js
+++ b/lib/client/presence/local-doc-presence.js
@@ -30,10 +30,20 @@ LocalDocPresence.prototype.submit = function(value, callback) {
     // be null. Let's early return, instead of error since this is a harmless
     // no-op
     if (value === null) return this._callbackOrEmit(null, callback);
-    var error = {
-      code: ERROR_CODE.ERR_DOC_DOES_NOT_EXIST,
-      message: 'Cannot submit presence. Document has not been created'
-    };
+
+    var error = null;
+    if (this._doc._isInHardRollback) {
+      error = {
+        code: ERROR_CODE.ERR_DOC_IN_HARD_ROLLBACK,
+        message: 'Cannot submit presence. Document is processing hard rollback'
+      };
+    } else {
+      error = {
+        code: ERROR_CODE.ERR_DOC_DOES_NOT_EXIST,
+        message: 'Cannot submit presence. Document has not been created'
+      };
+    }
+
     return this._callbackOrEmit(error, callback);
   };
 

--- a/test/client/presence/doc-presence.js
+++ b/test/client/presence/doc-presence.js
@@ -829,6 +829,20 @@ describe('DocPresence', function() {
     ], done);
   });
 
+
+  it('errors local presence when doc is in hard rollback', function(done) {
+    var localPresence1 = presence1.create('presence-1');
+
+    doc1.on('error', function(error) {
+      expect(error).to.be.equal('some error');
+    });
+    doc1._hardRollback('some error');
+    localPresence1.submit({index: 1}, function(error) {
+      expect(error.code).to.be.equal('ERR_DOC_IN_HARD_ROLLBACK');
+      done();
+    });
+  });
+
   it('returns errors sent from the middleware', function(done) {
     backend.use(backend.MIDDLEWARE_ACTIONS.sendPresence, function(request, callback) {
       callback('some error');


### PR DESCRIPTION
 Similar case to:
 - https://github.com/share/sharedb/pull/692

 however instead of submitting ops to doc is when we submit doc presence