### PR TITLE
🐛 Assign presence handlers to `RemoteDocPresence` prototype

### DIFF
--- a/lib/client/presence/remote-doc-presence.js
+++ b/lib/client/presence/remote-doc-presence.js
@@ -76,12 +76,12 @@ RemoteDocPresence.prototype._handleOp = function(op, source, connectionId) {
   this._setPendingPresence();
 };
 
-RemotePresence.prototype._handleCreateDel = function() {
+RemoteDocPresence.prototype._handleCreateDel = function() {
   this._cacheOp(null);
   this._setPendingPresence();
 };
 
-RemotePresence.prototype._handleLoad = function() {
+RemoteDocPresence.prototype._handleLoad = function() {
   this.value = null;
   this._pending = null;
   this._opCache = null;


### PR DESCRIPTION
Fixes https://github.com/share/sharedb/issues/708

At the moment, `_handleCreateDel` and `_handleLoad` are assigned to `RemotePresence.prototype` rather than `RemoteDocPresence.prototype`.

`RemotePresence` is the base class, and `RemoteDocPresence` is the only subclass, so these handlers still happen to be reachable via the prototype chain and the bug is invisible in practice. However, defining them on the base prototype pollutes it, and any future sibling subclass would silently inherit doc-specific presence handlers it has no business with.

This change assigns both handlers to `RemoteDocPresence.prototype` where they belong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

