### PR TITLE
🐛 Fix hasOwn function implementation to ensure proper property checking

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -9,7 +9,9 @@ exports.hasKeys = function(object) {
 };
 
 var hasOwn;
-exports.hasOwn = hasOwn = Object.hasOwn || Object.prototype.hasOwnProperty.call;
+exports.hasOwn = hasOwn = Object.hasOwn || function(obj, prop) {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+};
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger#Polyfill
 exports.isInteger = Number.isInteger || function(value) {


### PR DESCRIPTION
In browsers that lack native `Object.hasOwn` support, assigning `Object.prototype.hasOwnProperty.call` to a variable (e.g., hasOwn = `Object.prototype.hasOwnProperty.call`) detaches the `call` method from its original function context.   This results in a runtime error: `hasOwn is not a function`.

![image](https://github.com/user-attachments/assets/5a89e31b-bb06-4f9b-83fd-2f785f4dd1f2)

![image](https://github.com/user-attachments/assets/aa399587-2112-472f-956e-cda77a19e466)
